### PR TITLE
Blazor Preview 4 updates

### DIFF
--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -50,18 +50,24 @@ In a few steps, get started with Blazor:
       ```console
       dotnet new blazor -o WebApplication1
       ```
-
+   
       > [!NOTE]
       > Only Blazor client-side is supported on macOS in ASP.NET Core 3.0 Preview 4. For more information, see [Blazor server side: dotnet run fails with InvalidOperationException on MacOS](https://github.com/aspnet/AspNetCore/issues/9402).
    
+      For an experience with Blazor server-side, execute the following command from a command shell:
+   
+      ```console
+      dotnet new blazorserverside -o WebApplication1
+      ```
+   
    4. Open the *WebApplication1* folder in Visual Studio Code.
-   5. When prompted by Visual Studio Code for a Blazor server-side project, add assets to build and debug the project:
+   5. When prompted by Visual Studio Code for a Blazor server-side project, add assets to build the project:
    
       **Required assets to build and debug are missing from 'WebApplication1'. Add them?**
    
       Select **Yes**.
    
-   6. Execute `dotnet run` from the app's project folder.
+   6. If using a Blazor server-side app, run the app using the Visual Studio Code debugger. If using a Blazor client-side app, execute `dotnet run` from the app's project folder.
    
    <!--
    

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -5,7 +5,7 @@ description: Learn how to get started with Blazor.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/18/2019
+ms.date: 04/19/2019
 uid: blazor/get-started
 ---
 # Get started with Blazor
@@ -27,23 +27,25 @@ In a few steps, get started with Blazor:
    # [Visual Studio](#tab/visual-studio)
    
    1. Install the latest preview of [Visual Studio 2019](https://visualstudio.com/preview) with the **ASP.NET and web development** workload.
-   1. Install the latest [Blazor extension](https://go.microsoft.com/fwlink/?linkid=870389) from the Visual Studio Marketplace. This step makes Blazor templates available to Visual Studio.
-   1. Enable Visual Studio to use preview SDKs:
-      1. Open **Tools** > **Options** in the menu bar.
-      1. Open the **Projects and Solutions** node. Open the **.NET Core** tab.
-      1. Check the box for **Use previews of the .NET Core SDK**. Select **OK**.
-   1. Create a new project.
-   1. Select **ASP.NET Core Web Application**. Select **Next**.
-   1. Provide a name in the **Project name** field. Confirm the **Location** entry is correct or provide a location for the project. Select **Create**.
-   1. Make sure **.NET Core** and **ASP.NET Core 3.0** are selected at the top.
-   1. For an experience with Blazor server-side, choose the **Razor Components** template. The template will be renamed "Blazor (server-side)" in a future preview. For an experience with Blazor client-side, choose the **Blazor** template. Select **Create**.
-   1. Press **F5** to run the app.
+   2. Install the latest [Blazor extension](https://go.microsoft.com/fwlink/?linkid=870389) from the Visual Studio Marketplace. This step makes Blazor templates available to Visual Studio.
+   3. Enable Visual Studio to use preview SDKs:
+   
+      a. Open **Tools** > **Options** in the menu bar.
+      b. Open the **Projects and Solutions** node. Open the **.NET Core** tab.
+      c. Check the box for **Use previews of the .NET Core SDK**. Select **OK**.
+   
+   4. Create a new project.
+   5. Select **ASP.NET Core Web Application**. Select **Next**.
+   6. Provide a name in the **Project name** field. Confirm the **Location** entry is correct or provide a location for the project. Select **Create**.
+   7. Make sure **.NET Core** and **ASP.NET Core 3.0** are selected at the top.
+   8. For an experience with Blazor server-side, choose the **Blazor (server-side)** template. For an experience with Blazor client-side, choose the **Blazor (client-side)** template. Select **Create**.
+   9. Press **F5** to run the app.
    
    # [Visual Studio Code](#tab/visual-studio-code)
    
    1. Install [Visual Studio Code](https://code.visualstudio.com/).
-   1. Install the latest [C# for Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp).
-   1. For an experience with Blazor server-side, execute the following command from a command shell:
+   2. Install the latest [C# for Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp).
+   3. For an experience with Blazor server-side, execute the following command from a command shell:
    
       ```console
       dotnet new blazorserverside -o WebApplication1
@@ -54,34 +56,30 @@ In a few steps, get started with Blazor:
       ```console
       dotnet new blazor -o WebApplication1
       ```
+
+      > [!NOTE]
+      > On macOS, use a Blazor client-side app. For more information, see [Blazor server side: dotnet run fails with InvalidOperationException on MacOS](https://github.com/aspnet/AspNetCore/issues/9402).
    
-   1. Open the *WebApplication1* folder.
-   1. When prompted by Visual Studio Code, add assets to build and debug the project:
+   4. Open the *WebApplication1* folder in Visual Studio Code.
+   5. When prompted by Visual Studio Code for a Blazor server-side project, add assets to build and debug the project:
    
       **Required assets to build and debug are missing from 'WebApplication1'. Add them?**
    
       Select **Yes**.
    
-   1. If using a Blazor server-side app, run the app using the Visual Studio Code debugger. If using a Blazor client-side app, execute `dotnet run` from the app's project folder.
+   6. If using a Blazor server-side app, run the app using the Visual Studio Code debugger. If using a Blazor client-side app, execute `dotnet run` from the app's project folder.
    
    <!--
    
    # [Visual Studio for Mac](#tab/visual-studio-mac)
    
-   .NET Core 3.0 will be supported with Visual Studio for Mac version 8.0 or later. Visual Studio for Mac version 8.0 Preview isn't available at this time.
-   
-   Use the [.NET Core CLI version of this topic](xref:blazor/get-started?tabs=netcore-cli) on macOS.
-   
-   [!INCLUDE[](~/includes/net-core-prereqs-mac-3.0.md)]
-   
-   To create your first project Blazor (server-side) project in Visual Studio for Mac:
-   
-   1. Select **File** > **New Solution** or **New Project**.
-   1. In the sidebar, select **.NET Core** > **App**.
-   1. Select **ASP.NET Core Blazor (server-side)** and select **Next**.
-   1. The **Target Framework** defaults to **.NET Core 3.0**. Select **Next**.
-   1. In the **Project Name** field, enter `WebApplication1`. Select **Create**.
-   1. Select **Run** > **Run Without Debugging** to run the app *without the debugger*. Running with the debugger isn't supported at this time.
+   1. Install [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/). Switch the [Update channel to Preview](/visualstudio/mac/install-preview).
+   2. Select **File** > **New Solution** or **New Project**.
+   3. In the sidebar, select **.NET Core** > **App**.
+   4. For an experience with Blazor server-side, select the **ASP.NET Core Blazor (server-side)** template. For an experience with Blazor server-side, select the **ASP.NET Core Blazor (client-side)** template. Select **Next**.
+   5. The **Target Framework** defaults to **.NET Core 3.0**. Select **Next**.
+   6. In the **Project Name** field, enter `WebApplication1`. Select **Create**.
+   7. Select **Run** > **Run Without Debugging** to run the app *without the debugger*. Running with the debugger isn't supported at this time.
    
    -->
    
@@ -102,7 +100,10 @@ In a few steps, get started with Blazor:
    cd WebApplication1
    dotnet run
    ```
-  
+   
+   > [!NOTE]
+   > On macOS, use a Blazor client-side app. For more information, see [Blazor server side: dotnet run fails with InvalidOperationException on MacOS](https://github.com/aspnet/AspNetCore/issues/9402).
+   
    ---
 
 In a browser, navigate to `https://localhost:5001`.

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -159,3 +159,7 @@ Run the app. The homepage has its own counter that increments by ten each time t
 ## Next steps
 
 <xref:tutorials/first-blazor-app>
+
+## Additional resources
+
+* <xref:signalr/introduction>

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -51,14 +51,14 @@ In a few steps, get started with Blazor:
       dotnet new blazor -o WebApplication1
       ```
 
-      > [!NOTE]
-      > Only Blazor client-side is supported on macOS in ASP.NET Core 3.0 Preview 4. For more information, see [Blazor server side: dotnet run fails with InvalidOperationException on MacOS](https://github.com/aspnet/AspNetCore/issues/9402).
-
       For an experience with Blazor server-side, execute the following command from a command shell:
 
       ```console
       dotnet new blazorserverside -o WebApplication1
       ```
+
+      > [!NOTE]
+      > Only Blazor client-side is supported on macOS in ASP.NET Core 3.0 Preview 4. For more information, see [Blazor server side: dotnet run fails with InvalidOperationException on MacOS](https://github.com/aspnet/AspNetCore/issues/9402).
 
    4. Open the *WebApplication1* folder in Visual Studio Code.
    5. When prompted by Visual Studio Code for a Blazor server-side project, add assets to build the project:
@@ -93,9 +93,6 @@ In a few steps, get started with Blazor:
    dotnet run
    ```
 
-   > [!NOTE]
-   > On macOS, use a Blazor client-side app. Blazor server-side isn't supported for macOS on ASP.NET Core 3.0 Preview 4. For more information, see [Blazor server side: dotnet run fails with InvalidOperationException on MacOS](https://github.com/aspnet/AspNetCore/issues/9402).
-
    For an experience with Blazor server-side, execute the following commands from a command shell:
 
    ```console
@@ -103,6 +100,9 @@ In a few steps, get started with Blazor:
    cd WebApplication1
    dotnet run
    ```
+
+   > [!NOTE]
+   > On macOS, use a Blazor client-side app. Blazor server-side isn't supported for macOS on ASP.NET Core 3.0 Preview 4. For more information, see [Blazor server side: dotnet run fails with InvalidOperationException on MacOS](https://github.com/aspnet/AspNetCore/issues/9402).
 
    ---
 

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -38,7 +38,7 @@ In a few steps, get started with Blazor:
    5. Select **ASP.NET Core Web Application**. Select **Next**.
    6. Provide a name in the **Project name** field. Confirm the **Location** entry is correct or provide a location for the project. Select **Create**.
    7. Make sure **.NET Core** and **ASP.NET Core 3.0** are selected at the top.
-   8. For an experience with Blazor server-side, choose the **Blazor (server-side)** template. For an experience with Blazor client-side, choose the **Blazor (client-side)** template. Select **Create**.
+   8. For an experience with Blazor client-side, choose the **Blazor (client-side)** template. For an experience with Blazor server-side, choose the **Blazor (server-side)** template. Select **Create**.
    9. Press **F5** to run the app.
    
    # [Visual Studio Code](#tab/visual-studio-code)
@@ -61,7 +61,7 @@ In a few steps, get started with Blazor:
    
       Select **Yes**.
    
-   6. If using a Blazor server-side app, run the app using the Visual Studio Code debugger. If using a Blazor client-side app, execute `dotnet run` from the app's project folder.
+   6. Execute `dotnet run` from the app's project folder.
    
    <!--
    
@@ -79,18 +79,18 @@ In a few steps, get started with Blazor:
    
    # [.NET Core CLI](#tab/netcore-cli/)
    
-   For an experience with Blazor server-side, execute the following commands from a command shell:
-   
-   ```console
-   dotnet new blazorserverside -o WebApplication1
-   cd WebApplication1
-   dotnet run
-   ```
-   
    For an experience with Blazor client-side, execute the following commands from a command shell:
    
    ```console
    dotnet new blazor -o WebApplication1
+   cd WebApplication1
+   dotnet run
+   ```
+   
+   For an experience with Blazor server-side, execute the following commands from a command shell:
+   
+   ```console
+   dotnet new blazorserverside -o WebApplication1
    cd WebApplication1
    dotnet run
    ```

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -92,6 +92,9 @@ In a few steps, get started with Blazor:
    cd WebApplication1
    dotnet run
    ```
+
+   > [!NOTE]
+   > On macOS, use a Blazor client-side app. Blazor server-side isn't supported for macOS on ASP.NET Core 3.0 Preview 4. For more information, see [Blazor server side: dotnet run fails with InvalidOperationException on MacOS](https://github.com/aspnet/AspNetCore/issues/9402).
    
    For an experience with Blazor server-side, execute the following commands from a command shell:
    
@@ -100,9 +103,6 @@ In a few steps, get started with Blazor:
    cd WebApplication1
    dotnet run
    ```
-   
-   > [!NOTE]
-   > On macOS, use a Blazor client-side app. For more information, see [Blazor server side: dotnet run fails with InvalidOperationException on MacOS](https://github.com/aspnet/AspNetCore/issues/9402).
    
    ---
 

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -45,20 +45,14 @@ In a few steps, get started with Blazor:
    
    1. Install [Visual Studio Code](https://code.visualstudio.com/).
    2. Install the latest [C# for Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp).
-   3. For an experience with Blazor server-side, execute the following command from a command shell:
-   
-      ```console
-      dotnet new blazorserverside -o WebApplication1
-      ```
-   
-      For an experience with Blazor client-side, execute the following command from a command shell:
+   3. For an experience with Blazor client-side, execute the following command from a command shell:
    
       ```console
       dotnet new blazor -o WebApplication1
       ```
 
       > [!NOTE]
-      > On macOS, use a Blazor client-side app. For more information, see [Blazor server side: dotnet run fails with InvalidOperationException on MacOS](https://github.com/aspnet/AspNetCore/issues/9402).
+      > Only Blazor client-side is supported on macOS in ASP.NET Core 3.0 Preview 4. For more information, see [Blazor server side: dotnet run fails with InvalidOperationException on MacOS](https://github.com/aspnet/AspNetCore/issues/9402).
    
    4. Open the *WebApplication1* folder in Visual Studio Code.
    5. When prompted by Visual Studio Code for a Blazor server-side project, add assets to build and debug the project:

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -25,7 +25,7 @@ In a few steps, get started with Blazor:
 1. Follow the guidance for your choice of tooling:
 
    # [Visual Studio](#tab/visual-studio)
-   
+
    1. Install the latest preview of [Visual Studio 2019](https://visualstudio.com/preview) with the **ASP.NET and web development** workload.
    2. Install the latest [Blazor extension](https://go.microsoft.com/fwlink/?linkid=870389) from the Visual Studio Marketplace. This step makes Blazor templates available to Visual Studio.
    3. Enable Visual Studio to use preview SDKs:
@@ -33,46 +33,46 @@ In a few steps, get started with Blazor:
       a. Open **Tools** > **Options** in the menu bar.
       b. Open the **Projects and Solutions** node. Open the **.NET Core** tab.
       c. Check the box for **Use previews of the .NET Core SDK**. Select **OK**.
-   
+
    4. Create a new project.
    5. Select **ASP.NET Core Web Application**. Select **Next**.
    6. Provide a name in the **Project name** field. Confirm the **Location** entry is correct or provide a location for the project. Select **Create**.
    7. Make sure **.NET Core** and **ASP.NET Core 3.0** are selected at the top.
    8. For an experience with Blazor client-side, choose the **Blazor (client-side)** template. For an experience with Blazor server-side, choose the **Blazor (server-side)** template. Select **Create**.
    9. Press **F5** to run the app.
-   
+
    # [Visual Studio Code](#tab/visual-studio-code)
    
    1. Install [Visual Studio Code](https://code.visualstudio.com/).
    2. Install the latest [C# for Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp).
    3. For an experience with Blazor client-side, execute the following command from a command shell:
-   
+
       ```console
       dotnet new blazor -o WebApplication1
       ```
-   
+
       > [!NOTE]
       > Only Blazor client-side is supported on macOS in ASP.NET Core 3.0 Preview 4. For more information, see [Blazor server side: dotnet run fails with InvalidOperationException on MacOS](https://github.com/aspnet/AspNetCore/issues/9402).
-   
+
       For an experience with Blazor server-side, execute the following command from a command shell:
-   
+
       ```console
       dotnet new blazorserverside -o WebApplication1
       ```
-   
+
    4. Open the *WebApplication1* folder in Visual Studio Code.
    5. When prompted by Visual Studio Code for a Blazor server-side project, add assets to build the project:
-   
+
       **Required assets to build and debug are missing from 'WebApplication1'. Add them?**
-   
+
       Select **Yes**.
-   
+
    6. If using a Blazor server-side app, run the app using the Visual Studio Code debugger. If using a Blazor client-side app, execute `dotnet run` from the app's project folder.
-   
+
    <!--
-   
+
    # [Visual Studio for Mac](#tab/visual-studio-mac)
-   
+
    1. Install [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/). Switch the [Update channel to Preview](/visualstudio/mac/install-preview).
    2. Select **File** > **New Solution** or **New Project**.
    3. In the sidebar, select **.NET Core** > **App**.
@@ -80,13 +80,13 @@ In a few steps, get started with Blazor:
    5. The **Target Framework** defaults to **.NET Core 3.0**. Select **Next**.
    6. In the **Project Name** field, enter `WebApplication1`. Select **Create**.
    7. Select **Run** > **Run Without Debugging** to run the app *without the debugger*. Running with the debugger isn't supported at this time.
-   
+
    -->
-   
+
    # [.NET Core CLI](#tab/netcore-cli/)
-   
+
    For an experience with Blazor client-side, execute the following commands from a command shell:
-   
+
    ```console
    dotnet new blazor -o WebApplication1
    cd WebApplication1
@@ -95,15 +95,15 @@ In a few steps, get started with Blazor:
 
    > [!NOTE]
    > On macOS, use a Blazor client-side app. Blazor server-side isn't supported for macOS on ASP.NET Core 3.0 Preview 4. For more information, see [Blazor server side: dotnet run fails with InvalidOperationException on MacOS](https://github.com/aspnet/AspNetCore/issues/9402).
-   
+
    For an experience with Blazor server-side, execute the following commands from a command shell:
-   
+
    ```console
    dotnet new blazorserverside -o WebApplication1
    cd WebApplication1
    dotnet run
    ```
-   
+
    ---
 
 In a browser, navigate to `https://localhost:5001`.

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -5,7 +5,7 @@ description: Understand client-side and server-side Blazor hosting models.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/18/2019
+ms.date: 04/19/2019
 uid: blazor/hosting-models
 ---
 # Blazor hosting models

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -14,6 +14,36 @@ By [Daniel Roth](https://github.com/danroth27)
 
 Blazor is a web framework designed to run client-side in the browser on a [WebAssembly](http://webassembly.org/)-based .NET runtime (*Blazor client-side*) or server-side in ASP.NET Core (*Blazor server-side*). Regardless of the hosting model, the app and component models *remain the same*.
 
+## Client-side
+
+The principal hosting model for Blazor is running client-side in the browser on WebAssembly. The Blazor app, its dependencies, and the .NET runtime are downloaded to the browser. The app is executed directly on the browser UI thread. UI updates and event handling occur within the same process. The app's assets are deployed as static files to a web server or service capable of serving static content to clients.
+
+![Blazor client-side: The Blazor app runs on a UI thread inside the browser.](hosting-models/_static/client-side.png)
+
+To create a Blazor app using the client-side hosting model, use either of the following templates:
+
+* **Blazor** ([dotnet new blazor](/dotnet/core/tools/dotnet-new)) &ndash; Deployed as a set of static files.
+* **Blazor (ASP.NET Core Hosted)** ([dotnet new blazorhosted](/dotnet/core/tools/dotnet-new)) &ndash; Hosted by an ASP.NET Core server. The ASP.NET Core app serves the Blazor app to clients. The client-side Blazor app can interact with the server over the network using web API calls or [SignalR](xref:signalr/introduction).
+
+The templates include the *blazor.webassembly.js* script that handles:
+
+* Downloading the .NET runtime, the app, and the app's dependencies.
+* Initialization of the runtime to run the app.
+
+The client-side hosting model offers several benefits. Client-side Blazor:
+
+* Has no .NET server-side dependency.
+* Fully leverages client resources and capabilities.
+* Offloads work from the server to the client.
+* Supports offline scenarios.
+
+There are downsides to client-side hosting. Client-side Blazor:
+
+* Restricts the app to the capabilities of the browser.
+* Requires capable client hardware and software (for example, WebAssembly support).
+* Has a larger download size and longer app load time.
+* Has less mature .NET runtime and tooling support (for example, limitations in [.NET Standard](/dotnet/standard/net-standard) support and debugging).
+
 ## Server-side
 
 With the server-side hosting model, the app is executed on the server from within an ASP.NET Core app. UI updates, event handling, and JavaScript calls are handled over a [SignalR](xref:signalr/introduction) connection.
@@ -183,36 +213,6 @@ connection.onclose((error) => {
   document.getElementById("messagesList").appendChild(li);
 })
 ```
-
-## Client-side
-
-The principal hosting model for Blazor is running client-side in the browser on WebAssembly. The Blazor app, its dependencies, and the .NET runtime are downloaded to the browser. The app is executed directly on the browser UI thread. UI updates and event handling occur within the same process. The app's assets are deployed as static files to a web server or service capable of serving static content to clients.
-
-![Blazor client-side: The Blazor app runs on a UI thread inside the browser.](hosting-models/_static/client-side.png)
-
-To create a Blazor app using the client-side hosting model, use either of the following templates:
-
-* **Blazor** ([dotnet new blazor](/dotnet/core/tools/dotnet-new)) &ndash; Deployed as a set of static files.
-* **Blazor (ASP.NET Core Hosted)** ([dotnet new blazorhosted](/dotnet/core/tools/dotnet-new)) &ndash; Hosted by an ASP.NET Core server. The ASP.NET Core app serves the Blazor app to clients. The client-side Blazor app can interact with the server over the network using web API calls or [SignalR](xref:signalr/introduction).
-
-The templates include the *blazor.webassembly.js* script that handles:
-
-* Downloading the .NET runtime, the app, and the app's dependencies.
-* Initialization of the runtime to run the app.
-
-The client-side hosting model offers several benefits. Client-side Blazor:
-
-* Has no .NET server-side dependency.
-* Fully leverages client resources and capabilities.
-* Offloads work from the server to the client.
-* Supports offline scenarios.
-
-There are downsides to client-side hosting. Client-side Blazor:
-
-* Restricts the app to the capabilities of the browser.
-* Requires capable client hardware and software (for example, WebAssembly support).
-* Has a larger download size and longer app load time.
-* Has less mature .NET runtime and tooling support (for example, limitations in [.NET Standard](/dotnet/standard/net-standard) support and debugging).
 
 ## Additional resources
 

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -213,3 +213,7 @@ There are downsides to client-side hosting. Client-side Blazor:
 * Requires capable client hardware and software (for example, WebAssembly support).
 * Has a larger download size and longer app load time.
 * Has less mature .NET runtime and tooling support (for example, limitations in [.NET Standard](/dotnet/standard/net-standard) support and debugging).
+
+## Additional resources
+
+* <xref:signalr/introduction>

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -96,11 +96,7 @@ For example, the following Razor page renders a Counter component with an initia
 
 ### Detect when the app is prerendering
  
-While a Blazor app is prerendering, certain actions, such as calling into JavaScript, aren't possible because a connection with the browser hasn't been established. Components may need to render differently when prerendered.
- 
-To delay JavaScript interop calls until after the connection with the browser is established, you can use the `OnAfterRenderAsync` component lifecycle event. This event is only called after the app is fully rendered and the client connection is established.
- 
-To conditionally render different content based on whether the app is currently being prerendered or not, use the `IsConnected` property on the `IComponentContext` service. `IComponentContext` only returns `true` if there's an active connection to the client.
+[!INCLUDE[](~/includes/blazor-prerendering.md)]
 
 ### Configure the SignalR client for Blazor server-side apps
  

--- a/aspnetcore/blazor/javascript-interop.md
+++ b/aspnetcore/blazor/javascript-interop.md
@@ -24,7 +24,7 @@ For server-side apps:
 
 * Multiple user requests are processed by the server-side app. Don't call `JSRuntime.Current` in a component to invoke JavaScript functions.
 * Inject the `IJSRuntime` abstraction and use the injected object to issue JavaScript interop calls.
-* While a Blazor server-side app is prerendering, calling into JavaScript isn't possible because a connection with the browser hasn't been established. For more information, see the [Detect when a Blazor server-side app is prerendering](#detect-when-a-blazor-server-side-app-is-prerendering) section.
+* While a Blazor app is prerendering, calling into JavaScript isn't possible because a connection with the browser hasn't been established. For more information, see the [Detect when a Blazor app is prerendering](#detect-when-a-blazor-app-is-prerendering) section.
 
 The following example is based on [TextDecoder](https://developer.mozilla.org/docs/Web/API/TextDecoder), an experimental JavaScript-based decoder. The example demonstrates how to invoke a JavaScript function from a C# method. The JavaScript function accepts a byte array from a C# method, decodes the array, and returns the text to the component for display.
 
@@ -181,7 +181,7 @@ The sample app includes a component to demonstrate JavaScript interop. The compo
 1. The `showPrompt` function accepts user input (the user's name), which is HTML-encoded and returned to the component. The component stores the user's name in a local variable, `name`.
 1. The string stored in `name` is incorporated into a welcome message, which is passed to a JavaScript function, `displayWelcome`, which renders the welcome message into a heading tag.
 
-## Detect when a Blazor server-side app is prerendering
+## Detect when a Blazor app is prerendering
  
 [!INCLUDE[](~/includes/blazor-prerendering.md)]
 

--- a/aspnetcore/blazor/javascript-interop.md
+++ b/aspnetcore/blazor/javascript-interop.md
@@ -5,7 +5,7 @@ description: Learn how to invoke JavaScript functions from .NET and .NET methods
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/18/2019
+ms.date: 04/19/2019
 uid: blazor/javascript-interop
 ---
 # Blazor JavaScript interop

--- a/aspnetcore/blazor/javascript-interop.md
+++ b/aspnetcore/blazor/javascript-interop.md
@@ -24,6 +24,7 @@ For server-side apps:
 
 * Multiple user requests are processed by the server-side app. Don't call `JSRuntime.Current` in a component to invoke JavaScript functions.
 * Inject the `IJSRuntime` abstraction and use the injected object to issue JavaScript interop calls.
+* While a Blazor server-side app is prerendering, calling into JavaScript isn't possible because a connection with the browser hasn't been established. For more information, see the [Detect when a Blazor server-side app is prerendering](#detect-when-a-blazor-server-side-app-is-prerendering) section.
 
 The following example is based on [TextDecoder](https://developer.mozilla.org/docs/Web/API/TextDecoder), an experimental JavaScript-based decoder. The example demonstrates how to invoke a JavaScript function from a C# method. The JavaScript function accepts a byte array from a C# method, decodes the array, and returns the text to the component for display.
 
@@ -179,6 +180,10 @@ The sample app includes a component to demonstrate JavaScript interop. The compo
 1. When `TriggerJsPrompt` is executed by selecting the component's **Trigger JavaScript Prompt** button, the JavaScript `showPrompt` function provided in the *wwwroot/exampleJsInterop.js* file is called.
 1. The `showPrompt` function accepts user input (the user's name), which is HTML-encoded and returned to the component. The component stores the user's name in a local variable, `name`.
 1. The string stored in `name` is incorporated into a welcome message, which is passed to a JavaScript function, `displayWelcome`, which renders the welcome message into a heading tag.
+
+## Detect when a Blazor server-side app is prerendering
+ 
+[!INCLUDE[](~/includes/blazor-prerendering.md)]
 
 ## Capture references to elements
 

--- a/aspnetcore/includes/blazor-prerendering.md
+++ b/aspnetcore/includes/blazor-prerendering.md
@@ -3,3 +3,28 @@ While a Blazor server-side app is prerendering, certain actions, such as calling
 To delay JavaScript interop calls until after the connection with the browser is established, you can use the `OnAfterRenderAsync` component lifecycle event. This event is only called after the app is fully rendered and the client connection is established.
 
 To conditionally render different content based on whether the app is currently being prerendered or not, use the `IsConnected` property on the `IComponentContext` service. `IComponentContext` only returns `true` if there's an active connection to the client.
+
+```cshtml
+@page "/isconnected-example"
+@using Microsoft.AspNetCore.Components.Services
+@inject IComponentContext ComponentContext
+
+<h1>IsConnected Example</h1>
+
+<p>
+    Current state:
+    <strong id="connected-state">
+        @(ComponentContext.IsConnected ? "connected" : "not connected")
+    </strong>
+</p>
+
+<p>
+    Clicks:
+    <strong id="count">@count</strong>
+    <button id="increment-count" onclick="@(() => count++)">Click me</button>
+</p>
+
+@functions {
+    private int count;
+}
+```

--- a/aspnetcore/includes/blazor-prerendering.md
+++ b/aspnetcore/includes/blazor-prerendering.md
@@ -1,0 +1,5 @@
+While a Blazor server-side app is prerendering, certain actions, such as calling into JavaScript, aren't possible because a connection with the browser hasn't been established. Components may need to render differently when prerendered.
+
+To delay JavaScript interop calls until after the connection with the browser is established, you can use the `OnAfterRenderAsync` component lifecycle event. This event is only called after the app is fully rendered and the client connection is established.
+
+To conditionally render different content based on whether the app is currently being prerendered or not, use the `IsConnected` property on the `IComponentContext` service. `IComponentContext` only returns `true` if there's an active connection to the client.

--- a/aspnetcore/includes/blazor-prerendering.md
+++ b/aspnetcore/includes/blazor-prerendering.md
@@ -2,7 +2,7 @@ While a Blazor server-side app is prerendering, certain actions, such as calling
 
 To delay JavaScript interop calls until after the connection with the browser is established, you can use the `OnAfterRenderAsync` component lifecycle event. This event is only called after the app is fully rendered and the client connection is established.
 
-To conditionally render different content based on whether the app is currently being prerendered or not, use the `IsConnected` property on the `IComponentContext` service. `IComponentContext` only returns `true` if there's an active connection to the client.
+To conditionally render different content based on whether the app is currently prerendered content, use the `IsConnected` property on the `IComponentContext` service. When running server-side, `IsConnected` only returns `true` if there's an active connection to the client. It always returns `true` when running client-side.
 
 ```cshtml
 @page "/isconnected-example"

--- a/aspnetcore/includes/blazor-prerendering.md
+++ b/aspnetcore/includes/blazor-prerendering.md
@@ -2,7 +2,7 @@ While a Blazor server-side app is prerendering, certain actions, such as calling
 
 To delay JavaScript interop calls until after the connection with the browser is established, you can use the `OnAfterRenderAsync` component lifecycle event. This event is only called after the app is fully rendered and the client connection is established.
 
-To conditionally render different content based on whether the app is currently prerendered content, use the `IsConnected` property on the `IComponentContext` service. When running server-side, `IsConnected` only returns `true` if there's an active connection to the client. It always returns `true` when running client-side.
+To conditionally render different content based on whether the app is currently prerendering content, use the `IsConnected` property on the `IComponentContext` service. When running server-side, `IsConnected` only returns `true` if there's an active connection to the client. It always returns `true` when running client-side.
 
 ```cshtml
 @page "/isconnected-example"


### PR DESCRIPTION
Fixes #12044 
Fixes #12056
Fixes #12057 
Fixes #11795

[Internal Review Topic (Get Started)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/get-started?view=aspnetcore-3.0&branch=pr-en-us-12061)

This isn't meant to address the whole topic reviews for Pre4 that I'll perform next week on https://github.com/aspnet/AspNetCore.Docs/issues/10717. Hitting quick fixes here for Pre4.

* Updating VS tab template names: In my VS (and I'm not even on preview; I'm on 16.0.2), the template names are correct in the UI ["Blazor (server-side)" and "Blazor (client-side)"]. Let me know if the template names are only wrong in the VS preview (which I don't have installed); if so, I'll make a further update here to cover that.

  ![Capture](https://user-images.githubusercontent.com/1622880/56427586-0fb06600-6282-11e9-9503-11e84a645c81.PNG)

* macOS users should only use Blazor client-side at the moment. Adding a temporary NOTE to steer folks that way until the fix on https://github.com/aspnet/AspNetCore/issues/9402 goes live.

* Surface the prerendering note as an INCLUDE in the *Hosting Models* topic (we only have this content here at the moment) and the *JavaScript interop* topic.

* Also working with the ordered lists in the *Get Started* topic: Due to indentation of the tab control on a numbered step, which is what I want, it's currently giving us letters for the list marker types. *NO!* I'm trying explicit numbers in MD to see if I can bend it to my wishes. If not, I'll resort to a **bigger :hammer:** and try `<ol type="1">`.
