### PR TITLE
v3 preview 4 update to core vs 4.x compare

### DIFF
--- a/aspnetcore/fundamentals/choose-aspnet-framework.md
+++ b/aspnetcore/fundamentals/choose-aspnet-framework.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Explains ASP.NET Core vs. ASP.NET 4.x and how to choose between them.
 ms.author: riande
 ms.custom: "mvc, seodec18"
-ms.date: 09/11/2018
+ms.date: 05/02/2019
 uid: fundamentals/choose-between-aspnet-and-aspnetcore
 ---
 # Choose between ASP.NET 4.x and ASP.NET Core
@@ -38,7 +38,6 @@ See [ASP.NET Core targeting .NET Framework](xref:index#target-framework) for inf
 
 ## ASP.NET Core scenarios
 
-* [Razor Pages](xref:razor-pages/index) is the recommended approach to create a Web UI as of ASP.NET Core 2.x.
 * [Websites](xref:tutorials/first-mvc-app/index)
 * [APIs](xref:tutorials/first-web-api)
 * [Real-time](xref:signalr/index)

--- a/aspnetcore/includes/benefits.md
+++ b/aspnetcore/includes/benefits.md
@@ -3,6 +3,7 @@ ASP.NET Core provides the following benefits:
 * A unified story for building web UI and web APIs.
 * Architected for testability.
 * [Razor Pages](xref:razor-pages/index) makes coding page-focused scenarios easier and more productive.
+* [Blazor](xref:blazor/index)lets you use C# in the browser alongside JavaScript. Share server-side and client-side app logic all written with .NET. 
 * Ability to develop and run on Windows, macOS, and Linux.
 * Open-source and [community-focused](https://live.asp.net/).
 * Integration of [modern, client-side frameworks](xref:blazor/index) and development workflows.

--- a/aspnetcore/includes/benefits.md
+++ b/aspnetcore/includes/benefits.md
@@ -3,7 +3,7 @@ ASP.NET Core provides the following benefits:
 * A unified story for building web UI and web APIs.
 * Architected for testability.
 * [Razor Pages](xref:razor-pages/index) makes coding page-focused scenarios easier and more productive.
-* [Blazor](xref:blazor/index)lets you use C# in the browser alongside JavaScript. Share server-side and client-side app logic all written with .NET. 
+* [Blazor](xref:blazor/index) lets you use C# in the browser alongside JavaScript. Share server-side and client-side app logic all written with .NET. 
 * Ability to develop and run on Windows, macOS, and Linux.
 * Open-source and [community-focused](https://live.asp.net/).
 * Integration of [modern, client-side frameworks](xref:blazor/index) and development workflows.


### PR DESCRIPTION
Updated this comparison doc to account for ASP.NET Core 3.0 Preview 4.    The compare doc uses an include called benefits.md which was also updated.  Minor updates overall.

Current published version of this doc:
https://docs.microsoft.com/en-us/aspnet/core/fundamentals/choose-aspnet-framework?view=aspnetcore-3.0