### PR TITLE
Update `IAuthorizationPolicyProvider` docs

### DIFF
--- a/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
+++ b/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
@@ -156,7 +156,7 @@ As with all aspects of a custom `IAuthorizationPolicyProvider`, you can customiz
 
 ## Required policy
 
-Finally, a custom `IAuthorizationPolicyProvider` needs to implement `GetRequiredPolicyAsync` to, optionally, provide a policy that is always required. If `GetRequiredPolicyAsync` returns a non-null policy, that policy will be combined with any other (named or default) policy that is requested.
+A custom `IAuthorizationPolicyProvider` needs to implement `GetRequiredPolicyAsync` to, optionally, provide a policy that is always required. If `GetRequiredPolicyAsync` returns a non-null policy, that policy will be combined with any other (named or default) policy that is requested.
 
 If no required policy is needed, the provider can just return null or defer to the fallback provider:
 

--- a/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
+++ b/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
@@ -134,7 +134,7 @@ public MinimumAgePolicyProvider(IOptions<AuthorizationOptions> options)
 }
 ```
 
-Then, the `GetPolicyAsync` method can be updated to use the `FallbackProlicyProvider` instead of returning null:
+Then, the `GetPolicyAsync` method can be updated to use the `FallbackPolicyProvider` instead of returning null:
 
 ```csharp
 ...

--- a/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
+++ b/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
@@ -4,7 +4,7 @@ author: mjrousos
 description: Learn how to use a custom IAuthorizationPolicyProvider in an ASP.NET Core app to dynamically generate authorization policies.
 ms.author: riande
 ms.custom: mvc
-ms.date: 01/21/2019
+ms.date: 04/15/2019
 uid: security/authorization/iauthorizationpolicyprovider
 ---
 # Custom Authorization Policy Providers using IAuthorizationPolicyProvider in ASP.NET Core 
@@ -38,7 +38,7 @@ By implementing these two APIs, you can customize how authorization policies are
 
 One scenario where `IAuthorizationPolicyProvider` is useful is enabling custom `[Authorize]` attributes whose requirements depend on a parameter. For example, in [policy-based authorization](xref:security/authorization/policies) documentation, an age-based (“AtLeast21”) policy was used as a sample. If different controller actions in an app should be made available to users of *different* ages, it might be useful to have many different age-based policies. Instead of registering all the different age-based policies that the application will need in `AuthorizationOptions`, you can generate the policies dynamically with a custom `IAuthorizationPolicyProvider`. To make using the policies easier, you can annotate actions with custom authorization attribute like `[MinimumAgeAuthorize(20)]`.
 
-## Custom Authorization Attributes
+## Custom Authorization attributes
 
 Authorization policies are identified by their names. The custom `MinimumAgeAuthorizeAttribute` described previously needs to map arguments into a string that can be used to retrieve the corresponding authorization policy. You can do this by deriving from `AuthorizeAttribute` and making the `Age` property wrap the
 `AuthorizeAttribute.Policy` property.
@@ -154,7 +154,7 @@ public Task<AuthorizationPolicy> GetDefaultPolicyAsync() =>
 
 As with all aspects of a custom `IAuthorizationPolicyProvider`, you can customize this, as needed. In some cases, it may be desirable to retrieve the default policy from a fallback `IAuthorizationPolicyProvider`.
 
-## Required Policy
+## Required policy
 
 Finally, a custom `IAuthorizationPolicyProvider` needs to implement `GetRequiredPolicyAsync` to, optionally, provide a policy that is always required. If `GetRequiredPolicyAsync` returns a non-null policy, that policy will be combined with any other (named or default) policy that is requested.
 

--- a/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
+++ b/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
@@ -123,7 +123,7 @@ For example, consider an application that needs both custom age policies and mor
 
 The example `IAuthorizationPolicyProvider` implementation shown above can be updated to use the `DefaultAuthorizationPolicyProvider` by creating a fallback policy provider in its constructor (to be used in case the policy name doesn't match its expected pattern of 'MinimumAge' + age).
 
-```CSharp
+```csharp
 private DefaultAuthorizationPolicyProvider FallbackPolicyProvider { get; }
 
 public MinimumAgePolicyProvider(IOptions<AuthorizationOptions> options)
@@ -136,7 +136,7 @@ public MinimumAgePolicyProvider(IOptions<AuthorizationOptions> options)
 
 Then, the `GetPolicyAsync` method can be updated to use the `FallbackProlicyProvider` instead of returning null:
 
-```CSharp
+```csharp
 ...
 return FallbackPolicyProvider.GetPolicyAsync(policyName);
 ```
@@ -152,7 +152,7 @@ public Task<AuthorizationPolicy> GetDefaultPolicyAsync() =>
     Task.FromResult(new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build());
 ```
 
-As with all aspects of a custom `IAuthorizationPolicyProvider`, you can customize this, as needed. In some cases it may be desirable to retrieve the default policy from a fallback `IAuthorizationPolicyProvider`.
+As with all aspects of a custom `IAuthorizationPolicyProvider`, you can customize this, as needed. In some cases, it may be desirable to retrieve the default policy from a fallback `IAuthorizationPolicyProvider`.
 
 ## Required Policy
 
@@ -160,7 +160,7 @@ Finally, a custom `IAuthorizationPolicyProvider` needs to implement `GetRequired
 
 If no required policy is needed, the provider can just return null or defer to the fallback provider:
 
-```CSharp
+```csharp
 public Task<AuthorizationPolicy> GetRequiredPolicyAsync() => 
     Task.FromResult<AuthorizationPolicy>(null);
 ```


### PR DESCRIPTION
This adds more details on using fallback providers and adds documentation for the `GetRequiredPolicyAsync` API.

Fixes #10824