### PR TITLE
Use New-LocalUser in WS topic

### DIFF
--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -19,13 +19,7 @@ An ASP.NET Core app can be hosted on Windows as a [Windows Service](/dotnet/fram
 ## Prerequisites
 
 * [PowerShell 6.2 or later](https://github.com/PowerShell/PowerShell)
-
-> [!NOTE]
-> For Windows OS earlier than the Windows 10 April 2018 Update (version 1803/build 10.0.17134), the [Microsoft.PowerShell.LocalAccounts](/powershell/module/microsoft.powershell.localaccounts) module must be imported to gain access to the [New-LocalUser](/powershell/module/microsoft.powershell.localaccounts/new-localuser) cmdlet used in the [Create a user account](#create-a-user-account) section:
->
-> ```powershell
-> Import-Module Microsoft.PowerShell.LocalAccounts
-> ```
+* Windows 10 October 2018 Update (version 1809) or later
 
 ## Deployment type
 
@@ -209,8 +203,7 @@ Use the [RegisterService.ps1](https://github.com/aspnet/Docs/tree/master/aspnetc
     -Name {NAME} 
     -DisplayName "{DISPLAY NAME}" 
     -Description "{DESCRIPTION}" 
-    -Path "{PATH}" 
-    -Exe {ASSEMBLY}.exe 
+    -Exe "{PATH TO EXE}\{ASSEMBLY NAME}.exe" 
     -User {DOMAIN\USER}
 ```
 
@@ -225,8 +218,7 @@ In the following example for the sample app:
     -Name MyService 
     -DisplayName "My Cool Service" 
     -Description "This is the Sample App service." 
-    -Path "c:\svc" 
-    -Exe SampleApp.exe 
+    -Exe "c:\svc\SampleApp.exe" 
     -User Desktop-PC\ServiceUser
 ```
 

--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -152,24 +152,18 @@ dotnet publish --configuration Release --runtime win7-x64 --output c:\svc
 
 ## Create a user account
 
-Create a user account for the service from an administrative PowerShell 6 command shell.
-
-Execute the [Read-Host](/powershell/module/Microsoft.PowerShell.Utility/Read-Host) cmdlet to obtain a password and store it in `$Password`. Follow the guidance on creating a [strong password](/windows/security/threat-protection/security-policy-settings/password-must-meet-complexity-requirements).
+Create a user account for the service using the [New-LocalUser](/powershell/module/microsoft.powershell.localaccounts/new-localuser) cmdlet from an administrative PowerShell 6 command shell:
 
 ```powershell
-$Password = Read-Host -AsSecureString
+New-LocalUser -Name {NAME}
 ```
 
-Use `$Password` to create a user account for the service using the [New-LocalUser](/powershell/module/microsoft.powershell.localaccounts/new-localuser) cmdlet:
-
-```powershell
-New-LocalUser -Name {NAME} -Password $Password
-```
+Provide a [strong password](/windows/security/threat-protection/security-policy-settings/password-must-meet-complexity-requirements) when prompted.
 
 For the sample app, create a user account with the name `ServiceUser`.
 
 ```powershell
-New-LocalUser -Name ServiceUser -Password $Password
+New-LocalUser -Name ServiceUser
 ```
 
 Unless the `-AccountExpires` parameter is supplied to the [New-LocalUser](/powershell/module/microsoft.powershell.localaccounts/new-localuser) cmdlet with an expiration <xref:System.DateTime>, the account doesn't expire.

--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -19,7 +19,14 @@ An ASP.NET Core app can be hosted on Windows as a [Windows Service](/dotnet/fram
 ## Prerequisites
 
 * [PowerShell 6.2 or later](https://github.com/PowerShell/PowerShell)
-* Windows 10 October 2018 Update (version 1809) or later
+
+> [!NOTE]
+> For Windows OS earlier than the Windows 10 October 2018 Update (version 1809/build 10.0.17763), the [Microsoft.PowerShell.LocalAccounts](/powershell/module/microsoft.powershell.localaccounts) module must be imported with the [WindowsCompatibility module](https://github.com/PowerShell/WindowsCompatibility) to gain access to the [New-LocalUser](/powershell/module/microsoft.powershell.localaccounts/new-localuser) cmdlet used in the [Create a user account](#create-a-user-account) section:
+>
+> ```powershell
+> Install-Module WindowsCompatibility -Scope CurrentUser
+> Import-WinModule Microsoft.PowerShell.LocalAccounts
+> ```
 
 ## Deployment type
 

--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -20,6 +20,13 @@ An ASP.NET Core app can be hosted on Windows as a [Windows Service](/dotnet/fram
 
 * [PowerShell 6.2 or later](https://github.com/PowerShell/PowerShell)
 
+> [!NOTE]
+> For Windows OS earlier than the Windows 10 April 2018 Update (version 1803/build 10.0.17134), the [Microsoft.PowerShell.LocalAccounts](/powershell/module/microsoft.powershell.localaccounts) module must be imported to gain access to the [New-LocalUser](/powershell/module/microsoft.powershell.localaccounts/new-localuser) cmdlet used in the [Create a user account](#create-a-user-account) section:
+>
+> ```powershell
+> Import-Module Microsoft.PowerShell.LocalAccounts
+> ```
+
 ## Deployment type
 
 You can create either a framework-dependent or self-contained Windows Service deployment. For information and advice on deployment scenarios, see [.NET Core application deployment](/dotnet/core/deploying/).

--- a/aspnetcore/host-and-deploy/windows-service/scripts/2.x/RegisterService.ps1
+++ b/aspnetcore/host-and-deploy/windows-service/scripts/2.x/RegisterService.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Version 6.1.3
+﻿#Requires -Version 6.2
 #Requires -RunAsAdministrator
 
 param(
@@ -16,12 +16,10 @@ param(
     $User
 )
 
-$cred = Get-Credential -Credential $User
-
 $acl = Get-Acl $Path
 $aclRuleArgs = $cred.UserName, "Read,Write,ReadAndExecute", "ContainerInherit, ObjectInherit", "None", "Allow"
 $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule $aclRuleArgs
 $acl.SetAccessRule($accessRule)
 $acl | Set-Acl $Path
 
-New-Service -Name $Name -BinaryPathName "$Path\$Exe" -Credential $cred -Description $Description -DisplayName $DisplayName -StartupType Automatic
+New-Service -Name $Name -BinaryPathName "$Path\$Exe" -Credential $User -Description $Description -DisplayName $DisplayName -StartupType Automatic

--- a/aspnetcore/host-and-deploy/windows-service/scripts/2.x/RegisterService.ps1
+++ b/aspnetcore/host-and-deploy/windows-service/scripts/2.x/RegisterService.ps1
@@ -3,16 +3,22 @@
 
 param(
     [Parameter(mandatory=$true)]
+    [string]
     $Name,
     [Parameter(mandatory=$true)]
+    [string]
     $DisplayName,
     [Parameter(mandatory=$true)]
+    [string]
     $Description,
     [Parameter(mandatory=$true)]
+    [string]
     $Path,
     [Parameter(mandatory=$true)]
+    [string]
     $Exe,
     [Parameter(mandatory=$true)]
+    [string]
     $User
 )
 

--- a/aspnetcore/host-and-deploy/windows-service/scripts/2.x/RegisterService.ps1
+++ b/aspnetcore/host-and-deploy/windows-service/scripts/2.x/RegisterService.ps1
@@ -23,7 +23,7 @@ param(
 )
 
 $acl = Get-Acl $Path
-$aclRuleArgs = $cred.UserName, "Read,Write,ReadAndExecute", "ContainerInherit, ObjectInherit", "None", "Allow"
+$aclRuleArgs = $cred.UserName, "Read, Write, ReadAndExecute", "ContainerInherit, ObjectInherit", "None", "Allow"
 $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule $aclRuleArgs
 $acl.SetAccessRule($accessRule)
 $acl | Set-Acl $Path

--- a/aspnetcore/host-and-deploy/windows-service/scripts/2.x/RegisterService.ps1
+++ b/aspnetcore/host-and-deploy/windows-service/scripts/2.x/RegisterService.ps1
@@ -12,20 +12,17 @@ param(
     [string]
     $Description,
     [Parameter(mandatory=$true)]
-    [string]
-    $Path,
-    [Parameter(mandatory=$true)]
-    [string]
+    [System.IO.FileInfo]
     $Exe,
     [Parameter(mandatory=$true)]
     [string]
     $User
 )
 
-$acl = Get-Acl $Path
+$acl = Get-Acl $($Exe.DirectoryName)
 $aclRuleArgs = $cred.UserName, "Read, Write, ReadAndExecute", "ContainerInherit, ObjectInherit", "None", "Allow"
 $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule $aclRuleArgs
 $acl.SetAccessRule($accessRule)
-$acl | Set-Acl $Path
+$acl | Set-Acl $($Exe.DirectoryName)
 
-New-Service -Name $Name -BinaryPathName "$Path\$Exe" -Credential $User -Description $Description -DisplayName $DisplayName -StartupType Automatic
+New-Service -Name $Name -BinaryPathName $($Exe.FullName) -Credential $User -Description $Description -DisplayName $DisplayName -StartupType Automatic


### PR DESCRIPTION
Fixes #11344 

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/host-and-deploy/windows-service?view=aspnetcore-2.1&branch=pr-en-us-11839)

* Converting from `net user` over to PS 6.2+ `New-LocalUser`.
* I've been reading/hearing lately that "secure string" things aren't so hot any longer from a security perspective; however, this seems to be the way that the commands work in 6.2.
* The updated procedure on the PR has been checked here with :+1::smile: results.

@TravisEz13 ... Do you have a few minutes to look at this? It's a small update that shouldn't take long to review. You can scroll right down to Line 146 **(\#\# *Create a user account*)**.

