### PR TITLE
Fix logging code example

### DIFF
--- a/aspnetcore/host-and-deploy/proxy-load-balancer.md
+++ b/aspnetcore/host-and-deploy/proxy-load-balancer.md
@@ -4,7 +4,7 @@ author: guardrex
 description: Learn about configuration for apps hosted behind proxy servers and load balancers, which often obscure important request information.
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/06/2018
+ms.date: 05/08/2019
 uid: host-and-deploy/proxy-load-balancer
 ---
 # Configure ASP.NET Core to work with proxy servers and load balancers
@@ -243,9 +243,9 @@ services.Configure<ForwardedHeadersOptions>(options =>
 
 ## Troubleshoot
 
-When headers aren't forwarded as expected, enable [logging](xref:fundamentals/logging/index). If the logs don't provide sufficient information to troubleshoot the problem, enumerate the request headers received by the server. Use inline middleware to write request headers to an app response or log the headers. Place either of the following code examples immediately after the call to <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersExtensions.UseForwardedHeaders*> in `Startup.Configure`.
+When headers aren't forwarded as expected, enable [logging](xref:fundamentals/logging/index). If the logs don't provide sufficient information to troubleshoot the problem, enumerate the request headers received by the server. Use inline middleware to write request headers to an app response or log the headers. 
 
-To write the headers to the app's response, use the following terminal inline middleware:
+To write the headers to the app's response, place the following terminal inline middleware immediately after the call to <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersExtensions.UseForwardedHeaders*> in `Startup.Configure`:
 
 ```csharp
 app.Run(async (context) =>
@@ -277,10 +277,12 @@ app.Run(async (context) =>
 });
 ```
 
-You can write to logs instead of the response body. Writing to logs allows the site to function normally while debugging. To write logs rather than the response body:
+You can write to logs instead of the response body. Writing to logs allows the site to function normally while debugging.
 
-* *Inject `ILogger<Startup>` into the `Startup` class as described in [Create logs in Startup](xref:fundamentals/logging/index#create-logs-in-startup).
-* Place this middleware immediately after the call to <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersExtensions.UseForwardedHeaders*>:
+To write logs rather than to the response body:
+
+* Inject `ILogger<Startup>` into the `Startup` class as described in [Create logs in Startup](xref:fundamentals/logging/index#create-logs-in-startup).
+* Place the following inline middleware immediately after the call to <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersExtensions.UseForwardedHeaders*> in `Startup.Configure`.
 
 ```csharp
 app.Use(async (context, next) =>

--- a/aspnetcore/host-and-deploy/proxy-load-balancer.md
+++ b/aspnetcore/host-and-deploy/proxy-load-balancer.md
@@ -277,9 +277,10 @@ app.Run(async (context) =>
 });
 ```
 
-You can also write to logs instead of the response body. This allows the site to function normally while debugging.
+You can write to logs instead of the response body. Writing to logs allows the site to function normally while debugging. To write logs rather than the response body:
 
-First, inject an `ILogger<Startup>` into the `Startup` class as described in [Create logs in Startup](xref:fundamentals/logging/index#create-logs-in-startup). Then, place this middleware immediately after the call to <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersExtensions.UseForwardedHeaders*>:
+* *Inject `ILogger<Startup>` into the `Startup` class as described in [Create logs in Startup](xref:fundamentals/logging/index#create-logs-in-startup).
+* Place this middleware immediately after the call to <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersExtensions.UseForwardedHeaders*>:
 
 ```csharp
 app.Use(async (context, next) =>

--- a/aspnetcore/host-and-deploy/proxy-load-balancer.md
+++ b/aspnetcore/host-and-deploy/proxy-load-balancer.md
@@ -277,26 +277,26 @@ app.Run(async (context) =>
 });
 ```
 
-You can also write to logs instead of the response body by using the following inline middleware. This allows the site to function normally while debugging.
+You can also write to logs instead of the response body. This allows the site to function normally while debugging.
+
+First, inject an `ILogger<Startup>` into the `Startup` class as described in [Create logs in Startup](xref:/fundamentals/logging/index#create-logs-in-startup). Then, place this middleware immediately after the call to <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersExtensions.UseForwardedHeaders*>:
 
 ```csharp
-var logger = _loggerFactory.CreateLogger<Startup>();
-
 app.Use(async (context, next) =>
 {
     // Request method, scheme, and path
-    logger.LogDebug("Request Method: {METHOD}", context.Request.Method);
-    logger.LogDebug("Request Scheme: {SCHEME}", context.Request.Scheme);
-    logger.LogDebug("Request Path: {PATH}", context.Request.Path);
+    _logger.LogDebug("Request Method: {METHOD}", context.Request.Method);
+    _logger.LogDebug("Request Scheme: {SCHEME}", context.Request.Scheme);
+    _logger.LogDebug("Request Path: {PATH}", context.Request.Path);
 
     // Headers
     foreach (var header in context.Request.Headers)
     {
-        logger.LogDebug("Header: {KEY}: {VALUE}", header.Key, header.Value);
+        _logger.LogDebug("Header: {KEY}: {VALUE}", header.Key, header.Value);
     }
 
     // Connection: RemoteIp
-    logger.LogDebug("Request RemoteIp: {REMOTE_IP_ADDRESS}", 
+    _logger.LogDebug("Request RemoteIp: {REMOTE_IP_ADDRESS}", 
         context.Connection.RemoteIpAddress);
 
     await next();

--- a/aspnetcore/host-and-deploy/proxy-load-balancer.md
+++ b/aspnetcore/host-and-deploy/proxy-load-balancer.md
@@ -279,7 +279,7 @@ app.Run(async (context) =>
 
 You can also write to logs instead of the response body. This allows the site to function normally while debugging.
 
-First, inject an `ILogger<Startup>` into the `Startup` class as described in [Create logs in Startup](xref:/fundamentals/logging/index#create-logs-in-startup). Then, place this middleware immediately after the call to <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersExtensions.UseForwardedHeaders*>:
+First, inject an `ILogger<Startup>` into the `Startup` class as described in [Create logs in Startup](xref:fundamentals/logging/index#create-logs-in-startup). Then, place this middleware immediately after the call to <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersExtensions.UseForwardedHeaders*>:
 
 ```csharp
 app.Use(async (context, next) =>


### PR DESCRIPTION
The [proxies and load balancers](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/proxy-load-balancer?view=aspnetcore-2.2) document had a code example that didn't line up with the [logging pattern](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/index?view=aspnetcore-2.2) in ASP.NET Core 2.2. This PR updates the code example and instructions.