### PR TITLE
Update debug.md

### DIFF
--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -39,7 +39,7 @@ To debug a client-side Blazor app in Chrome:
 * Build a Blazor app in `Debug` configuration (the default for unpublished apps).
 * Run the Blazor app in Chrome (version 70 or later).
 * With the keyboard focus on the app (not in the developer tools panel, which you should probably close for a less confusing debugging experience), select the following Blazor-specific keyboard shortcut:
-  * `Shift+Alt+D` on Windows/Linux
+  * `Shift+Windows key+D` on Windows/Linux
   * `Shift+Cmd+D` on macOS
 
 ## Enable remote debugging


### PR DESCRIPTION
In my case the shortcut Shift+Alt+D does not work. I am using Chrome Version 74.0.3729.131 (Official Build) (64-bit). Maybe the shortcut changed?



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->