### PR TITLE
SEO April: include ASP.NET Core 3.0 in title

### DIFF
--- a/aspnetcore/razor-components/index.md
+++ b/aspnetcore/razor-components/index.md
@@ -1,10 +1,10 @@
 ---
-title: Introduction to Razor Components
+title: Introduction to Razor Components in ASP.NET Core 3.0
 author: guardrex
 description: Explore ASP.NET Core Razor Components, a way to build interactive client-side web UI with .NET in an ASP.NET Core app.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
-ms.custom: mvc
+ms.custom: seoapril2019
 ms.date: 03/27/2019
 uid: razor-components/index
 ---


### PR DESCRIPTION
SEO April Effort: This topic is for ASP.NET Core 3.0 and a top keyword being used in search included "3".  It is not immediately clear the topic is for ASP.NET Core 3.0 in search or even once you look at the topic.  Changing to see if the bounce rate improves.  Following up on bounce ratings next month for this as part of SEO hackadoc.  No related issue for this PR.

