### PR TITLE
Middleware ordering for signalr and authentication

### DIFF
--- a/aspnetcore/signalr/authn-and-authz.md
+++ b/aspnetcore/signalr/authn-and-authz.md
@@ -19,6 +19,29 @@ By [Andrew Stanton-Nurse](https://twitter.com/anurse)
 
 SignalR can be used with [ASP.NET Core authentication](xref:security/authentication/identity) to associate a user with each connection. In a hub, authentication data can be accessed from the [`HubConnectionContext.User`](/dotnet/api/microsoft.aspnetcore.signalr.hubconnectioncontext.user) property. Authentication allows the hub to call methods on all connections associated with a user (See [Manage users and groups in SignalR](xref:signalr/groups) for more information). Multiple connections may be associated with a single user.
 
+The following is an example of `Startup.Configure` in a typical ASP.NET Core 2.2 app which uses SignalR and ASP.NET Core authentication:
+
+```csharp
+public void Configure(IApplicationBuilder app)
+{
+    ...
+
+    app.UseStaticFiles();
+    
+    app.UseAuthentication();
+
+    app.UseSignalR(hubs =>
+    {
+        hubs.MapHub<ChatHub>("/chat");
+    });
+
+    app.UseMvc(routes =>
+    {
+        routes.MapRoute("default", "{controller=Home}/{action=Index}/{id?}");
+    });
+}
+```
+
 ### Cookie authentication
 
 In a browser-based app, cookie authentication allows your existing user credentials to automatically flow to SignalR connections. When using the browser client, no additional configuration is needed. If the user is logged in to your app, the SignalR connection automatically inherits this authentication.

--- a/aspnetcore/signalr/authn-and-authz.md
+++ b/aspnetcore/signalr/authn-and-authz.md
@@ -42,6 +42,9 @@ public void Configure(IApplicationBuilder app)
 }
 ```
 
+> [!NOTE]
+> The order in which you register the SignalR and ASP.NET Core authentication middleware matters. Always put `UseAuthentication()` before `UseSignalR()` so that SignalR has a user on the `HttpContext`.
+
 ### Cookie authentication
 
 In a browser-based app, cookie authentication allows your existing user credentials to automatically flow to SignalR connections. When using the browser client, no additional configuration is needed. If the user is logged in to your app, the SignalR connection automatically inherits this authentication.


### PR DESCRIPTION
Fixes #11389 

Adds an example to show correct middleware ordering when configuring an ASP.NET Core app to use SignalR with ASP.NET Core authentication. 

Also added an explicit note specifying that `UseAuthentication()` must be called before `UseSignalR`. Used comments from @davidfowl (https://github.com/aspnet/SignalR/issues/2316#issuecomment-447933827) in the text when explaining why ordering matters.
