### PR TITLE
Add docs for markup in code blocks.

### DIFF
--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -166,6 +166,31 @@ The code renders the following HTML:
 <p>Hate cannot drive out hate, only love can do that. - Martin Luther King, Jr.</p>
 ```
 
+::: moniker range=">= aspnetcore-3.0"
+
+In code blocks, declare local functions (introduced in C# 7.0) with markup to serve as templating methods:
+
+```cshtml
+@{
+    void RenderName(string name)
+    {
+        <p>Name: <strong>@name</strong></p>
+    }
+
+    RenderName("Mahatma Gandhi");
+    RenderName("Martin Luther King, Jr.");
+}
+```
+
+The code renders the following HTML:
+
+```html
+<p>Name: <strong>Mahatma Gandhi</strong></p>
+<p>Name: <strong>Martin Luther King, Jr.</strong></p>
+```
+
+::: moniker-end
+
 ### Implicit transitions
 
 The default language in a code block is C#, but the Razor Page can transition back to HTML:
@@ -515,6 +540,33 @@ The code generates the following HTML markup:
 The following code is the generated Razor C# class:
 
 [!code-csharp[](razor/sample/Classes/Views_Home_Test_cshtml.cs?range=1-19)]
+
+::: moniker range=">= aspnetcore-3.0"
+
+`@functions` methods serve as templating methods when they have markup:
+
+```cshtml
+@{
+    RenderName("Mahatma Gandhi");
+    RenderName("Martin Luther King, Jr.");
+}
+
+@functions {
+    private void RenderName(string name)
+    {
+        <p>Name: <strong>@name</strong></p>
+    }
+}
+```
+
+The code renders the following HTML:
+
+```html
+<p>Name: <strong>Mahatma Gandhi</strong></p>
+<p>Name: <strong>Martin Luther King, Jr.</strong></p>
+```
+
+::: moniker-end
 
 ### @section
 

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -168,7 +168,7 @@ The code renders the following HTML:
 
 ::: moniker range=">= aspnetcore-3.0"
 
-In code blocks, declare local functions (introduced in C# 7.0) with markup to serve as templating methods:
+In code blocks, declare [local functions](/dotnet/csharp/programming-guide/classes-and-structs/local-functions) with markup to serve as templating methods:
 
 ```cshtml
 @{


### PR DESCRIPTION
- Markup in code blocks were added in order to allow easy templating alternatives for users who are coming from pre-.NET Core days of Razor where `@helper` was an option.
- Expanded the Razor syntax sheet to include the markup in code blocks pieces. Didn't want to call out specifically that this is an alternative to using old school `@helper` because that could technically lead to more confusion for those who are just entering the .NET Core world and have never seen `@helper` in their lives.

@guardrex @scottaddie @RickAndMSFT how do I ensure these docs only show up when .NET Core 3.0.0 is selected in the docs?

Fixes #11647