### PR TITLE
Fix language specification in one code sample

### DIFF
--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -343,7 +343,7 @@ When the button is selected in the Child component:
 
 `EventCallback` and `EventCallback<T>` permit asynchronous delegates. `EventCallback<T>` is strongly typed and requires a specific argument type. `EventCallback` is weakly typed and allows any argument type.
 
-```chstml
+```cshtml
 <p><b>@messageText</b></p>
 
 @{ var message = "Default Text"; }


### PR DESCRIPTION
There was a typo "chstml" instead of "cshtml" that caused the code section to not do proper syntax coloring



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->