### PR TITLE
Update the App implicit version guidance for 2.2

### DIFF
--- a/aspnetcore/fundamentals/metapackage-app.md
+++ b/aspnetcore/fundamentals/metapackage-app.md
@@ -1,5 +1,5 @@
 ---
-title: Microsoft.AspNetCore.App metapackage for ASP.NET Core 2.1 and later
+title: Microsoft.AspNetCore.App metapackage for ASP.NET Core 2.1 or later
 author: Rick-Anderson
 description: The Microsoft.AspNetCore.App metapackage includes all supported ASP.NET Core and Entity Framework Core packages.
 monikerRange: '>= aspnetcore-2.1'
@@ -7,9 +7,9 @@ ms.author: riande
 ms.date: 04/21/2019
 uid: fundamentals/metapackage-app
 ---
-# Microsoft.AspNetCore.App metapackage for ASP.NET Core 2.1
+# Microsoft.AspNetCore.App metapackage for ASP.NET Core 2.1 or later
 
-This feature requires ASP.NET Core 2.1 and later targeting .NET Core 2.1 and later.
+This feature requires ASP.NET Core 2.1 or later targeting .NET Core 2.1 or later.
 
 The [Microsoft.AspNetCore.App](https://www.nuget.org/packages/Microsoft.AspNetCore.App) [metapackage](/dotnet/core/packages#metapackages) for ASP.NET Core:
 

--- a/aspnetcore/fundamentals/metapackage-app.md
+++ b/aspnetcore/fundamentals/metapackage-app.md
@@ -4,7 +4,7 @@ author: Rick-Anderson
 description: The Microsoft.AspNetCore.App metapackage includes all supported ASP.NET Core and Entity Framework Core packages.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
-ms.date: 09/20/2017
+ms.date: 04/21/2019
 uid: fundamentals/metapackage-app
 ---
 # Microsoft.AspNetCore.App metapackage for ASP.NET Core 2.1
@@ -51,12 +51,17 @@ The implicit version is set to `major.minor.0` for portable apps. The shared fra
 
 Specifying a version number on the `Microsoft.AspNetCore.App` reference does **not** guarantee that version of the shared framework will be chosen. For example, suppose version "2.1.1" is specified, but "2.1.3" is installed. In that case, the app will use "2.1.3". Although not recommended, you can disable roll forward (patch and/or minor). For more information regarding dotnet host roll-forward and how to configure its behavior, see [dotnet host roll forward](https://github.com/dotnet/core-setup/blob/master/Documentation/design-docs/roll-forward-on-no-candidate-fx.md).
 
-`<Project Sdk` must be set to `Microsoft.NET.Sdk.Web` to use the implicit version `Microsoft.AspNetCore.App`.  When `<Project Sdk="Microsoft.NET.Sdk">` (without the trailing `.Web`) is used:
+::: moniker range="= aspnetcore-2.1"
+
+`<Project Sdk` must be set to `Microsoft.NET.Sdk.Web` to use the implicit version `Microsoft.AspNetCore.App`. When `<Project Sdk="Microsoft.NET.Sdk">` (without the trailing `.Web`) is used:
 
 * The following warning is generated:
 
-     *Warning NU1604: Project dependency Microsoft.AspNetCore.App does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.*
-* This is a known issue with the .NET Core 2.1 SDK and will be fixed in the .NET Core 2.2 SDK.
+  *Warning NU1604: Project dependency Microsoft.AspNetCore.App does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.*
+
+* This is a known issue with the .NET Core 2.1 SDK.
+
+::: moniker-end
 
 <a name="update"></a>
 


### PR DESCRIPTION
Fixes #12094

We can accomplish this by merely boxing the current content for 2.1.