### PR TITLE
Adopt certificate approach in AKV config provider topic

### DIFF
--- a/aspnetcore/security/key-vault-configuration/sample/Program.cs
+++ b/aspnetcore/security/key-vault-configuration/sample/Program.cs
@@ -1,8 +1,10 @@
-#define Basic // Managed
+#define Certificate // Managed
 // Change to 'Managed' to run the sample in Managed Identity configuration.
 // For details, see the Azure Key Vault Configuration Provider topic:
 // https://docs.microsoft.com/aspnet/core/security/key-vault-configuration
 
+
+using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Azure.KeyVault;
@@ -19,8 +21,9 @@ namespace SampleApp
             CreateWebHostBuilder(args).Build().Run();
         }
 
-#if Basic
+#if Certificate
         #region snippet1
+        // using System.Security.Cryptography.X509Certificates;
         // using Microsoft.Extensions.Configuration;
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
@@ -34,7 +37,7 @@ namespace SampleApp
                         config.AddAzureKeyVault(
                             $"https://{builtConfig["KeyVaultName"]}.vault.azure.net/",
                             builtConfig["AzureADApplicationId"],
-                            builtConfig["AzureADPassword"]);
+                            new X509Certificate2("TestCert.pfx"));
                     }
                 })
                 .UseStartup<Startup>();

--- a/aspnetcore/security/key-vault-configuration/sample/README.md
+++ b/aspnetcore/security/key-vault-configuration/sample/README.md
@@ -4,7 +4,7 @@ This sample illustrates the use of the Azure Key Vault Configuration Provider.
 
 The sample runs in one of two modes determined by the `#define` statement at the top of the *Program.cs* file. For instructions, see [Preprocessor directives in sample code](https://docs.microsoft.com/aspnet/core#preprocessor-directives-in-sample-code):
 
-* `Basic` &ndash; Demonstrates the use of an Azure Key Vault Client ID and Secret to access secrets stored in Azure Key Vault. This version of the sample can be run from any location, deployed to Azure App Service or any host capable of serving an ASP.NET Core app.
+* `Certificate` &ndash; Demonstrates the use of an Azure Key Vault Client ID and X.509 certificate to access secrets stored in Azure Key Vault. This version of the sample can be run from any location, deployed to Azure App Service or any host capable of serving an ASP.NET Core app.
 * `Managed` &ndash; Demonstrates how to use Azure's [Managed Service Identity](https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview) to authenticate the app to Azure Key Vault with Azure AD authentication without credentials in the app's code or configuration. An Azure AD Client ID and Secret aren't required for the app to authenticate with Azure Key Vault. This sample must be deployed to Azure App Service to explore the Managed Identity scearnio.
 
 For more information, see [Azure Key Vault Configuration Provider](https://docs.microsoft.com/aspnet/core/security/key-vault-configuration).

--- a/aspnetcore/security/key-vault-configuration/sample/appsettings.json
+++ b/aspnetcore/security/key-vault-configuration/sample/appsettings.json
@@ -1,5 +1,4 @@
 {
   "KeyVaultName": "Key Vault Name",
-  "AzureADApplicationId": "Azure AD Application ID",
-  "AzureADPassword": "Azure AD Password/Client Secret"
+  "AzureADApplicationId": "Azure AD Application ID"
 }


### PR DESCRIPTION
Fixes #10790 

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/security/key-vault-configuration?view=aspnetcore-2.1&branch=pr-en-us-11827)

... almost fixes. This fixes the certificate guidance recommendation from the Azure PM. It removes the ClientID/Secret approach.

Never did find out how to use the Cloud Shell for granting access to KV. We can go on with the portal as described in the topic.

We prob need to merge this work now because we're going on the road to **_Merge Conflict City_** with a future PR if we don't (e.g., a sample update or 3.x work on the topic).