### PR TITLE
Hosting Models topic updates

### DIFF
--- a/aspnetcore/razor-components/hosting-models.md
+++ b/aspnetcore/razor-components/hosting-models.md
@@ -5,32 +5,39 @@ description: Understand client-side Blazor and server-side ASP.NET Core Razor Co
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 01/29/2019
+ms.date: 03/28/2019
 uid: razor-components/hosting-models
 ---
 # Razor Components hosting models
 
 By [Daniel Roth](https://github.com/danroth27)
 
-Razor Components is a web framework designed to run client-side in the browser on a WebAssembly-based .NET runtime (*Blazor*) or server-side in ASP.NET Core (*ASP.NET Core Razor Components*). Regardless of the hosting model, the app and component models *remain the same*. This article discusses the available hosting models.
+Razor Components is a web framework designed to run client-side in the browser on a [WebAssembly](http://webassembly.org/)-based .NET runtime (*Blazor*) or server-side in ASP.NET Core (*ASP.NET Core Razor Components*). Regardless of the hosting model, the app and component models *remain the same*. This article discusses the available hosting models:
+
+* [Client-side Blazor](#client-side-hosting-model)
+* [Server-side ASP.NET Core Razor Components](#server-side-hosting-model)
 
 ## Client-side hosting model
 
 [!INCLUDE[](~/includes/razor-components-preview-notice.md)]
 
-The principal hosting model for Blazor is running client-side in the browser. In this model, the Blazor app, its dependencies, and the .NET runtime are downloaded to the browser. The app is executed directly on the browser UI thread. All UI updates and event handling happens within the same process. The app assets can be deployed as static files using whatever web server is preferred (see [Host and deploy](xref:host-and-deploy/razor-components/index)).
+The principal hosting model for Blazor is running client-side in the browser on WebAssembly. The Blazor app, its dependencies, and the .NET runtime are downloaded to the browser. The app is executed directly on the browser UI thread. UI updates and event handling occur within the same process. The app's assets are deployed as static files to any web server or service capable of serving static content to clients.
 
 ![Blazor client-side: The Blazor app runs on a UI thread inside the browser.](hosting-models/_static/client-side.png)
 
-To create a Blazor app using the client-side hosting model, use the **Blazor** or **Blazor (ASP.NET Core Hosted)** project templates (`blazor` or `blazorhosted` template when using the [dotnet new](/dotnet/core/tools/dotnet-new) command at a command prompt). The included *components.webassembly.js* script handles:
+To create a Blazor app using the client-side hosting model, use either of the following templates:
 
-* Downloading the .NET runtime, the app, and its dependencies.
+* **Blazor** ([dotnet new blazor](/dotnet/core/tools/dotnet-new)) &ndash; Deployed as a set of static files.
+* **Blazor (ASP.NET Core Hosted)** ([dotnet new blazorhosted](/dotnet/core/tools/dotnet-new)) &ndash; Hosted by an ASP.NET Core server. The ASP.NET Core app serves the Blazor app to clients. The client-side Blazor app can interact with the server over the network using web API calls or [SignalR](xref:signalr/introduction).
+
+The templates include the *components.webassembly.js* script that handles:
+
+* Downloading the .NET runtime, the app, and the app's dependencies.
 * Initialization of the runtime to run the app.
 
 The client-side hosting model offers several benefits. Client-side Blazor:
 
 * Has no .NET server-side dependency.
-* Has a rich interactive UI.
 * Fully leverages client resources and capabilities.
 * Offloads work from the server to the client.
 * Supports offline scenarios.
@@ -40,22 +47,15 @@ There are downsides to client-side hosting. Client-side Blazor:
 * Restricts the app to the capabilities of the browser.
 * Requires capable client hardware and software (for example, WebAssembly support).
 * Has a larger download size and longer app load time.
-* Has less mature .NET runtime and tooling support (for example, limitations in .NET Standard support and debugging).
-
-Visual Studio includes the **Blazor (ASP.NET Core hosted)** project template for creating a Blazor app that runs on WebAssembly and is hosted on an ASP.NET Core server. The ASP.NET Core app serves the Blazor app to clients but is otherwise a separate process. The client-side Blazor app can interact with the server over the network using Web API calls or SignalR connections.
-
-> [!IMPORTANT]
-> If a client-side Blazor app is served by an ASP.NET Core app hosted as an IIS sub-app, disable the inherited ASP.NET Core Module handler. Set the app base path in the Blazor app's *index.html* file to the IIS alias used when configuring the sub-app in IIS.
->
-> For more information, see [App base path](xref:host-and-deploy/razor-components/index#app-base-path).
+* Has less mature .NET runtime and tooling support (for example, limitations in [.NET Standard](/dotnet/standard/net-standard) support and debugging).
 
 ## Server-side hosting model
 
-In the ASP.NET Core Razor Components server-side hosting model, the app is executed on the server from within an ASP.NET Core app. UI updates, event handling, and JavaScript calls are handled over a SignalR connection.
+With the ASP.NET Core Razor Components server-side hosting model, the app is executed on the server from within an ASP.NET Core app. UI updates, event handling, and JavaScript calls are handled over a [SignalR](xref:signalr/introduction) connection.
 
 ![ASP.NET Core Razor Components server-side: The browser interacts with the app (hosted inside of an ASP.NET Core app) on the server over a SignalR connection.](hosting-models/_static/server-side.png)
 
-To create a Razor Components app using the server-side hosting model, use the ASP.NET Core **Razor Components** template (`razorcomponents` when using [dotnet new](/dotnet/core/tools/dotnet-new) at a command prompt). An ASP.NET Core app hosts the Razor Components server-side app and sets up the SignalR endpoint where clients connect. The ASP.NET Core app references the app's `Startup` class to add:
+To create a Razor Components app using the server-side hosting model, use the ASP.NET Core **Razor Components** template ([dotnet new razorcomponents](/dotnet/core/tools/dotnet-new)). The ASP.NET Core app hosts the Razor Components server-side app and sets up the SignalR endpoint where clients connect. The ASP.NET Core app references the app's `Startup` class to add:
 
 * Server-side Razor Components services.
 * The app to the request handling pipeline.
@@ -64,20 +64,19 @@ To create a Razor Components app using the server-side hosting model, use the AS
 
 The *components.server.js* script&dagger; establishes the client connection. It's the app's responsibility to persist and restore app state as required (for example, in the event of a lost network connection).
 
-The server-side hosting model offers several benefits:
+The server-side hosting model offers several benefits. Server-side Razor Components:
 
-* Allows you to write your entire app with .NET and C# using the component model.
-* Provides a rich interactive feel and avoids unnecessary page refreshes.
-* Has a significantly smaller app size than a client-side Blazor app and loads much faster.
-* Component logic can take full advantage of server capabilities, including using any .NET Core compatible APIs.
-* Runs on .NET Core on the server, so existing .NET tooling, such as debugging, works as expected.
+* Have a significantly smaller app size than a client-side Blazor app and load much faster.
+* Can take full advantage of server capabilities, including using any .NET Core compatible APIs.
+* Run on .NET Core on the server, so existing .NET tooling, such as debugging, works as expected.
 * Works with thin clients (for example, browsers that don't support WebAssembly and resource constrained devices).
+* .NET/C# code base, including the app's component code, isn't served to clients.
 
-There are downsides to server-side hosting:
+There are downsides to server-side hosting. Server-side Razor Components:
 
-* Has higher latency: Every user interaction involves a network hop.
-* Offers no offline support: If the client connection fails, the app stops working.
-* Has reduced scalability: The server must manage multiple client connections and handle client state.
-* Requires an ASP.NET Core server to serve the app. Deployment without a server (for example, from a CDN) isn't possible.
+* Have higher latency: Every user interaction involves a network hop.
+* Offer no offline support: If the client connection fails, the app stops working.
+* Have reduced scalability: The server must manage multiple client connections and handle client state.
+* Require an ASP.NET Core server to serve the app. Deployment without a server (for example, from a CDN) isn't possible.
 
 &dagger;The *components.server.js* script is published to the following path: *bin/{Debug|Release}/{TARGET FRAMEWORK}/publish/{APPLICATION NAME}.App/dist/_framework*.

--- a/aspnetcore/razor-components/hosting-models.md
+++ b/aspnetcore/razor-components/hosting-models.md
@@ -21,7 +21,7 @@ Razor Components is a web framework designed to run client-side in the browser o
 
 [!INCLUDE[](~/includes/razor-components-preview-notice.md)]
 
-The principal hosting model for Blazor is running client-side in the browser on WebAssembly. The Blazor app, its dependencies, and the .NET runtime are downloaded to the browser. The app is executed directly on the browser UI thread. UI updates and event handling occur within the same process. The app's assets are deployed as static files to any web server or service capable of serving static content to clients.
+The principal hosting model for Blazor is running client-side in the browser on WebAssembly. The Blazor app, its dependencies, and the .NET runtime are downloaded to the browser. The app is executed directly on the browser UI thread. UI updates and event handling occur within the same process. The app's assets are deployed as static files to a web server or service capable of serving static content to clients.
 
 ![Blazor client-side: The Blazor app runs on a UI thread inside the browser.](hosting-models/_static/client-side.png)
 

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -560,6 +560,8 @@
           uid: razor-components/index
         - name: Get started
           uid: razor-components/get-started
+        - name: Hosting models
+          uid: razor-components/hosting-models
         - name: Build your first app
           uid: tutorials/first-razor-components-app
         - name: Components
@@ -576,8 +578,6 @@
           uid: razor-components/javascript-interop
         - name: Debug
           uid: razor-components/debug
-        - name: Hosting models
-          uid: razor-components/hosting-models
         - name: Host and deploy
           items:
             - name: Overview
@@ -592,6 +592,8 @@
               uid: spa/blazor/index
             - name: Get started
               uid: spa/blazor/get-started
+            - name: Hosting models
+              uid: razor-components/hosting-models
             - name: Build your first app
               uid: tutorials/first-razor-components-app
             - name: Components
@@ -608,8 +610,6 @@
               uid: razor-components/javascript-interop
             - name: Debug
               uid: razor-components/debug
-            - name: Hosting models
-              uid: razor-components/hosting-models
             - name: Host and deploy
               items:
                 - name: Overview


### PR DESCRIPTION
Fixes #11713 

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/razor-components/hosting-models?view=aspnetcore-3.0&branch=pr-en-us-11721)

* Moves this coverage UP in the TOC ... under the *Get Started* topics. Devs make the decision on which hosting model to adopt early in the software development process. Ideally, they'll pick the one they like based on characteristics of each and carry that decision into the *Build Your First* experience (the next topic).
* Cross-links to this topic are good. No changes needed.
* The code sample in the *Server-side hosting model* section (`Startup`) ... is that necessary? I don't think it provides much value. It's an implementation detail AFAICT. They can inspect the RC `Startup` easily enough when they get to the *Build Your First* experience. I left it here, but I'd like to cut it (perhaps move it to the *Build Your First* topic). **_Thoughts?_**
* For the following points, aren't they true of both hosting models? (I cut them here because they seem like common features.)
  * "Has a rich interactive UI."
  * "Allows you to write your entire app with .NET and C# using the component model."
  * "Provides a rich interactive feel and avoids unnecessary page refreshes."
* Added one for server-side (keeps the code private): ".NET/C# code base, including the app's component code, isn't served to clients."