### PR TITLE
Patch redirects

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -747,12 +747,12 @@
         },
         {
             "source_path": "aspnetcore/client-side/spa/index.md",
-            "redirect_url": "/aspnet/core/client-side/spa/blazor/index",
+            "redirect_url": "/aspnet/core/blazor/",
             "redirect_document_id": false
         },
         {
             "source_path": "aspnetcore/client-side/index.md",
-            "redirect_url": "/aspnet/core/client-side/razor-components/index",
+            "redirect_url": "/aspnet/core/blazor/",
             "redirect_document_id": false
         },
         {


### PR DESCRIPTION
Here's that patch for the two existing Blazor redirects.

We should be good with the trailing slash on the `redirect_url` (as opposed to `/index`, which isn't really what our links resolve to; there might be another redirect if we go the `/index` way).

btw -- It was actually *410 - Gone* that I was originally asking them about. I added a request to it for specifying the status code. https://github.com/dotnet/docfx/issues/2672