### PR TITLE
File uploads in Custom Model Binding topic

### DIFF
--- a/aspnetcore/mvc/advanced/custom-model-binding/sample/CustomModelBindingSample/Controllers/ImageController.cs
+++ b/aspnetcore/mvc/advanced/custom-model-binding/sample/CustomModelBindingSample/Controllers/ImageController.cs
@@ -25,13 +25,12 @@ namespace CustomModelBindingSample.Controllers
         [HttpPost]
         public void Post(byte[] file, string filename)
         {
-            // Don't trust the file name sent by the client. Use Linq to
-            // remove invalid characters. Another option is to use
+            // Don't trust the file name sent by the client. Use
             // Path.GetRandomFileName to generate a safe random
-            // file name.
-            var invalidFileNameChars = Path.GetInvalidFileNameChars();
-            var trustedFileName = invalidFileNameChars.Aggregate(
-                filename, (current, c) => current.Replace(c, '_'));
+            // file name. _targetFilePath receives a value
+            // from configuration (the appsettings.json file in
+            // the sample app).
+            var trustedFileName = Path.GetRandomFileName();
             var filePath = Path.Combine(_targetFilePath, trustedFileName);
 
             if (System.IO.File.Exists(filePath))
@@ -47,13 +46,12 @@ namespace CustomModelBindingSample.Controllers
         [HttpPost("Profile")]
         public void SaveProfile(ProfileViewModel model)
         {
-            // Don't trust the file name sent by the client. Use Linq to
-            // remove invalid characters. Another option is to use
+            // Don't trust the file name sent by the client. Use
             // Path.GetRandomFileName to generate a safe random
-            // file name.
-            var invalidFileNameChars = Path.GetInvalidFileNameChars();
-            var trustedFileName = invalidFileNameChars.Aggregate(
-                model.FileName, (current, c) => current.Replace(c, '_'));
+            // file name. _targetFilePath receives a value
+            // from configuration (the appsettings.json file in
+            // the sample app).
+            var trustedFileName = Path.GetRandomFileName();
             var filePath = Path.Combine(_targetFilePath, trustedFileName);
             
             if (System.IO.File.Exists(filePath))

--- a/aspnetcore/mvc/advanced/custom-model-binding/sample/CustomModelBindingSample/Controllers/ImageController.cs
+++ b/aspnetcore/mvc/advanced/custom-model-binding/sample/CustomModelBindingSample/Controllers/ImageController.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using System.Linq;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;

--- a/aspnetcore/mvc/advanced/custom-model-binding/sample/CustomModelBindingSample/appsettings.json
+++ b/aspnetcore/mvc/advanced/custom-model-binding/sample/CustomModelBindingSample/appsettings.json
@@ -4,5 +4,6 @@
     "LogLevel": {
       "Default": "Warning"
     }
-  }
+  },
+  "StoredFilesPath": "<PATH TO FILE STORAGE LOCATION>"
 }


### PR DESCRIPTION
Fixes #12292

* Mirrors the approach used in the [File Uploads PR (aspnet/AspNetCore.Docs #12344)](https://github.com/aspnet/AspNetCore.Docs/pull/12344).
* Specifically:
  * Have the example save the file elsewhere, not to *wwwroot*.
  * ~Cleanse the filename with `Path.GetInvalidFileNameChars` and Linq.~ Use `Path.GetRandomFileName` to get a fully trusted random file name.
* The topic makes no direct reference to any of this, so the topic doesn't require changes. Line highlights in the topic for the `regions` here don't require an update either.

Thanks @omerlh! :rocket: