### PR TITLE
Update source of the blazor.server.js script

### DIFF
--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -78,7 +78,7 @@ There are downsides to server-side hosting:
 * Reduced scalability: The server must manage multiple client connections and handle client state.
 * An ASP.NET Core server is required to serve the app. Deployment without a server (for example, from a CDN) isn't possible.
 
-&dagger;The *blazor.server.js* script is served directly from an embedded resource in `.Components.Server` middleware.
+&dagger;The *blazor.server.js* script is served from an embedded resource in the ASP.NET Core shared framework.
 
 ### Reconnection to the same server
 

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -5,7 +5,7 @@ description: Understand client-side and server-side Blazor hosting models.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/25/2019
+ms.date: 05/10/2019
 uid: blazor/hosting-models
 ---
 # Blazor hosting models
@@ -78,7 +78,7 @@ There are downsides to server-side hosting:
 * Reduced scalability: The server must manage multiple client connections and handle client state.
 * An ASP.NET Core server is required to serve the app. Deployment without a server (for example, from a CDN) isn't possible.
 
-&dagger;The *blazor.server.js* script is published to the following path: *bin/{Debug|Release}/{TARGET FRAMEWORK}/publish/{APPLICATION NAME}.App/dist/_framework*.
+&dagger;The *blazor.server.js* script is served directly from an embedded resource in `.Components.Server` middleware.
 
 ### Reconnection to the same server
 


### PR DESCRIPTION
Fixes #12358 

> We no longer need to load `blazor.server.js` from the client app project, because it's now served directly from an embedded resource in `.Components.Server` middleware.

https://github.com/aspnet/AspNetCore/pull/6562