### PR TITLE
Adjust .NET Standard paragraph

### DIFF
--- a/aspnetcore/client-side/spa/blazor/index.md
+++ b/aspnetcore/client-side/spa/blazor/index.md
@@ -86,7 +86,7 @@ For apps that require third-party JavaScript libraries and browser APIs, Blazor 
 
 ## Code sharing and .NET Standard
 
-Apps can reference and use existing [.NET Standard](/dotnet/standard/net-standard) libraries. .NET Standard is a formal specification of .NET APIs that are common across .NET implementations. Blazor implements .NET Standard 2.0. APIs that aren't applicable inside a web browser (for example, accessing the file system, opening a socket, threading, and other features) throw <xref:System.PlatformNotSupportedException>. .NET Standard 2.0 class libraries can be shared across different .NET platforms, like Blazor, .NET Framework, .NET Core, Xamarin, Mono, and Unity.
+Apps can reference and use existing [.NET Standard](/dotnet/standard/net-standard) libraries. .NET Standard is a formal specification of .NET APIs that are common across .NET implementations. Blazor implements .NET Standard 2.0. APIs that aren't applicable inside a web browser (for example, accessing the file system, opening a socket, threading, and other features) throw <xref:System.PlatformNotSupportedException>. .NET Standard class libraries can be shared across different .NET platforms, like Blazor, .NET Framework, .NET Core, Xamarin, Mono, and Unity.
 
 ## Optimization
 

--- a/aspnetcore/client-side/spa/blazor/index.md
+++ b/aspnetcore/client-side/spa/blazor/index.md
@@ -86,7 +86,7 @@ For apps that require third-party JavaScript libraries and browser APIs, Blazor 
 
 ## Code sharing and .NET Standard
 
-Apps can reference and use existing [.NET Standard](/dotnet/standard/net-standard) libraries. .NET Standard is a formal specification of .NET APIs that are common across .NET implementations. Blazor supports .NET Standard 2.0. APIs that aren't applicable inside a web browser (for example, accessing the file system, opening a socket, threading, and other features) throw <xref:System.PlatformNotSupportedException>. .NET Standard 2.0 class libraries can be shared across different .NET platforms, like Blazor, .NET Framework, .NET Core, Xamarin, Mono, and Unity.
+Apps can reference and use existing [.NET Standard](/dotnet/standard/net-standard) libraries. .NET Standard is a formal specification of .NET APIs that are common across .NET implementations. Blazor implements .NET Standard 2.0. APIs that aren't applicable inside a web browser (for example, accessing the file system, opening a socket, threading, and other features) throw <xref:System.PlatformNotSupportedException>. .NET Standard 2.0 class libraries can be shared across different .NET platforms, like Blazor, .NET Framework, .NET Core, Xamarin, Mono, and Unity.
 
 ## Optimization
 

--- a/aspnetcore/client-side/spa/blazor/index.md
+++ b/aspnetcore/client-side/spa/blazor/index.md
@@ -86,7 +86,7 @@ For apps that require third-party JavaScript libraries and browser APIs, Blazor 
 
 ## Code sharing and .NET Standard
 
-Apps can reference and use existing [.NET Standard](/dotnet/standard/net-standard) libraries. .NET Standard is a formal specification of .NET APIs that are common across .NET implementations. .NET Standard 2.0 or higher is supported. APIs that aren't applicable inside a web browser (for example, accessing the file system, opening a socket, threading, and other features) throw <xref:System.PlatformNotSupportedException>. .NET Standard class libraries can be shared across server code and in browser-based apps.
+Apps can reference and use existing [.NET Standard](/dotnet/standard/net-standard) libraries. .NET Standard is a formal specification of .NET APIs that are common across .NET implementations. Blazor supports .NET Standard 2.0. APIs that aren't applicable inside a web browser (for example, accessing the file system, opening a socket, threading, and other features) throw <xref:System.PlatformNotSupportedException>. .NET Standard 2.0 class libraries can be shared across different .NET platforms, like Blazor, .NET Framework, .NET Core, Xamarin, Mono, and Unity.
 
 ## Optimization
 


### PR DESCRIPTION
A platform that supports .NET Standard 2.0 supports all previous versions: 1.0, 1.1, 1.2,1.3,1.4,1.5 and 1.6. So the original statement ".NET Standard 2.0 or higher is supported" is misleading, as Blazor won't support .NET Standard 2.1 without adjustments to the platform.

So my suggestion is to just change it to "Blazor supports .NET Standard 2.0".

In addition libraries can not only be shared between browser and server side, but between different platforms. 




<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->