### PR TITLE
Added missing slash in example code

### DIFF
--- a/aspnetcore/tutorials/build-your-first-blazor-app.md
+++ b/aspnetcore/tutorials/build-your-first-blazor-app.md
@@ -182,7 +182,7 @@ Add a new component to the app that implements a simple todo list.
    [!code-cshtml[](build-your-first-blazor-app/samples_snapshot/3.x/ToDo7.razor?highlight=2)]
 
    ```cshtml
-   <input placeholder="Something todo" bind="@newTodo">
+   <input placeholder="Something todo" bind="@newTodo"/>
    ```
 
 1. Update the `AddTodo` method to add the `TodoItem` with the specified title to the list. Clear the value of the text input by setting `newTodo` to an empty string:

--- a/aspnetcore/tutorials/build-your-first-blazor-app.md
+++ b/aspnetcore/tutorials/build-your-first-blazor-app.md
@@ -5,7 +5,7 @@ description: Build a Blazor app step-by-step.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/14/2019
+ms.date: 05/19/2019
 uid: tutorials/first-blazor-app
 ---
 # Build your first Blazor app
@@ -182,7 +182,7 @@ Add a new component to the app that implements a simple todo list.
    [!code-cshtml[](build-your-first-blazor-app/samples_snapshot/3.x/ToDo7.razor?highlight=2)]
 
    ```cshtml
-   <input placeholder="Something todo" bind="@newTodo"/>
+   <input placeholder="Something todo" bind="@newTodo" />
    ```
 
 1. Update the `AddTodo` method to add the `TodoItem` with the specified title to the list. Clear the value of the text input by setting `newTodo` to an empty string:


### PR DESCRIPTION
Changed:

```cshtml
<input placeholder="Something todo" bind="@newTodo">
```

on line 185 to:

```cshtml
<input placeholder="Something todo" bind="@newTodo"/>
```

because it won't run otherwise / syntax mistake



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->