### PR TITLE
Disable markdownlint rule

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -44,7 +44,7 @@
     "no-space-in-code": true,
     "no-space-in-emphasis": true,
     "no-space-in-links": true,
-    "no-trailing-punctuation": true,
+    "no-trailing-punctuation": false,
     "no-trailing-spaces": false,
     "ol-prefix": {
         "style": "one_or_ordered"

--- a/aspnetcore/index.md
+++ b/aspnetcore/index.md
@@ -18,7 +18,7 @@ ASP.NET Core is a cross-platform, high-performance, [open-source](https://github
 * Deploy to the cloud or on-premises.
 * Run on [.NET Core or .NET Framework](/dotnet/articles/standard/choosing-core-framework-server).
 
-## Why to use ASP.NET Core
+## Why choose ASP.NET Core?
 
 Millions of developers have used (and continue to use) [ASP.NET 4.x](/aspnet/overview) to create web apps. ASP.NET Core is a redesign of ASP.NET 4.x, with architectural changes that result in a leaner, more modular framework.
 


### PR DESCRIPTION
Leaving this PR to merge to master to avoid picking up extraneous commits, can wait until 5/6 to merge.

A heading was changed to satisfy a Markdownlint rule.  The rule disallows "trailing punctuation" including question marks in headings, but headings are sometimes appropriately phrased as questions, and question marks are appropriate in such cases.

This PR 
* Disables the rule
* Restores the heading to what it was previously but changes "use" to "choose"
