### PR TITLE
Blazor class libraries topic updates

### DIFF
--- a/aspnetcore/blazor/class-libraries.md
+++ b/aspnetcore/blazor/class-libraries.md
@@ -5,7 +5,7 @@ description: Discover how components can be included in Blazor apps from an exte
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/23/2019
+ms.date: 04/26/2019
 uid: blazor/class-libraries
 ---
 # Razor components class libraries
@@ -24,11 +24,9 @@ Just as components are regular .NET types, components provided by Razor class li
 
 # [Visual Studio](#tab/visual-studio)
 
-To create a Razor class library in Visual Studio:
-
 1. Create a new project.
 1. Select **ASP.NET Core Web Application**. Select **Next**.
-1. Provide a project name in the **Project name** field or accept the default project name. The examples in this topic use the project name `MyComponentLib1`. Confirm the **Location** entry is correct or provide a location for the project. Select **Create**.
+1. Provide a project name in the **Project name** field or accept the default project name. The examples in this topic use the project name `MyComponentLib1`. Select **Create**.
 1. In the **Create a new ASP.NET Core Web Application** dialog, confirm that **.NET Core** and **ASP.NET Core 3.0** are selected.
 1. Select the **Razor Class Library** template. Select **Create**.
 1. Add the Razor class library to a solution:

--- a/aspnetcore/blazor/class-libraries.md
+++ b/aspnetcore/blazor/class-libraries.md
@@ -5,7 +5,7 @@ description: Discover how components can be included in Blazor apps from an exte
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/15/2019
+ms.date: 04/23/2019
 uid: blazor/class-libraries
 ---
 # Razor components class libraries
@@ -20,45 +20,72 @@ Components can be shared in Razor class libraries across projects. Components ca
 
 Just as components are regular .NET types, components provided by Razor class libraries are normal .NET assemblies.
 
-Use the `razorclasslib` (Razor class library) template with the [dotnet new](/dotnet/core/tools/dotnet-new) command:
-
-```console
-dotnet new razorclasslib -o MyComponentLib1
-```
-
-Add Razor component files (*.razor*) to the Razor class library.
-
-To add the library to an existing project, use the [dotnet sln](/dotnet/core/tools/dotnet-sln) command:
+## Create a Razor class library
 
 # [Visual Studio](#tab/visual-studio)
 
-```console
-dotnet sln add .\MyComponentLib1
-```
+To create a Razor class library in Visual Studio:
 
-# [.NET Core CLI](#tab/netcore-cli)
+1. Create a new project.
+1. Select **ASP.NET Core Web Application**. Select **Next**.
+1. Provide a project name in the **Project name** field or accept the default project name. The examples in this topic use the project name `MyComponentLib1`. Confirm the **Location** entry is correct or provide a location for the project. Select **Create**.
+1. In the **Create a new ASP.NET Core Web Application** dialog, confirm that **.NET Core** and **ASP.NET Core 3.0** are selected.
+1. Select the **Razor Class Library** template. Select **Create**.
+1. Add the Razor class library to a solution:
+   1. Right-click the solution. Select **Add** > **Existing Project**.
+   1. Navigate to the Razor class library's project file.
+   1. Select the Razor class library's project file (*.csproj*).
+1. Add a reference the Razor class library from the app:
+   1. Right-click the app project. Select **Add** > **Reference**.
+   1. Select the Razor class library project. Select **OK**.
 
-```console
-dotnet add WebApplication1 reference MyComponentLib1
-```
+# [Visual Studio Code / .NET Core CLI](#tab/visual-studio-code+netcore-cli)
+
+1. Use the Razor class library (`razorclasslib`) template with the [dotnet new](/dotnet/core/tools/dotnet-new) command from a command shell. In the following example, a Razor class library is created named `MyComponentLib1`. The folder that holds `MyComponentLib1` is created automatically when the command is executed.
+
+   ```console
+   dotnet new razorclasslib -o MyComponentLib1
+   ```
+
+1. To add the library to an existing project, use the [dotnet add reference](/dotnet/core/tools/dotnet-add-reference) command from a command shell. In the following example, the Razor class library is added to the app. Execute the following command from the app's project folder with the path to the library:
+
+   ```console
+   dotnet add reference {PATH TO LIBRARY}
+   ```
 
 ---
 
