### PR TITLE
Should import the namespace first

### DIFF
--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -69,6 +69,10 @@ dotnet add TodoApi.csproj package Swashbuckle.AspNetCore
 
 ## Add and configure Swagger middleware
 
+Import the following namespace to use the `Info` class:
+
+[!code-csharp[](../tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup2.cs?name=snippet_InfoClassNamespace)]
+
 Add the Swagger generator to the services collection in the `Startup.ConfigureServices` method:
 
 ::: moniker range="<= aspnetcore-2.0"
@@ -82,10 +86,6 @@ Add the Swagger generator to the services collection in the `Startup.ConfigureSe
 [!code-csharp[](../tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.Swashbuckle/Startup2.cs?name=snippet_ConfigureServices&highlight=9-12)]
 
 ::: moniker-end
-
-Import the following namespace to use the `Info` class:
-
-[!code-csharp[](../tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup2.cs?name=snippet_InfoClassNamespace)]
 
 In the `Startup.Configure` method, enable the middleware for serving the generated JSON document and the Swagger UI:
 


### PR DESCRIPTION
You should import the Swashbuckle.AspNetCore.Swagger namespace _before_ adding the Swagger generator to the services collection or you get a red squiggly.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->