### PR TITLE
Turn off blanks-around-lists markdownlint rule

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,7 @@
 {
     "default": true,
 
+    "blanks-around-lists": false,
     "blanks-around-fences": true,
     "blanks-around-headers": true,
     "fenced-code-language": true,


### PR DESCRIPTION
Disabling blanks-around-lists per team discussion on 4/2.