### PR TITLE
Update AKV config provider for new Azure process

### DIFF
--- a/aspnetcore/security/key-vault-configuration/sample/Startup.cs
+++ b/aspnetcore/security/key-vault-configuration/sample/Startup.cs
@@ -1,9 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Azure.KeyVault.Models;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Configuration.AzureKeyVault;
-using System.Reflection;
 using System.Text;
 
 namespace SampleApp

--- a/aspnetcore/security/key-vault-configuration/sample/appsettings.json
+++ b/aspnetcore/security/key-vault-configuration/sample/appsettings.json
@@ -1,4 +1,5 @@
 {
   "KeyVaultName": "Key Vault Name",
-  "AzureADApplicationId": "Azure AD Application ID"
+  "AzureADApplicationId": "Azure AD Application ID",
+  "AzureADCertThumbprint": "Azure AD Certificate Thumbprint"
 }

--- a/aspnetcore/security/key-vault-configuration/sample_snapshot/Program.cs
+++ b/aspnetcore/security/key-vault-configuration/sample_snapshot/Program.cs
@@ -1,43 +1,40 @@
-using System.Reflection;
-using Microsoft.AspNetCore;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
+// using System.Reflection;
+// using Microsoft.Azure.KeyVault;
+// using Microsoft.Azure.Services.AppAuthentication;
+// using Microsoft.Extensions.Configuration;
+// using Microsoft.Extensions.Configuration.AzureKeyVault;
 
-namespace SampleApp
-{
-    public static class Program
-    {
-        public static void Main(string[] args)
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .ConfigureAppConfiguration((context, config) =>
         {
-            CreateWebHostBuilder(args).Build().Run();
-        }
+            if (context.HostingEnvironment.IsProduction())
+            {
+                // The appVersion obtains the app version (5.0.0.0), which 
+                // is set in the project file and obtained from the entry 
+                // assembly. The versionPrefix holds the version without 
+                // dot notation for the PrefixKeyVaultSecretManager.
+                var appVersion = Assembly.GetEntryAssembly().GetName().Version.ToString();
+                var versionPrefix = appVersion.Replace(".", string.Empty);
 
-        #region snippet1
-        // using Microsoft.Extensions.Configuration;
+                var builtConfig = config.Build();
 
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .ConfigureAppConfiguration((context, config) =>
+                using (var store = new X509Store(StoreName.My,
+                    StoreLocation.CurrentUser))
                 {
-                    if (context.HostingEnvironment.IsProduction())
-                    {
-                        // The appVersion obtains the app version (5.0.0.0), which 
-                        // is set in the project file and obtained from the entry 
-                        // assembly. The versionPrefix holds the version without 
-                        // dot notation for the PrefixKeyVaultSecretManager.
-                        var appVersion = Assembly.GetEntryAssembly().GetName().Version.ToString();
-                        var versionPrefix = appVersion.Replace(".", string.Empty);
+                    store.Open(OpenFlags.ReadOnly);
+                    var certs = store.Certificates
+                        .Find(X509FindType.FindByThumbprint,
+                            builtConfig["AzureADCertThumbprint"], false);
 
-                        var builtConfig = config.Build();
+                    config.AddAzureKeyVault(
+                        $"https://{builtConfig["KeyVaultName"]}.vault.azure.net/",
+                        builtConfig["AzureADApplicationId"],
+                        certs.OfType<X509Certificate2>().Single(),
+                        new PrefixKeyVaultSecretManager(versionPrefix));
 
-                        config.AddAzureKeyVault(
-                            $"https://{builtConfig["KeyVaultName"]}.vault.azure.net/",
-                            builtConfig["AzureADApplicationId"],
-                            builtConfig["AzureADPassword"],
-                            new PrefixKeyVaultSecretManager(versionPrefix));
-                    }
-                })
-                .UseStartup<Startup>();
-        #endregion
-    }
-}
+                    store.Close();
+                }
+            }
+        })
+        .UseStartup<Startup>();


### PR DESCRIPTION
Fixes #12393

@anurse: Are you available for review? If not, who would be good to look at this one?

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/security/key-vault-configuration?view=aspnetcore-2.1&branch=pr-en-us-12396)

* Use certificate from the cert store as the main approach (over a cert in the root of the app, which would require a `SecureString` of the cert's password to work).
* Update instructions: Azure AD only allows CER, CRT, and PEM uploads now. Have the reader create and upload a CER from a PFX for their AAD-registered app. The PFX is in the cert store, and the CER goes to Azure.

Questions:

* Do we need to ask Azure AD engineers why a PFX can't be uploaded any longer?
* Does Azure AD engineering need to look into why a CER, CRT, or PEM can't be supplied to `Microsoft.IdentityModel.Clients.ActiveDirectory` (`AcquireTokenAsync(String resource, IClientAssertionCertificate clientCertificate)`)? ... they all throw a NRE. Only a PFX works.

Neither of those slow us down here tho. We can proceed with this PR and open a new docs issue to come back later for further updates.

cc: @apwestgarth