### PR TITLE
removed old xamarin warning

### DIFF
--- a/aspnetcore/signalr/dotnet-client.md
+++ b/aspnetcore/signalr/dotnet-client.md
@@ -13,9 +13,6 @@ uid: signalr/dotnet-client
 
 The ASP.NET Core SignalR .NET client library lets you communicate with SignalR hubs from .NET apps.
 
-> [!NOTE]
-> Xamarin has special requirements for Visual Studio version. For more information, see [SignalR Client 2.1.1 in Xamarin](https://github.com/aspnet/Announcements/issues/305).
-
 [View or download sample code](https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/signalr/dotnet-client/sample) ([how to download](xref:index#how-to-download-a-sample))
 
 The code sample in this article is a WPF app that uses the ASP.NET Core SignalR .NET client.


### PR DESCRIPTION
This warning is out-of-date and needed removal. 