### PR TITLE
Improve discoverability of secrets management docs

### DIFF
--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -939,9 +939,10 @@
     - name: Secrets management
       items:
         - name: Protect secrets in development
-          displayName: password
+          displayName: password, connection string, API key
           uid: security/app-secrets
         - name: Azure Key Vault Configuration Provider
+          displayName: password, connection string, API key
           uid: security/key-vault-configuration
     - name: Enforce HTTPS
       uid: security/enforcing-ssl

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -936,11 +936,13 @@
               uid: security/data-protection/compatibility/index
             - name: Replace machineKey in ASP.NET
               uid: security/data-protection/compatibility/replacing-machinekey
-    - name: Protect secrets in development
-      displayName: password
-      uid: security/app-secrets
-    - name: Azure Key Vault Configuration Provider
-      uid: security/key-vault-configuration
+    - name: Secrets management
+      items:
+        - name: Protect secrets in development
+          displayName: password
+          uid: security/app-secrets
+        - name: Azure Key Vault Configuration Provider
+          uid: security/key-vault-configuration
     - name: Enforce HTTPS
       uid: security/enforcing-ssl
     - name: EU General Data Protection Regulation (GDPR) support


### PR DESCRIPTION
Moves the Secret Manager and Azure Key Vault config provider docs under a new **Secrets management** ToC node. This change should make it easier to locate those docs.