### PR TITLE
Fix typo in Blazor Layouts code example

### DIFF
--- a/aspnetcore/blazor/layouts.md
+++ b/aspnetcore/blazor/layouts.md
@@ -50,7 +50,7 @@ For example, the following *_Imports.razor* file imports:
  
 ```cshtml
 @layout MainLayout
-@using Microsoft.AspNetCore.Components.
+@using Microsoft.AspNetCore.Components
 @using BlazorApp1.Data
 ```
 


### PR DESCRIPTION
Fixes #12085

There's a stray period in an `@using` statement that was copied over from the [blog post: \_Imports.razor section](https://devblogs.microsoft.com/aspnet/asp-net-core-updates-in-net-core-3-0-preview-4/).