### PR TITLE
AllowExplicitVersion if referencing a WebApi project

### DIFF
--- a/aspnetcore/migration/21-to-22.md
+++ b/aspnetcore/migration/21-to-22.md
@@ -68,6 +68,15 @@ The metapackage reference should resemble the following `<PackageReference />` n
 </ItemGroup>
 ```
 
+If targeting .NET Core and referencing your .NET Core project in a .NET Core project (such as a unit test project), then implicit references will map to 2.1 assemblies, causing build errors.  In this case, use the `AllowExplicitVersion="true"` attribute on `Microsoft.AspNetCore.App` reference:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Microsoft.AspNetCore.App" AllowExplicitVersion="true" Version="<your version>" />
+</ItemGroup>
+```
+
+
 If targeting .NET Framework, update each package reference's `Version` attribute to 2.2.0 or later. Here are the package references in a typical ASP.NET Core 2.2 project targeting .NET Framework:
 
 ```xml

--- a/aspnetcore/migration/21-to-22.md
+++ b/aspnetcore/migration/21-to-22.md
@@ -68,7 +68,7 @@ The metapackage reference should resemble the following `<PackageReference />` n
 </ItemGroup>
 ```
 
-If targeting .NET Core and referencing your .NET Core project in a .NET Core project (such as a unit test project), then implicit references will map to 2.1 assemblies, causing build errors.  In this case, use the `AllowExplicitVersion="true"` attribute on `Microsoft.AspNetCore.App` reference:
+When targeting .NET Core and referencing a .NET Core project in a .NET Core project (such as a unit test project), implicit references will map to 2.1 assemblies, resulting in build errors.  In this case, use the `AllowExplicitVersion="true"` attribute on `Microsoft.AspNetCore.App` reference:
 
 ```xml
 <ItemGroup>

--- a/aspnetcore/migration/21-to-22.md
+++ b/aspnetcore/migration/21-to-22.md
@@ -68,14 +68,7 @@ The metapackage reference should resemble the following `<PackageReference />` n
 </ItemGroup>
 ```
 
-When targeting .NET Core and referencing a .NET Core project in a .NET Core project (such as a unit test project), implicit references will map to 2.1 assemblies, resulting in build errors.  In this case, use the `AllowExplicitVersion="true"` attribute on `Microsoft.AspNetCore.App` reference:
-
-```xml
-<ItemGroup>
-  <PackageReference Include="Microsoft.AspNetCore.App" AllowExplicitVersion="true" Version="<your version>" />
-</ItemGroup>
-```
-
+When targeting .NET Core and transitively referencing a .NET Core project in another .NET Core project (such as a unit test project), implicit references will map to 2.1 assemblies, resulting in build errors.  In this case, add `<PackageReference Include="Microsoft.AspNetCore.App" />` as a package reference in your project (e.g., the unit test project referencing ASP.NET Core metapackage).
 
 If targeting .NET Framework, update each package reference's `Version` attribute to 2.2.0 or later. Here are the package references in a typical ASP.NET Core 2.2 project targeting .NET Framework:
 


### PR DESCRIPTION
@mairaw  See my comments on https://github.com/dotnet/sdk/issues/2879#issuecomment-476811104