### PR TITLE
remove link to deleted article

### DIFF
--- a/aspnetcore/host-and-deploy/docker/index.md
+++ b/aspnetcore/host-and-deploy/docker/index.md
@@ -23,9 +23,6 @@ Learn terms and definitions for Docker technology.
 [Docker containers, images, and registries](/dotnet/standard/microservices-architecture/container-docker-introduction/docker-containers-images-registries)  
 Find out how Docker container images are stored in an image registry for consistent deployment across environments.
 
-[Build Docker Images for .NET Core Applications](/dotnet/articles/core/docker/building-net-docker-images)  
-Learn how to build and dockerize an ASP.NET Core app. Explore Docker images maintained by Microsoft and examine use cases.
-
 [Visual Studio Tools for Docker](xref:host-and-deploy/docker/visual-studio-tools-for-docker)  
 Discover how Visual Studio 2017 supports building, debugging, and running ASP.NET Core apps targeting either .NET Framework or .NET Core on Docker for Windows. Both Windows and Linux containers are supported.
 

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -749,9 +749,6 @@
         - name: Overview
           displayName: deploy, publish, docker
           uid: host-and-deploy/docker/index
-        - name: Build Docker images
-          displayName: deploy, publish, docker
-          href: /dotnet/core/docker/building-net-docker-images
         - name: Visual Studio Tools
           displayName: deploy, publish, docker
           uid: host-and-deploy/docker/visual-studio-tools-for-docker


### PR DESCRIPTION
This article was deleted from the .NET Core docs repo and its URL was redirected to a completely different article.  The intent was to move the article to the ASP.NET Core repo and then the link would be accurate again, but until that can be done it will be better not to mislead people.
See #11705 