+Add Razor component files (*.razor*) to the Razor class library.
+
+## Razor class libraries not supported for client-side apps
+
+In Preview 4, Razor class libraries aren't compatible with Blazor client-side apps.
+
+For Blazor client-side apps, use a Blazor component library created by the `blazorlib` template from a command shell:
+
+```console
+dotnet new blazorlib -o MyComponentLib1
+```
+
+Component libraries using the `blazorlib` template can include static files, such as images, JavaScript, and stylesheets. At build time, static files are embedded into the built assembly file (*.dll*), which allows consumption of the components without having to worry about how to include their resources. Any files included in the `content` directory are marked as an embedded resource.
+
+## Static assets not supported for server-side apps
+
+In Preview 4, Blazor server-side apps can't consume static assets from either a Razor class library (`razorclasslib`) or a Blazor library (`blazorlib`).
+
+As a temporary workaround, you can try [BlazorEmbedLibrary](https://www.nuget.org/packages/BlazorEmbedLibrary/).
+
 > [!NOTE]
-> Razor class libraries aren't compatible with Blazor apps in ASP.NET Core Preview 4.
->
-> To create components in a library that can be shared with Blazor client-side and Razor components server-side apps, use a Blazor class library created by the `blazorlib` template.
->
-> Razor class libraries don't support static assets in ASP.NET Core Preview 4. Component libraries using the `blazorlib` template can include static files, such as images, JavaScript, and stylesheets. At build time, static files are embedded into the built assembly file (*.dll*), which allows consumption of the components without having to worry about how to include their resources. Any files included in the `content` directory are marked as an embedded resource.
+> [BlazorEmbedLibrary](https://www.nuget.org/packages/BlazorEmbedLibrary/) isn't maintained or supported by Microsoft.
 
 ## Consume a library component
 
 In order to consume components defined in a library in another project, use either of the following approaches:
 
-* Full type name with the namespace.
-* Razor's [\@using](xref:mvc/views/razor#using) directive. Individual components may be added by name.
+* Use the full type name with the namespace.
+* Use Razor's [\@using](xref:mvc/views/razor#using) directive. Individual components can be added by name.
 
-In the following examples, `MyComponentLibrary` is a component library containing the Sales Report (`SalesReport`) component.
+In the following examples, `MyComponentLib1` is a component library containing a Sales Report (`SalesReport`) component.
 
 The Sales Report component can be referenced using its full type name with namespace:
 
@@ -67,13 +94,13 @@ The Sales Report component can be referenced using its full type name with names
 
 Welcome to your new app.
 
-<MyComponentLibrary.SalesReport />
+<MyComponentLib1.SalesReport />
 ```
 
 The component can also be referenced if the library is brought into scope with an `@using` directive:
 
 ```cshtml
-@using MyComponentLibrary
+@using MyComponentLib1
 
 <h1>Hello, world!</h1>
 
@@ -82,20 +109,20 @@ Welcome to your new app.
 <SalesReport />
 ```
 
-The `@using` directive can be included in *_Import.razor* to make the components available for an entire project or applied to a single page or set of pages within a folder.
+Include the `@using MyComponentLib1` directive in the top-level *_Import.razor* file to make the library's components available to an entire project. Add the directive to an *_Import.razor* file at any level to apply the namespace to a single page or set of pages within a folder.
 
 ## Build, pack, and ship to NuGet
 
-Because component libraries are standard .NET libraries, packaging and shipping them to NuGet is no different from packaging and shipping any library to NuGet. Packaging is performed using the [dotnet pack](/dotnet/core/tools/dotnet-pack) command:
+Because component libraries are standard .NET libraries, packaging and shipping them to NuGet is no different from packaging and shipping any library to NuGet. Packaging is performed using the [dotnet pack](/dotnet/core/tools/dotnet-pack) command from a command shell:
 
 ```console
 dotnet pack
 ```
 
-Upload the package to NuGet using the [dotnet nuget publish](/dotnet/core/tools/dotnet-nuget-push) command:
+Upload the package to NuGet using the [dotnet nuget publish](/dotnet/core/tools/dotnet-nuget-push) command from a command shell:
 
 ```console
 dotnet nuget publish
 ```
 
-When using the `blazorlib` template, static resources are included in the NuGet package. Library consumers automatically receive scripts and stylesheets, so consumers aren't required to manually install the resources.
+When using the `blazorlib` template, static resources are included in the NuGet package. Library consumers automatically receive scripts and stylesheets, so consumers aren't required to manually install the resources. Note that [static assets aren't supported for server-side apps](#static-assets-not-supported-for-server-side-apps), including when a Blazor library (`blazorlib`) is referenced by a server-side app.


### PR DESCRIPTION
Addresses #10717 
Fixes #12117 

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/class-libraries?view=aspnetcore-3.0&branch=pr-en-us-12132)

* Overhaul the instructions for set up, including clear VS instructions.
* Enhanced coverage:
  * Razor class library and client-side scenario
  * Static assets and server-side scenario 
    **NOTE**: Do you want to pitch [BlazorEmbedLibrary](https://www.nuget.org/packages/BlazorEmbedLibrary/) as a temp workaround with a support warning? If not, is there any workaround that can be pitched until Preview 7?
* The usual style+grammar pass.
* **QUESTION**: We say static resources are "embedded into the built assembly file," but stylesheets end up in the *_content* folder and referenced from there by *index.html*, so that doesn't seem fully accurate. How should this be addressed?

cc: @4deeptech :rocket: