### PR TITLE
Blazor _Host.cshtml coverage + base path touchup

### DIFF
--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -5,7 +5,7 @@ description: Understand client-side and server-side Blazor hosting models.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/10/2019
+ms.date: 05/13/2019
 uid: blazor/hosting-models
 ---
 # Blazor hosting models
@@ -134,7 +134,7 @@ For example, the following Razor page renders a Counter component with an initia
  
 Sometimes, you need to configure the SignalR client used by Blazor server-side apps. For example, you might want to configure logging on the SignalR client to diagnose a connection issue.
  
-To configure the SignalR client in the *wwwroot/index.htm* file:
+To configure the SignalR client in the *Pages/\_Host.cshtml* file:
 
 * Add an `autostart="false"` attribute to the `<script>` tag for the *blazor.server.js* script.
 * Call `Blazor.start` and pass in a configuration object that specifies the SignalR builder.

--- a/aspnetcore/blazor/javascript-interop.md
+++ b/aspnetcore/blazor/javascript-interop.md
@@ -5,7 +5,7 @@ description: Learn how to invoke JavaScript functions from .NET and .NET methods
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/25/2019
+ms.date: 05/13/2019
 uid: blazor/javascript-interop
 ---
 # Blazor JavaScript interop
@@ -28,11 +28,11 @@ For server-side apps:
 
 The following example is based on [TextDecoder](https://developer.mozilla.org/docs/Web/API/TextDecoder), an experimental JavaScript-based decoder. The example demonstrates how to invoke a JavaScript function from a C# method. The JavaScript function accepts a byte array from a C# method, decodes the array, and returns the text to the component for display.
 
-Inside the `<head>` element of *wwwroot/index.html*, provide a function that uses `TextDecoder` to decode a passed array:
+Inside the `<head>` element of *wwwroot/index.html* (Blazor client-side) or *Pages/\_Host.cshtml* (Blazor server-side), provide a function that uses `TextDecoder` to decode a passed array:
 
 [!code-html[](javascript-interop/samples_snapshot/index-script.html)]
 
-JavaScript code, such as the code shown in the preceding example, can also be loaded from a JavaScript file (*.js*) with a reference to the script file in the *wwwroot/index.html* file:
+JavaScript code, such as the code shown in the preceding example, can also be loaded from a JavaScript file (*.js*) with a reference to the script file:
 
 ```html
 <script src="exampleJsInterop.js"></script>
@@ -71,9 +71,15 @@ In the client-side sample app that accompanies this topic, two JavaScript functi
 
 [!code-javascript[](./common/samples/3.x/BlazorSample/wwwroot/exampleJsInterop.js?highlight=2-7)]
 
-Place the `<script>` tag that references the JavaScript file in the *wwwroot/index.html* file:
+Place the `<script>` tag that references the JavaScript file in the *wwwroot/index.html* file (Blazor client-side) or *Pages/\_Host.cshtml* file (Blazor server-side).
+
+*wwwroot/index.html* (Blazor client-side):
 
 [!code-html[](./common/samples/3.x/BlazorSample/wwwroot/index.html?highlight=15)]
+
+*Pages/\_Host.cshtml* (Blazor server-side):
+
+[!code-cshtml[](javascript-interop/samples_snapshot/_Host.cshtml?highlight=29)]
 
 Don't place a `<script>` tag in a component file because the `<script>` tag can't be updated dynamically.
 

--- a/aspnetcore/blazor/javascript-interop/samples_snapshot/_Host.cshtml
+++ b/aspnetcore/blazor/javascript-interop/samples_snapshot/_Host.cshtml
@@ -1,0 +1,31 @@
+@page "/"
+@namespace blazorsample.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Blazor Sample (Server-side Example)</title>
+    <base href="~/" />
+    <environment include="Development">
+        <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
+    </environment>
+    <environment exclude="Development">
+        <link rel="stylesheet" 
+            href="{CDN PATH TO bootstrap.min.css}"
+            asp-fallback-href="css/bootstrap/bootstrap.min.css"
+            asp-fallback-test-class="sr-only" asp-fallback-test-property="position"
+            asp-fallback-test-value="absolute" crossorigin="anonymous"
+            integrity="{SHA384 HASH}"/>
+    </environment>
+    <link href="css/site.css" rel="stylesheet" />
+</head>
+<body>
+    <app>@(await Html.RenderComponentAsync<App>())</app>
+
+    <script src="_framework/blazor.server.js"></script>
+    <script src="exampleJsInterop.js"></script>
+</body>
+</html>

--- a/aspnetcore/blazor/routing.md
+++ b/aspnetcore/blazor/routing.md
@@ -5,7 +5,7 @@ description: Learn how to route requests in apps and about the NavLink component
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/06/2019
+ms.date: 05/13/2019
 uid: blazor/routing
 ---
 # Blazor routing
@@ -51,7 +51,7 @@ The following example sets a component defined in *Pages/MyFallbackRazorComponen
 ```
 
 > [!IMPORTANT]
-> To generate routes properly, the app must include a `<base>` tag in its *wwwroot/index.html* file with the app base path specified in the `href` attribute (`<base href="/">`). For more information, see <xref:host-and-deploy/blazor/client-side#app-base-path>.
+> To generate routes properly, the app must include a `<base>` tag in its *wwwroot/index.html* file (Blazor client-side) or *Pages/\_Host.cshtml* file (Blazor server-side) with the app base path specified in the `href` attribute (`<base href="/">`). For more information, see <xref:host-and-deploy/blazor/client-side#app-base-path>.
 
 ## Route parameters
 

--- a/aspnetcore/host-and-deploy/blazor/client-side.md
+++ b/aspnetcore/host-and-deploy/blazor/client-side.md
@@ -5,7 +5,7 @@ description: Learn how to host and deploy a Blazor app using ASP.NET Core, Conte
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/18/2019
+ms.date: 05/13/2019
 uid: host-and-deploy/blazor/client-side
 ---
 # Host and deploy Blazor client-side
@@ -120,13 +120,19 @@ Because browsers make requests to Internet-based hosts for client-side pages, we
 
 ## App base path
 
-The *app base path* is the virtual app root path on the server. For example, an app that resides on the Contoso server in a virtual folder at `/CoolApp/` is reached at `https://www.contoso.com/CoolApp` and has a virtual base path of `/CoolApp/`. By setting the app base path to `CoolApp/`, the app is made aware of where it virtually resides on the server. The app can use the app base path to construct URLs relative to the app root from a component that isn't in the root directory. This allows components that exist at different levels of the directory structure to build links to other resources at locations throughout the app. The app base path is also used to intercept hyperlink clicks where the `href` target of the link is within the app base path URI space&mdash;the Blazor router handles the internal navigation.
+The *app base path* is the virtual app root path on the server. For example, an app that resides on the Contoso server in a virtual folder at `/CoolApp/` is reached at `https://www.contoso.com/CoolApp` and has a virtual base path of `/CoolApp/`. By setting the app base path to the virtual path (`<base href="/CoolApp/">`), the app is made aware of where it virtually resides on the server. The app can use the app base path to construct URLs relative to the app root from a component that isn't in the root directory. This allows components that exist at different levels of the directory structure to build links to other resources at locations throughout the app. The app base path is also used to intercept hyperlink clicks where the `href` target of the link is within the app base path URI space&mdash;the Blazor router handles the internal navigation.
 
-In many hosting scenarios, the server's virtual path to the app is the root of the app. In these cases, the app base path is a forward slash (`<base href="/" />`), which is the default configuration for an app. In other hosting scenarios, such as GitHub Pages and IIS virtual directories or sub-applications, the app base path must be set to the server's virtual path to the app. To set the app's base path, add or update the `<base>` tag in *index.html* found within the `<head>` tag elements. Set the `href` attribute value to `virtual-path/` (the trailing slash is required), where `virtual-path/` is the full virtual app root path on the server for the app. In the preceding example, the virtual path is set to `CoolApp/`: `<base href="CoolApp/">`.
+In many hosting scenarios, the server's virtual path to the app is the root of the app. In these cases, the app base path is a forward slash (`<base href="/" />`), which is the default configuration for an app. In other hosting scenarios, such as GitHub Pages and IIS virtual directories or sub-applications, the app base path must be set to the server's virtual path to the app. To set the app's base path, update the `<base>` tag within the `<head>` tag elements of the *wwwroot/index.html* file. Set the `href` attribute value to `/virtual-path/` (the trailing slash is required), where `/virtual-path/` is the full virtual app root path on the server for the app. In the preceding example, the virtual path is set to `/CoolApp/`: `<base href="/CoolApp/">`.
 
-For an app with a non-root virtual path configured (for example, `<base href="CoolApp/">`), the app fails to find its resources *when run locally*. To overcome this problem during local development and testing, you can supply a *path base* argument that matches the `href` value of the `<base>` tag at runtime.
+For an app with a non-root virtual path configured (for example, `<base href="/CoolApp/">`), the app fails to find its resources *when run locally*. To overcome this problem during local development and testing, you can supply a *path base* argument that matches the `href` value of the `<base>` tag at runtime.
 
-To pass the path base argument with the root path (`/`) when running the app locally, execute the following command from the app's directory:
+To pass the path base argument with the root path (`/`) when running the app locally, execute the `dotnet run` command from the app's directory with the `--pathbase` option:
+
+```console
+dotnet run --pathbase=/{Virtual Path (no trailing slash)}
+```
+
+For an app with a virtual base path of `/CoolApp/` (`<base href="/CoolApp/">`), the command is:
 
 ```console
 dotnet run --pathbase=/CoolApp


### PR DESCRIPTION
Fixes #12188 

* Adds *\_Host.cshtml* coverage.
* Touch the app base path coverage in Blazor client-side host and deploy topic.

Thanks @patrickjlee! :rocket:

btw- I would've asked here about contacting Disqus about what we did on #12188 to get an example of a Disqus implementation in Blazor apps, but I think we'll need Blazor at RTM to approach them with the example. Maybe it's something we could do later this year.