### PR TITLE
C80832: Adding two spaces at the end of a line

### DIFF
--- a/aspnetcore/mvc/views/tag-helpers/authoring.md
+++ b/aspnetcore/mvc/views/tag-helpers/authoring.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn how to author Tag Helpers in ASP.NET Core.
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/12/2019
+ms.date: 04/29/2019
 uid: mvc/views/tag-helpers/authoring
 ---
 # Author Tag Helpers in ASP.NET Core
@@ -102,7 +102,8 @@ Update the `EmailTagHelper` class with the following:
 
 That approach works for the attribute "href" as long as it doesn't currently exist in the attributes collection. You can also use the `output.Attributes.Add` method to add a tag helper attribute to the end of the collection of tag attributes.
 
-1. Update the markup in the *Views/Home/Contact.cshtml* file with these changes:  
+1. Update the markup in the *Views/Home/Contact.cshtml* file with these changes:
+
    [!code-html[](../../../mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/Views/Home/ContactCopy.cshtml?highlight=15,16)]
 
 1. Run the app and verify that it generates the correct links.

--- a/aspnetcore/mvc/views/tag-helpers/authoring.md
+++ b/aspnetcore/mvc/views/tag-helpers/authoring.md
@@ -102,7 +102,7 @@ Update the `EmailTagHelper` class with the following:
 
 That approach works for the attribute "href" as long as it doesn't currently exist in the attributes collection. You can also use the `output.Attributes.Add` method to add a tag helper attribute to the end of the collection of tag attributes.
 
-1. Update the markup in the *Views/Home/Contact.cshtml* file with these changes:
+1. Update the markup in the *Views/Home/Contact.cshtml* file with these changes:  
    [!code-html[](../../../mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/Views/Home/ContactCopy.cshtml?highlight=15,16)]
 
 1. Run the app and verify that it generates the correct links.


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
Description: missing spaces are breaking formatting on loc pages
@guardrex



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->