### PR TITLE
Use correct gRPC client project name

### DIFF
--- a/aspnetcore/tutorials/grpc/grpc-client.md
+++ b/aspnetcore/tutorials/grpc/grpc-client.md
@@ -83,7 +83,7 @@ Packages can be added with the following approaches:
 Run the following command from the **Integrated Terminal**:
 
 ```console
-dotnet add TodoApi.csproj package Grpc.Core
+dotnet add GrpcGreeterClient.csproj package Grpc.Core
 ```
 
 Repeat for Google.Protobuf and Grpc.Tools


### PR DESCRIPTION
When adding gRPC packages the project to add them to should be GrpcGreeterClient.csproj.