### PR TITLE
Fix .NET Standard issue and link version table

### DIFF
--- a/aspnetcore/index.md
+++ b/aspnetcore/index.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Get an introduction to ASP.NET Core, a cross-platform, high-performance, open-source framework for building modern, cloud-based, Internet-connected applications.
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/06/2019
+ms.date: 04/07/2019
 uid: index
 ---
 # Introduction to ASP.NET Core
@@ -44,7 +44,7 @@ ASP.NET Core integrates seamlessly with popular client-side frameworks and libra
 
 ## ASP.NET Core targeting .NET Framework
 
-ASP.NET Core 2.x can target .NET Core or .NET Framework. ASP.NET Core apps targeting .NET Framework aren't cross-platform&mdash;they run on Windows only. Generally, ASP.NET Core 2.x is made up of [.NET Standard](/dotnet/standard/net-standard) libraries. Libraries written with .NET Standard 2.0 run on [any .NET platform that implements .NET Standard 2.0](https://github.com/dotnet/standard/blob/master/docs/versions.md).
+ASP.NET Core 2.x can target .NET Core or .NET Framework. ASP.NET Core apps targeting .NET Framework aren't cross-platform&mdash;they run on Windows only. Generally, ASP.NET Core 2.x is made up of [.NET Standard](/dotnet/standard/net-standard) libraries. Libraries written with .NET Standard 2.0 run on [any .NET platform that implements .NET Standard 2.0](/dotnet/standard/net-standard#net-implementation-support).
 
 ASP.NET Core 2.x is supported on .NET Framework versions that implement .NET Standard 2.0:
 

--- a/aspnetcore/index.md
+++ b/aspnetcore/index.md
@@ -44,7 +44,7 @@ ASP.NET Core integrates seamlessly with popular client-side frameworks and libra
 
 ## ASP.NET Core targeting .NET Framework
 
-ASP.NET Core 2.x can target .NET Core or .NET Framework. ASP.NET Core apps targeting .NET Framework aren't cross-platform&mdash;they run on Windows only. Generally, ASP.NET Core 2.x is made up of [.NET Standard](/dotnet/standard/net-standard) libraries. Apps written with .NET Standard 2.0 run anywhere that .NET Standard 2.0 is implemented.
+ASP.NET Core 2.x can target .NET Core or .NET Framework. ASP.NET Core apps targeting .NET Framework aren't cross-platform&mdash;they run on Windows only. Generally, ASP.NET Core 2.x is made up of [.NET Standard](/dotnet/standard/net-standard) libraries. Libraries written with .NET Standard 2.0 run on [any .NET platform that implements .NET Standard 2.0](https://github.com/dotnet/standard/blob/master/docs/versions.md).
 
 ASP.NET Core 2.x is supported on .NET Framework versions that implement .NET Standard 2.0:
 


### PR DESCRIPTION
You can't build "Apps" with .NET Standard, as it is not a runtime. You can only build libraries with it. And those libraries can be executed by a runtime that implements .NET Standard, like .NET Core or .NET Framework. So I changed "Apps" to "Libraries" in that paragraph. I also linked the versions table from the .NET Standard GitHub repo. 

This change is a minor fix to the already closed issue #11866 (cc @guardrex)



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->