### PR TITLE
Add web API MS Learn module to ToC

### DIFF
--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -20,6 +20,13 @@
       uid: aspnetcore-2.0
     - name: What's new in 1.1
       uid: aspnetcore-1.1
+- name: Tutorials (interactive)
+  items:
+    - name: Web API apps
+      items:
+        - name: Create a web API
+          displayName: tutorial
+          href: /learn/modules/build-web-api-net-core/
 - name: Tutorials
   items:
     - name: Web apps

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -20,13 +20,6 @@
       uid: aspnetcore-2.0
     - name: What's new in 1.1
       uid: aspnetcore-1.1
-- name: Tutorials (interactive)
-  items:
-    - name: Web API apps
-      items:
-        - name: Create a web API
-          displayName: tutorial
-          href: /learn/modules/build-web-api-net-core/
 - name: Tutorials
   items:
     - name: Web apps
@@ -153,6 +146,10 @@
               uid: data/ef-mvc/inheritance
             - name: Advanced topics
               uid: data/ef-mvc/advanced
+- name: Tutorials (Microsoft Learn)
+  items:
+    - name: Web API apps
+      href: /learn/modules/build-web-api-net-core/
 - name: Fundamentals
   items:
     - name: Overview

--- a/aspnetcore/web-api/advanced/conventions/sample/Controllers/ContactsConventionController.cs
+++ b/aspnetcore/web-api/advanced/conventions/sample/Controllers/ContactsConventionController.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using ApiConventions.Models;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 
 namespace ApiConventions.Controllers
 {
@@ -70,6 +71,9 @@ namespace ApiConventions.Controllers
 
         // DELETE api/contactsconvention/{guid}
         [HttpDelete("{id}")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesDefaultResponseType]
         public IActionResult Delete(string id)
         {
             var contact = _contacts.Get(id);

--- a/aspnetcore/web-api/advanced/conventions/sample/Controllers/ContactsConventionController.cs
+++ b/aspnetcore/web-api/advanced/conventions/sample/Controllers/ContactsConventionController.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using ApiConventions.Models;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Http;
 
 namespace ApiConventions.Controllers
 {
@@ -71,9 +70,6 @@ namespace ApiConventions.Controllers
 
         // DELETE api/contactsconvention/{guid}
         [HttpDelete("{id}")]
-        [ProducesResponseType(StatusCodes.Status204NoContent)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesDefaultResponseType]
         public IActionResult Delete(string id)
         {
             var contact = _contacts.Get(id);


### PR DESCRIPTION
Note: I'm trying to mirror the ToC structure under the **Tutorials** node. We'll have a **Data access** child node once the EF Core Learn module publishes. There will also be a **Web apps** child node when Wade's Razor Pages Learn module publishes.