### PR TITLE
Adds a simpler example for view-injection

### DIFF
--- a/aspnetcore/mvc/views/dependency-injection.md
+++ b/aspnetcore/mvc/views/dependency-injection.md
@@ -14,14 +14,39 @@ ASP.NET Core supports [dependency injection](xref:fundamentals/dependency-inject
 
 [View or download sample code](https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/mvc/views/dependency-injection/sample) ([how to download](xref:index#how-to-download-a-sample))
 
-## A Simple Example
+## Configuration injection
 
-You can inject a service into a view using the `@inject` directive. You can think of `@inject` as adding a property to your view, and populating the property using DI.
+You can inject values from `appsettings.json` directly into a view.
+
+Example of an `appsettings.json` file:
+
+```json
+{
+   "root": {
+      "parent": {
+         "child": "myvalue"
+      }
+   }
+}
+```
 
 The syntax for `@inject`:
    `@inject <type> <name>`
 
 An example of `@inject` in action:
+
+```csharp
+@using Microsoft.Extensions.Configuration
+@inject IConfiguration Configuration
+@{
+   string myValue = Configuration["root:parent:child"];
+   ...
+}
+```
+
+## Service injection
+
+You can inject a service into a view using the `@inject` directive. You can think of `@inject` as adding a property to your view, and populating the property using DI.
 
 [!code-csharp[](../../mvc/views/dependency-injection/sample/src/ViewInjectSample/Views/ToDo/Index.cshtml?highlight=4,5,15,16,17)]
 

--- a/aspnetcore/mvc/views/dependency-injection.md
+++ b/aspnetcore/mvc/views/dependency-injection.md
@@ -16,9 +16,9 @@ ASP.NET Core supports [dependency injection](xref:fundamentals/dependency-inject
 
 ## Configuration injection
 
-You can inject values from `appsettings.json` directly into a view.
+You can inject values from *appsettings.json* directly into a view.
 
-Example of an `appsettings.json` file:
+Example of an *appsettings.json* file:
 
 ```json
 {

--- a/aspnetcore/mvc/views/dependency-injection.md
+++ b/aspnetcore/mvc/views/dependency-injection.md
@@ -16,7 +16,7 @@ ASP.NET Core supports [dependency injection](xref:fundamentals/dependency-inject
 
 ## Configuration injection
 
-You can inject values from *appsettings.json* directly into a view.
+*appsettings.json* values can be injected directly into a view.
 
 Example of an *appsettings.json* file:
 
@@ -33,7 +33,7 @@ Example of an *appsettings.json* file:
 The syntax for `@inject`:
    `@inject <type> <name>`
 
-An example of `@inject` in action:
+An example using `@inject`:
 
 ```csharp
 @using Microsoft.Extensions.Configuration
@@ -46,7 +46,7 @@ An example of `@inject` in action:
 
 ## Service injection
 
-You can inject a service into a view using the `@inject` directive. You can think of `@inject` as adding a property to your view, and populating the property using DI.
+A service can be injected into a view using the `@inject` directive. You can think of `@inject` as adding a property to your view, and populating the property using DI.
 
 [!code-csharp[](../../mvc/views/dependency-injection/sample/src/ViewInjectSample/Views/ToDo/Index.cshtml?highlight=4,5,15,16,17)]
 

--- a/aspnetcore/mvc/views/dependency-injection.md
+++ b/aspnetcore/mvc/views/dependency-injection.md
@@ -46,7 +46,7 @@ An example using `@inject`:
 
 ## Service injection
 
-A service can be injected into a view using the `@inject` directive. You can think of `@inject` as adding a property to your view, and populating the property using DI.
+A service can be injected into a view using the `@inject` directive. You can think of `@inject` as adding a property to the view, and populating the property using DI.
 
 [!code-csharp[](../../mvc/views/dependency-injection/sample/src/ViewInjectSample/Views/ToDo/Index.cshtml?highlight=4,5,15,16,17)]
 


### PR DESCRIPTION
Fixes #10985

I've added a simpler example for injecting configuration into a view. Separated the two examples so the new example is for configuration-injection and the existing is for service-injection.

[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/mvc/views/dependency-injection?view=aspnetcore-2.2&branch=pr-en-us-12337#configuration-injection)