### PR TITLE
Blazor call web API topic with sample

### DIFF
--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -1,0 +1,230 @@
+---
+title: Call a web API
+author: guardrex
+description: Learn how to call a web API from a Blazor app using JSON helpers, including making cross-origin resource sharing (CORS) requests.
+monikerRange: '>= aspnetcore-3.0'
+ms.author: riande
+ms.custom: mvc
+ms.date: 05/20/2019
+uid: blazor/call-web-api
+---
+# Call a web API
+
+By [Luke Latham](https://github.com/guardrex)
+
+Blazor apps call web API services using [HttpClient](xref:fundamentals/http-requests). Compose requests using Blazor JSON helpers or with <xref:System.Net.Http.HttpRequestMessage>, which can include JavaScript [Fetch API](https://developer.mozilla.org/docs/Web/API/Fetch_API) request options.
+
+[View or download sample code](https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/blazor/common/samples/) ([how to download](xref:index#how-to-download-a-sample))
+
+See the following components in the sample app:
+
+* Call Web API (*Pages/CallWebAPI.razor*)
+* HTTP Request Tester (*Components/HTTPRequestTester.razor*)
+
+## HttpClient and JSON helpers
+
+Use [HttpClient](xref:fundamentals/http-requests) and JSON helpers to call a web API service endpoint in a Razor component. Blazor client-side uses the [Fetch API](https://developer.mozilla.org/docs/Web/API/Fetch_API), while Blazor server-side uses <xref:System.Net.Http.HttpClient?displayProperty=fullName>.
+
+Include an `@using` statement for <xref:System.Threading.Tasks> for asynchronous web API calls and inject an `HttpClient` instance:
+
+```cshtml
+@using System.Threading.Tasks
+@inject HttpClient Http
+```
+
+In the following examples, a Todo web API service processes create, read, update, and delete (CRUD) operations. The examples are based on a `TodoItem` class that stores the:
+
+* ID (`Id`, `long`) &ndash; Unique ID of the item.
+* Name (`Name`, `string`) &ndash; Name of the item.
+* Status (`IsComplete`, `bool`) &ndash; Indication if the Todo item is finished.
+
+```csharp
+private class TodoItem
+{
+    public long Id { get; set; }
+    public string Name { get; set; }
+    public bool IsComplete { get; set; }
+}
+```
+
+JSON helper methods send requests to a URI (a web API in the following examples) and process the response:
+
+* `GetJsonAsync` &ndash; Sends a GET request and parses the JSON response body to create an object.
+
+  In the following code, the `_todoItems` are displayed by the component. The `GetTodoItems` method is triggered when the component is finished rendering ([OnInitAsync](xref:blazor/components#lifecycle-methods)). See the sample app for a complete example.
+
+  ```cshtml
+  @using Microsoft.AspNetCore.Blazor.Http
+  @inject HttpClient Http
+
+  @functions {
+      private const string ServiceEndpoint = "https://localhost:10000/api/todo";
+      private TodoItem[] _todoItems;
+
+      protected override async Task OnInitAsync() => 
+          await GetTodoItems();
+
+      private async Task GetTodoItems() => 
+          _todoItems = await Http.GetJsonAsync<TodoItem[]>(ServiceEndpoint);
+  }
+  ```
+
+* `PostJsonAsync` &ndash; Sends a POST request, including JSON-encoded content, and parses the JSON response body to create an object.
+
+  In the following code, `_newItemName` is provided by a bound element of the component. The `AddItem` method is triggered by selecting a `<button>` element. See the sample app for a complete example.
+
+  ```cshtml
+  @using Microsoft.AspNetCore.Blazor.Http
+  @inject HttpClient Http
+
+  <input type="text" bind="@_newItemName" placeholder="New Todo Item" />
+  <button onclick="@(async () => await AddItem())">Add</button>
+
+  @functions {
+      private const string ServiceEndpoint = "https://localhost:10000/api/todo";
+      private string _newItemName;
+
+      private async Task AddItem()
+      {
+          var addItem = new TodoItem { Name = _newItemName, IsComplete = false };
+          await Http.PostJsonAsync(ServiceEndpoint, addItem);
+      }
+  }
+  ```
+
+* `PutJsonAsync` &ndash; Sends a PUT request, including JSON-encoded content.
+
+  In the following code, `_editItem` values (`Id`, `Name`, `IsCompleted`) are provided by bound elements of the component. The `SaveItem` method is triggered by selecting the Save `<button>` element. See the sample app for a complete example.
+
+  ```cshtml
+  @using Microsoft.AspNetCore.Blazor.Http
+  @inject HttpClient Http
+
+  <input type="text" bind="@_editItem.Id" />
+  <input type="checkbox" bind="@_editItem.IsComplete" />
+  <input type="text" bind="@_editItem.Name" />
+  <button onclick="@(async () => await SaveItem())">Save</button>
+
+  @functions {
+      private const string ServiceEndpoint = "https://localhost:10000/api/todo";
+      private TodoItem _editItem = new TodoItem();
+
+      private async Task SaveItem()
+      {
+          await Http.PutJsonAsync(
+              Path.Combine(ServiceEndpoint, _editItem.Id.ToString()), _editItem);
+      }
+  }
+  ```
+
+<xref:System.Net.Http> includes additional extension methods for sending HTTP requests and receiving HTTP responses. [HttpClient.DeleteAsync](xref:System.Net.Http.HttpClient.DeleteAsync*) is used to send a DELETE request to a web API.
+
+In the following code, the Delete `<button>` element supplies the `id` when it's selected in the UI. See the sample app for a complete example.
+
+```cshtml
+@using Microsoft.AspNetCore.Blazor.Http
+@inject HttpClient Http
+
+<input type="text" bind="@_id" />
+<button onclick="@(async () => await DeleteItem())">Delete</button>
+
+@functions {
+    private const string ServiceEndpoint = "https://localhost:10000/api/todo";
+    private long _id;
+
+    private async Task DeleteItem()
+    {
+        await Http.DeleteAsync(Path.Combine(ServiceEndpoint, _id.ToString()));
+    }
+}
+```
+
+## HttpClient and HttpRequestMessage with Fetch API request options
+
+Use [HttpClient](xref:fundamentals/http-requests) and <xref:System.Net.Http.HttpRequestMessage> to supply request options to the underlying JavaScript [Fetch API](https://developer.mozilla.org/docs/Web/API/Fetch_API).
+
+In the following example:
+
+* JSON serialization and deserialization must be handled by user code (*not shown*).
+* The `credentials` property is set to any of the following values:
+
+  * `FetchCredentialsOption.Include` ("include") &ndash; Advises the browser to send credentials (such as cookies or HTTP auth headers) even for cross-origin requests. Only allowed when the CORS Middleware policy in the web API is configured to <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowCredentials*>.
+  * `FetchCredentialsOption.Omit` ("omit") &ndash; Advises the browser never to send credentials (such as cookies or HTTP auth headers).
+  * `FetchCredentialsOption.SameOrigin` ("same-origin") &ndash; Advises the browser to send credentials (such as cookies or HTTP auth headers) only if the target URL is on the same origin as the calling application.
+
+```cshtml
+@using System.Net.Http.Headers
+@using Microsoft.AspNetCore.Blazor.Http
+@inject HttpClient Http
+
+@functions {
+    private async Task PostRequest()
+    {
+        Http.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", "{OAUTH TOKEN}");
+
+        var requestMessage = new HttpRequestMessage()
+        {
+            Method = new HttpMethod("POST"),
+            RequestUri = new Uri("https://localhost:10000/api/todo"),
+            Content = 
+                new StringContent(
+                    @"{""name"":""A New Todo Item"",""isComplete"":false}")
+        };
+
+        requestMessage.Content.Headers.ContentType = 
+            new System.Net.Http.Headers.MediaTypeHeaderValue(
+                "application/json");
+
+        requestMessage.Content.Headers.TryAddWithoutValidation(
+            "x-custom-header", "value");
+        
+        requestMessage.Properties[WebAssemblyHttpMessageHandler.FetchArgs] = new
+        { 
+            credentials = FetchCredentialsOption.Include
+        };
+
+        var response = await Http.SendAsync(requestMessage);
+        var responseStatusCode = response.StatusCode;
+        var responseBody = await response.Content.ReadAsStringAsync();
+    }
+}
+```
+
+For more information on Fetch API options, see [MDN web docs: Window​OrWorker​Global​Scope​.fetch():Parameters](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters).
+
+When sending credentials (authorization cookies/headers) on CORS requests, allow the `Authorization` header when creating the CORS policy for CORS middleware. The following policy includes configuration for:
+
+* Request origins (`http://localhost:5000`, `https://localhost:5001`).
+* Any method (verb).
+* `Content-Type` and `Authorization` headers. To allow a custom header (for example, `x-custom-header`), list the header when calling <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.WithHeaders*>.
+* Credentials set by client-side JavaScript code (`credentials` property set to `include`).
+
+```csharp
+app.UseCors(policy => 
+    policy.WithOrigins("http://localhost:5000", "https://localhost:5001")
+    .AllowAnyMethod()
+    .WithHeaders(HeaderNames.ContentType, HeaderNames.Authorization, "x-custom-header")
+    .AllowCredentials());
+```
+
+For more information, see <xref:security/cors> and the sample app's HTTP Request Tester component (*Components/HTTPRequestTester.razor*).
+
+## Cross-origin resource sharing (CORS)
+
+For more information on making cross-origin resource sharing (CORS) requests, see <xref:security/cors>. The sample app demonstrates CORS. See the Call Web API component (*Pages/CallWebAPI.razor*).
+
+## HTTP Request Tester
+
+The sample app includes an HTTP Request Tester component (*Components/HTTPRequestTester.razor*). The component is included in the Call Web API component:
+
+```cshtml
+<HTTPRequestTester />
+```
+
+Use the component to test request-responses against web API service endpoints.
+
+## Additional resources
+
+* <xref:fundamentals/http-requests>
+* [Cross Origin Resource Sharing (CORS) at W3C](https://www.w3.org/TR/cors/)

--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -1,14 +1,14 @@
 ---
-title: Call a web API
+title: Call a web API from ASP.NET Core Blazor
 author: guardrex
 description: Learn how to call a web API from a Blazor app using JSON helpers, including making cross-origin resource sharing (CORS) requests.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/20/2019
+ms.date: 06/14/2019
 uid: blazor/call-web-api
 ---
-# Call a web API
+# Call a web API from ASP.NET Core Blazor
 
 By [Luke Latham](https://github.com/guardrex)
 

--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -5,7 +5,7 @@ description: Learn how to call a web API from a Blazor app using JSON helpers, i
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 06/24/2019
+ms.date: 06/25/2019
 uid: blazor/call-web-api
 ---
 # Call a web API from ASP.NET Core Blazor
@@ -14,7 +14,7 @@ By [Luke Latham](https://github.com/guardrex) and [Daniel Roth](https://github.c
 
 Blazor client-side apps call web APIs using a preconfigured `HttpClient` service. Compose requests, which can include JavaScript [Fetch API](https://developer.mozilla.org/docs/Web/API/Fetch_API) options, using Blazor JSON helpers or with <xref:System.Net.Http.HttpRequestMessage>.
 
-Blazor server-side apps call web APIs using <xref:System.Net.Http.IHttpClientFactory>, which implements <xref:System.Net.Http.HttpClient>. For more information, see <xref:fundamentals/http-requests>.
+Blazor server-side apps call web APIs using <xref:System.Net.Http.HttpClient> instances typically created using <xref:System.Net.Http.IHttpClientFactory>. For more information, see <xref:fundamentals/http-requests>.
 
 [View or download sample code](https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/blazor/common/samples/) ([how to download](xref:index#how-to-download-a-sample))
 
@@ -137,11 +137,11 @@ In the following code, the Delete `<button>` element calls the `DeleteItem` meth
 
 ## Cross-origin resource sharing (CORS)
 
-Browser security prevents a web page from making requests to a different domain than the one that served the web page. This restriction is called the *same-origin policy*. The same-origin policy prevents a malicious site from reading sensitive data from another site. Sometimes, you might want to allow other sites to make cross-origin resource sharing (CORS) requests to your app.
+Browser security prevents a webpage from making requests to a different domain than the one that served the webpage. This restriction is called the *same-origin policy*. The same-origin policy prevents a malicious site from reading sensitive data from another site. To make requests from the browser to an endpoint with a different origin, the *endpoint* must enable [cross-origin resource sharing (CORS)](https://www.w3.org/TR/cors/).
 
 The sample app demonstrates the use of CORS in the Call Web API component (*Pages/CallWebAPI.razor*).
 
-For more information, see <xref:security/cors>.
+To allow other sites to make cross-origin resource sharing (CORS) requests to your app, see <xref:security/cors>.
 
 ## HttpClient and HttpRequestMessage with Fetch API request options
 
@@ -194,7 +194,9 @@ Supply request options to the underlying JavaScript [Fetch API](https://develope
 
 For more information on Fetch API options, see [MDN web docs: WindowOrWorkerGlobalScope.fetch():Parameters](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters).
 
-When sending credentials (authorization cookies/headers) on CORS requests, allow the `Authorization` header when creating the CORS policy for CORS middleware. The following policy includes configuration for:
+When sending credentials (authorization cookies/headers) on CORS requests, the `Authorization` header must be allowed by the CORS policy.
+
+The following policy includes configuration for:
 
 * Request origins (`http://localhost:5000`, `https://localhost:5001`).
 * Any method (verb).

--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -25,7 +25,7 @@ For Blazor client-side examples, see the following components in the sample app:
 
 ## HttpClient and JSON helpers
 
-In Blazor client-side apps, [HttpClient](xref:fundamentals/http-requests) is available as a preconfigured service for making requests back to the origin server. `HttpClient` and JSON helpers are also used to call third party web API service endpoints. `HttpClient` is implemented using the browser [Fetch API](https://developer.mozilla.org/docs/Web/API/Fetch_API) and is subject to its limitations, including enforcement of the same origin policy.
+In Blazor client-side apps, [HttpClient](xref:fundamentals/http-requests) is available as a preconfigured service for making requests back to the origin server. `HttpClient` and JSON helpers are also used to call third-party web API endpoints. `HttpClient` is implemented using the browser [Fetch API](https://developer.mozilla.org/docs/Web/API/Fetch_API) and is subject to its limitations, including enforcement of the same origin policy.
 
 The client's base address is set to the originating server's address. Inject an `HttpClient` instance using the `@inject` directive:
 
@@ -34,7 +34,7 @@ The client's base address is set to the originating server's address. Inject an 
 @inject HttpClient Http
 ```
 
-In the following examples, a Todo web API service processes create, read, update, and delete (CRUD) operations. The examples are based on a `TodoItem` class that stores the:
+In the following examples, a Todo web API processes create, read, update, and delete (CRUD) operations. The examples are based on a `TodoItem` class that stores the:
 
 * ID (`Id`, `long`) &ndash; Unique ID of the item.
 * Name (`Name`, `string`) &ndash; Name of the item.
@@ -51,7 +51,7 @@ private class TodoItem
 
 JSON helper methods send requests to a URI (a web API in the following examples) and process the response:
 
-* `GetJsonAsync` &ndash; Sends a GET request and parses the JSON response body to create an object.
+* `GetJsonAsync` &ndash; Sends an HTTP GET request and parses the JSON response body to create an object.
 
   In the following code, the `_todoItems` are displayed by the component. The `GetTodoItems` method is triggered when the component is finished rendering ([OnInitAsync](xref:blazor/components#lifecycle-methods)). See the sample app for a complete example.
 
@@ -67,7 +67,7 @@ JSON helper methods send requests to a URI (a web API in the following examples)
   }
   ```
 
-* `PostJsonAsync` &ndash; Sends a POST request, including JSON-encoded content, and parses the JSON response body to create an object.
+* `PostJsonAsync` &ndash; Sends an HTTP POST request, including JSON-encoded content, and parses the JSON response body to create an object.
 
   In the following code, `_newItemName` is provided by a bound element of the component. The `AddItem` method is triggered by selecting a `<button>` element. See the sample app for a complete example.
 
@@ -89,9 +89,9 @@ JSON helper methods send requests to a URI (a web API in the following examples)
   }
   ```
 
-* `PutJsonAsync` &ndash; Sends a PUT request, including JSON-encoded content.
+* `PutJsonAsync` &ndash; Sends an HTTP PUT request, including JSON-encoded content.
 
-  In the following code, `_editItem` values for `Name`and `IsCompleted` are provided by bound elements of the component. The item's `Id` is set when the item is selected in another part of the UI and `EditItem` is called. The `SaveItem` method is triggered by selecting the Save `<button>` element. See the sample app for a complete example.
+  In the following code, `_editItem` values for `Name` and `IsCompleted` are provided by bound elements of the component. The item's `Id` is set when the item is selected in another part of the UI and `EditItem` is called. The `SaveItem` method is triggered by selecting the Save `<button>` element. See the sample app for a complete example.
 
   ```cshtml
   @using System.Net.Http
@@ -116,7 +116,7 @@ JSON helper methods send requests to a URI (a web API in the following examples)
   }
   ```
 
-<xref:System.Net.Http> includes additional extension methods for sending HTTP requests and receiving HTTP responses. [HttpClient.DeleteAsync](xref:System.Net.Http.HttpClient.DeleteAsync*) is used to send a DELETE request to a web API.
+<xref:System.Net.Http> includes additional extension methods for sending HTTP requests and receiving HTTP responses. [HttpClient.DeleteAsync](xref:System.Net.Http.HttpClient.DeleteAsync*) is used to send an HTTP DELETE request to a web API.
 
 In the following code, the Delete `<button>` element calls the `DeleteItem` method. The bound `<input>` element supplies the `id` of the item to delete. See the sample app for a complete example.
 
@@ -137,7 +137,7 @@ In the following code, the Delete `<button>` element calls the `DeleteItem` meth
 
 ## Cross-origin resource sharing (CORS)
 
-Browser security prevents a web page from making requests to a different domain than the one that served the web page. This restriction is called the *same-origin policy*. The same-origin policy prevents a malicious site from reading sensitive data from another site. Sometimes, you might want to allow other sites make cross-origin resource sharing (CORS) requests to your app.
+Browser security prevents a web page from making requests to a different domain than the one that served the web page. This restriction is called the *same-origin policy*. The same-origin policy prevents a malicious site from reading sensitive data from another site. Sometimes, you might want to allow other sites to make cross-origin resource sharing (CORS) requests to your app.
 
 The sample app demonstrates the use of CORS in the Call Web API component (*Pages/CallWebAPI.razor*).
 

--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -124,7 +124,7 @@ In the following code, the Delete `<button>` element calls the `DeleteItem` meth
 <input @bind="_id" />
 <button @onclick="@DeleteItem">Delete</button>
 
-@functions {
+@code {
     private long _id;
 
     private async Task DeleteItem() =>

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/App.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/App.razor
@@ -1,1 +1,5 @@
-﻿<Router AppAssembly="typeof(Program).Assembly" />
+﻿<Router AppAssembly="typeof(Program).Assembly">
+    <NotFoundContent>
+        <p>Sorry, there's nothing at this address.</p>
+    </NotFoundContent>
+</Router>

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/BlazorSample.csproj
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/BlazorSample.csproj
@@ -1,19 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <RestoreAdditionalProjectSources>
-      https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
-      https://dotnet.myget.org/F/blazor-dev/api/v3/index.json;
-    </RestoreAdditionalProjectSources>
     <LangVersion>7.3</LangVersion>
     <RazorLangVersion>3.0</RazorLangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.0.0-preview4-19216-03" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.0.0-preview4-19216-03" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.DevServer" Version="3.0.0-preview4-19216-03" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.0.0-preview6.19307.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.0.0-preview6.19307.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.DevServer" Version="3.0.0-preview6.19307.2" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/Components/HTTPRequestTester.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/Components/HTTPRequestTester.razor
@@ -1,0 +1,178 @@
+@using System.Net
+@using System.Net.Http
+@using Microsoft.AspNetCore.Blazor.Http
+@using Microsoft.AspNetCore.Components
+@inject HttpClient Http
+@inject IUriHelper UriHelper
+
+<h2>HTTP Request Tester</h2>
+
+<p>The default values of the following form POST (add a Todo item) to the web API service created in the <a href="https://docs.microsoft.com/aspnet/core/tutorials/first-web-api">Tutorial: Create a web API with ASP.NET Core MVC</a> topic with:</p>
+
+<ul>
+    <li>An endpoint URI of <code>https://localhost:10000/api/todo</code>.</li>
+    <li>The <code>Content-Type</code> header set to <code>application/json</code>, which describes the payload of a POST/PUT request to the service.</li>
+    <li>Fetch API credentials of <code>include</code>, which is permitted by the service's CORS Middleware policy with an <code>Authorization</code> header included in the request.</li>
+</ul>
+
+<p>Add the following CORS middleware configuration to the web API's service's <code>Startup.Configure</code> method before it calls <code>UseMvc</code>:</p>
+
+<pre><code>app.UseCors(policy =>
+    policy.WithOrigins("http://localhost:5000", "https://localhost:5001")
+    .AllowAnyMethod()
+    .WithHeaders(HeaderNames.ContentType, HeaderNames.Authorization)
+    .AllowCredentials());</code></pre>
+
+<p>Adjust the domains and ports of <code>WithOrigins</code> as needed for the Blazor app.</p>
+
+<p>The web API service is configured for CORS to permit authorization cookies/headers and requests from client code, but the service as created by the tutorial doesn't actually authorize requests. See the <a href="https://docs.microsoft.com/aspnet/core/security/">ASP.NET Core Security and Identity articles</a> for implementation guidance.</p>
+
+<p>
+    <div>URI:</div>
+    <input id="request-uri" type="text" bind="@_uri" size="120" />
+</p>
+
+<p>
+    <div>Method:</div>
+    <select id="request-method" bind="@_method">
+        <option value="GET">GET</option>
+        <option value="POST" selected>POST</option>
+        <option value="PUT">PUT</option>
+        <option value="DELETE">DELETE</option>
+    </select>
+</p>
+
+<p>
+    <div>Credentials:</div>
+    <select id="request-credentials" bind="@_credentials">
+        <option value="include" selected>include</option>
+        <option value="same-origin">same-origin</option>
+        <option value="omit">omit</option>
+    </select>
+</p>
+
+<p>
+    <div>Request body:</div>
+    <textarea id="request-body" bind="@_requestBody"></textarea>
+</p>
+
+<p>
+    <div>Request headers:</div>
+    @foreach (var header in _requestHeaders)
+    {
+        <div class="header-entry">
+            Name: <input bind="@header.Name" />
+            Value: <input bind="@header.Value" />
+            <button class="btn btn-danger" onclick="@(e => RemoveHeader(header))">remove</button>
+        </div>
+    }
+    <button class="btn btn-primary" id="add-header" onclick="@AddHeader">Add</button>
+</p>
+
+<p>
+    <div>Request referrer:</div>
+    <input id="request-referrer" type="text" bind="@_requestReferrer" size="120" />
+</p>
+
+<button class="btn btn-success" id="send-request" onclick="@DoRequest">Request</button>
+
+@if (_responseStatusCode.HasValue)
+{
+    <h2>Response</h2>
+    <p><div>Status:</div><span id="response-status">@_responseStatusCode</span></p>
+    <p><div>Body:</div><textarea id="response-body" readonly>@_responseBody</textarea></p>
+    <p><div>Headers:</div><textarea id="response-headers" readonly>@_responseHeaders</textarea></p>
+}
+
+@functions {
+    private string _uri = "https://localhost:10000/api/todo";
+    private string _method = "POST";
+    private string _requestBody = @"{""name"":""A New Todo Item"",""isComplete"":false}";
+    private List<RequestHeader> _requestHeaders = new List<RequestHeader>()
+{
+        new RequestHeader() { Name = "Content-Type", Value = "application/json" },
+        new RequestHeader() { Name = "Authorization", Value = "Bearer MHrHDcEfxjoYZgeFONFh7HgQ" }
+    };
+    private string _requestReferrer;
+    private string _credentials = "include";
+    private HttpStatusCode? _responseStatusCode;
+    private string _responseBody;
+    private string _responseHeaders;
+
+    protected override void OnInit()
+    {
+        _requestReferrer = UriHelper.GetAbsoluteUri();
+    }
+
+    private async void DoRequest()
+    {
+        _responseStatusCode = null;
+
+        try
+        {
+            var requestMessage = new HttpRequestMessage()
+            {
+                Method = new HttpMethod(_method),
+                RequestUri = new Uri(_uri),
+                Content = string.IsNullOrEmpty(_requestBody)
+                    ? null
+                    : new StringContent(_requestBody)
+            };
+
+            foreach (var header in _requestHeaders)
+            {
+                // StringContent automatically adds its own Content-Type header with default value "text/plain"
+                // If the developer is trying to specify a content type explicitly, we need to replace the default value,
+                // rather than adding a second Content-Type header.
+                if (header.Name.Equals("Content-Type", StringComparison.OrdinalIgnoreCase) && requestMessage.Content != null)
+                {
+                    requestMessage.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(header.Value);
+                    continue;
+                }
+
+                if (!requestMessage.Headers.TryAddWithoutValidation(header.Name, header.Value))
+                {
+                    requestMessage.Content?.Headers.TryAddWithoutValidation(header.Name, header.Value);
+                }
+            }
+
+            requestMessage.Properties[WebAssemblyHttpMessageHandler.FetchArgs] = new
+            {
+                referrer = _requestReferrer,
+                credentials = _credentials
+            };
+
+            var response = await Http.SendAsync(requestMessage);
+            _responseStatusCode = response.StatusCode;
+            _responseBody = await response.Content.ReadAsStringAsync();
+            var allHeaders = response.Headers.Concat(response.Content?.Headers
+                ?? Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>());
+            _responseHeaders = string.Join(
+                Environment.NewLine,
+                allHeaders.Select(pair => $"{pair.Key}: {pair.Value.First()}").ToArray());
+        }
+        catch (Exception ex)
+        {
+            if (ex is AggregateException)
+            {
+                ex = ex.InnerException;
+            }
+            _responseStatusCode = HttpStatusCode.SeeOther;
+            _responseBody = ex.Message + Environment.NewLine + ex.StackTrace;
+        }
+
+        StateHasChanged();
+    }
+
+    private void AddHeader()
+        => _requestHeaders.Add(new RequestHeader());
+
+    private void RemoveHeader(RequestHeader header)
+        => _requestHeaders.Remove(header);
+
+    private class RequestHeader
+    {
+        public string Name { get; set; }
+        public string Value { get; set; }
+    }
+}

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/Components/HTTPRequestTester.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/Components/HTTPRequestTester.razor
@@ -1,6 +1,4 @@
-@using System.Net
 @using System.Net.Http
-@using Microsoft.AspNetCore.Blazor.Http
 @using Microsoft.AspNetCore.Components
 @inject HttpClient Http
 @inject IUriHelper UriHelper
@@ -29,12 +27,12 @@
 
 <p>
     <div>URI:</div>
-    <input id="request-uri" type="text" bind="@_uri" size="120" />
+    <input id="request-uri" @bind="_uri" size="120" />
 </p>
 
 <p>
     <div>Method:</div>
-    <select id="request-method" bind="@_method">
+    <select id="request-method" @bind="_method">
         <option value="GET">GET</option>
         <option value="POST" selected>POST</option>
         <option value="PUT">PUT</option>
@@ -44,7 +42,7 @@
 
 <p>
     <div>Credentials:</div>
-    <select id="request-credentials" bind="@_credentials">
+    <select id="request-credentials" @bind="_credentials">
         <option value="include" selected>include</option>
         <option value="same-origin">same-origin</option>
         <option value="omit">omit</option>
@@ -53,7 +51,7 @@
 
 <p>
     <div>Request body:</div>
-    <textarea id="request-body" bind="@_requestBody"></textarea>
+    <textarea id="request-body" @bind="_requestBody"></textarea>
 </p>
 
 <p>
@@ -61,20 +59,20 @@
     @foreach (var header in _requestHeaders)
     {
         <div class="header-entry">
-            Name: <input bind="@header.Name" />
-            Value: <input bind="@header.Value" />
-            <button class="btn btn-danger" onclick="@(e => RemoveHeader(header))">remove</button>
+            Name: <input @bind="header.Name" />
+            Value: <input @bind="header.Value" />
+            <button class="btn btn-danger" @onclick="@(e => RemoveHeader(header))">remove</button>
         </div>
     }
-    <button class="btn btn-primary" id="add-header" onclick="@AddHeader">Add</button>
+    <button class="btn btn-primary" id="add-header" @onclick="@AddHeader">Add</button>
 </p>
 
 <p>
     <div>Request referrer:</div>
-    <input id="request-referrer" type="text" bind="@_requestReferrer" size="120" />
+    <input id="request-referrer" type="text" @bind="_requestReferrer" size="120" />
 </p>
 
-<button class="btn btn-success" id="send-request" onclick="@DoRequest">Request</button>
+<button class="btn btn-success" id="send-request" @onclick="@DoRequest">Request</button>
 
 @if (_responseStatusCode.HasValue)
 {
@@ -84,7 +82,7 @@
     <p><div>Headers:</div><textarea id="response-headers" readonly>@_responseHeaders</textarea></p>
 }
 
-@functions {
+@code {
     private string _uri = "https://localhost:10000/api/todo";
     private string _method = "POST";
     private string _requestBody = @"{""name"":""A New Todo Item"",""isComplete"":false}";

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/Components/HTTPRequestTester.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/Components/HTTPRequestTester.razor
@@ -1,5 +1,4 @@
-@using System.Net.Http
-@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Blazor.Http
 @inject HttpClient Http
 @inject IUriHelper UriHelper
 
@@ -87,13 +86,13 @@
     private string _method = "POST";
     private string _requestBody = @"{""name"":""A New Todo Item"",""isComplete"":false}";
     private List<RequestHeader> _requestHeaders = new List<RequestHeader>()
-{
+    {
         new RequestHeader() { Name = "Content-Type", Value = "application/json" },
         new RequestHeader() { Name = "Authorization", Value = "Bearer MHrHDcEfxjoYZgeFONFh7HgQ" }
     };
     private string _requestReferrer;
     private string _credentials = "include";
-    private HttpStatusCode? _responseStatusCode;
+    private System.Net.HttpStatusCode? _responseStatusCode;
     private string _responseBody;
     private string _responseHeaders;
 
@@ -112,9 +111,7 @@
             {
                 Method = new HttpMethod(_method),
                 RequestUri = new Uri(_uri),
-                Content = string.IsNullOrEmpty(_requestBody)
-                    ? null
-                    : new StringContent(_requestBody)
+                Content = string.IsNullOrEmpty(_requestBody) ? null : new StringContent(_requestBody)
             };
 
             foreach (var header in _requestHeaders)
@@ -143,11 +140,8 @@
             var response = await Http.SendAsync(requestMessage);
             _responseStatusCode = response.StatusCode;
             _responseBody = await response.Content.ReadAsStringAsync();
-            var allHeaders = response.Headers.Concat(response.Content?.Headers
-                ?? Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>());
-            _responseHeaders = string.Join(
-                Environment.NewLine,
-                allHeaders.Select(pair => $"{pair.Key}: {pair.Value.First()}").ToArray());
+            var allHeaders = response.Headers.Concat(response.Content?.Headers ?? Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>());
+            _responseHeaders = string.Join(Environment.NewLine, allHeaders.Select(pair => $"{pair.Key}: {pair.Value.First()}").ToArray());
         }
         catch (Exception ex)
         {
@@ -155,7 +149,7 @@
             {
                 ex = ex.InnerException;
             }
-            _responseStatusCode = HttpStatusCode.SeeOther;
+            _responseStatusCode = System.Net.HttpStatusCode.SeeOther;
             _responseBody = ex.Message + Environment.NewLine + ex.StackTrace;
         }
 

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/Components/HTTPRequestTester.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/Components/HTTPRequestTester.razor
@@ -5,7 +5,7 @@
 
 <h2>HTTP Request Tester</h2>
 
-<p>The default values of the following form POST (add a Todo item) to the web API service created in the <a href="https://docs.microsoft.com/aspnet/core/tutorials/first-web-api">Tutorial: Create a web API with ASP.NET Core MVC</a> topic with:</p>
+<p>The default values of the following form POST (add a Todo item) to the web API created in the <a href="https://docs.microsoft.com/aspnet/core/tutorials/first-web-api">Tutorial: Create a web API with ASP.NET Core MVC</a> topic with:</p>
 
 <ul>
     <li>An endpoint URI of <code>https://localhost:10000/api/todo</code>.</li>
@@ -13,7 +13,7 @@
     <li>Fetch API credentials of <code>include</code>, which is permitted by the service's CORS Middleware policy with an <code>Authorization</code> header included in the request.</li>
 </ul>
 
-<p>Add the following CORS middleware configuration to the web API's service's <code>Startup.Configure</code> method before it calls <code>UseMvc</code>:</p>
+<p>Add the following CORS middleware configuration to the web API's <code>Startup.Configure</code> method before it calls <code>UseMvc</code>:</p>
 
 <pre><code>app.UseCors(policy =>
     policy.WithOrigins("http://localhost:5000", "https://localhost:5001")
@@ -23,7 +23,7 @@
 
 <p>Adjust the domains and ports of <code>WithOrigins</code> as needed for the Blazor app.</p>
 
-<p>The web API service is configured for CORS to permit authorization cookies/headers and requests from client code, but the service as created by the tutorial doesn't actually authorize requests. See the <a href="https://docs.microsoft.com/aspnet/core/security/">ASP.NET Core Security and Identity articles</a> for implementation guidance.</p>
+<p>The web API is configured for CORS to permit authorization cookies/headers and requests from client code, but the web API as created by the tutorial doesn't actually authorize requests. See the <a href="https://docs.microsoft.com/aspnet/core/security/">ASP.NET Core Security and Identity articles</a> for implementation guidance.</p>
 
 <p>
     <div>URI:</div>

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/JsInteropClasses/ExampleJsInterop.cs
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/JsInteropClasses/ExampleJsInterop.cs
@@ -22,7 +22,7 @@ namespace BlazorSample.JsInteropClasses
             // sayHello is implemented in wwwroot/exampleJsInterop.js
             return _jsRuntime.InvokeAsync<object>(
                 "exampleJsFunctions.sayHello",
-                new DotNetObjectRef(new HelloHelper(name)));
+                DotNetObjectRef.Create(new HelloHelper(name)));
         }
     }
     #endregion

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/Pages/CallWebAPI.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/Pages/CallWebAPI.razor
@@ -1,0 +1,129 @@
+@page "/CallWebAPI"
+@using System.IO
+@using System.Linq
+@using System.Threading.Tasks
+@inject HttpClient Http
+
+<h1>Call a Web API from Blazor</h1>
+
+<h2>Blazor Example</h2>
+
+<p>This example requires a running web API service based on the sample app for the <a href="https://docs.microsoft.com/aspnet/core/tutorials/first-web-api">Tutorial: Create a web API with ASP.NET Core MVC</a> topic. This Blazor sample app makes requests to the web API service at <code>https://localhost:10000/api/todo</code>. If a different service address is used, update the <code>ServiceEndpoint</code> constant value in the Razor component's <code>@@functions</code> block.</p>
+
+<p>The Blazor sample app makes a <a href="https://docs.microsoft.com/aspnet/core/security/cors">cross-origin resource sharing (CORS)</a> request from <code>http://localhost:5000</code> or <code>https://localhost:5001</code> to the web API service app. Add the following CORS middleware configuration to the web API's service's <code>Startup.Configure</code> method before it calls <code>UseMvc</code>:</p>
+
+<pre><code>app.UseCors(policy => 
+    policy.WithOrigins("http://localhost:5000", "https://localhost:5001")
+    .AllowAnyMethod()
+    .WithHeaders(HeaderNames.ContentType));</code></pre>
+
+<p>Adjust the domains and ports of <code>WithOrigins</code> as needed for the Blazor app.</p>
+
+<h3>Todo Items</h3>
+
+@if (_todoItems == null)
+{
+    <p>No Todo Items found.</p>
+}
+else
+{
+    <table class="table">
+        <thead>
+            <tr>
+                <th class="text-center">Complete</th>
+                <th>Name</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr id="editRow" style="display:@_editRowStyle">
+                <td class="text-center">
+                    <input type="checkbox" bind="@_editItem.IsComplete" />
+                </td>
+                <td>
+                    <input type="text" bind="@_editItem.Name" />
+                </td>
+                <td class="text-center">
+                    <button class="btn btn-success" onclick="@(async () => await SaveItem())">Save</button>
+                    <button class="btn btn-danger" onclick="@(() => _editRowStyle = "none")">Cancel</button>
+                </td>
+            </tr>
+            @foreach (var item in _todoItems)
+            {
+                <tr>
+                    <td class="text-center">
+                        @if (item.IsComplete)
+                        {
+                            <span>&#10004;</span>
+                        }
+                    </td>
+                    <td>@item.Name</td>
+                    <td class="text-center">
+                        <button class="btn btn-warning" onclick="@(() => EditItem(item.Id))">Edit</button>
+                        <button class="btn btn-danger" onclick="@(async () => await DeleteItem(item.Id))">Delete</button>
+                    </td>
+                </tr>
+            }
+            <tr id="addRow">
+                <td></td>
+                <td>
+                    <input type="text" bind="@_newItemName" placeholder="New Todo Item" />
+                </td>
+                <td class="text-center">
+                    <button class="btn btn-success" onclick="@(async () => await AddItem())">Add</button>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+}
+
+<HTTPRequestTester />
+
+@functions {
+    private const string ServiceEndpoint = "https://localhost:10000/api/todo";
+    private TodoItem[] _todoItems;
+    private TodoItem _editItem = new TodoItem();
+    private string _editRowStyle = "none";
+    private string _newItemName;
+
+    protected override async Task OnInitAsync() => await GetTodoItems();
+
+    private async Task GetTodoItems() => _todoItems = await Http.GetJsonAsync<TodoItem[]>(ServiceEndpoint);
+
+    private void EditItem(long id)
+    {
+        var editItem = _todoItems.Single(i => i.Id == id);
+        _editItem = new TodoItem { Id = editItem.Id, Name = editItem.Name, IsComplete = editItem.IsComplete };
+        _editRowStyle = "table-row";
+    }
+
+    private async Task AddItem()
+    {
+        var addItem = new TodoItem { Name = _newItemName, IsComplete = false };
+        await Http.PostJsonAsync(ServiceEndpoint, addItem);
+        _newItemName = string.Empty;
+        await GetTodoItems();
+        _editRowStyle = "none";
+    }
+
+    private async Task SaveItem()
+    {
+        await Http.PutJsonAsync(Path.Combine(ServiceEndpoint, _editItem.Id.ToString()), _editItem);
+        await GetTodoItems();
+        _editRowStyle = "none";
+    }
+
+    private async Task DeleteItem(long id)
+    {
+        await Http.DeleteAsync(Path.Combine(ServiceEndpoint, id.ToString()));
+        await GetTodoItems();
+        _editRowStyle = "none";
+    }
+
+    private class TodoItem
+    {
+        public long Id { get; set; }
+        public string Name { get; set; }
+        public bool IsComplete { get; set; }
+    }
+}

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/Pages/CallWebAPI.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/Pages/CallWebAPI.razor
@@ -5,7 +5,7 @@
 
 <h2>Blazor Example</h2>
 
-<p>This example requires a running web API service based on the sample app for the <a href="https://docs.microsoft.com/aspnet/core/tutorials/first-web-api">Tutorial: Create a web API with ASP.NET Core MVC</a> topic. This Blazor sample app makes requests to the web API service at <code>https://localhost:10000/api/todo</code>. If a different service address is used, update the <code>ServiceEndpoint</code> constant value in the Razor component's <code>@@code</code> block.</p>
+<p>This example requires a running web API based on the sample app for the <a href="https://docs.microsoft.com/aspnet/core/tutorials/first-web-api">Tutorial: Create a web API with ASP.NET Core MVC</a> topic. This Blazor sample app makes requests to the web API at <code>https://localhost:10000/api/todo</code>. If a different web API address is used, update the <code>ServiceEndpoint</code> constant value in the Razor component's <code>@@code</code> block.</p>
 
 <p>The Blazor sample app makes a <a href="https://docs.microsoft.com/aspnet/core/security/cors">cross-origin resource sharing (CORS)</a> request from <code>http://localhost:5000</code> or <code>https://localhost:5001</code> to the web API service app. Add the following CORS middleware configuration to the web API's service's <code>Startup.Configure</code> method before it calls <code>UseMvc</code>:</p>
 

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/Pages/CallWebAPI.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/Pages/CallWebAPI.razor
@@ -1,14 +1,11 @@
 @page "/CallWebAPI"
-@using System.IO
-@using System.Linq
-@using System.Threading.Tasks
 @inject HttpClient Http
 
 <h1>Call a Web API from Blazor</h1>
 
 <h2>Blazor Example</h2>
 
-<p>This example requires a running web API service based on the sample app for the <a href="https://docs.microsoft.com/aspnet/core/tutorials/first-web-api">Tutorial: Create a web API with ASP.NET Core MVC</a> topic. This Blazor sample app makes requests to the web API service at <code>https://localhost:10000/api/todo</code>. If a different service address is used, update the <code>ServiceEndpoint</code> constant value in the Razor component's <code>@@functions</code> block.</p>
+<p>This example requires a running web API service based on the sample app for the <a href="https://docs.microsoft.com/aspnet/core/tutorials/first-web-api">Tutorial: Create a web API with ASP.NET Core MVC</a> topic. This Blazor sample app makes requests to the web API service at <code>https://localhost:10000/api/todo</code>. If a different service address is used, update the <code>ServiceEndpoint</code> constant value in the Razor component's <code>@@code</code> block.</p>
 
 <p>The Blazor sample app makes a <a href="https://docs.microsoft.com/aspnet/core/security/cors">cross-origin resource sharing (CORS)</a> request from <code>http://localhost:5000</code> or <code>https://localhost:5001</code> to the web API service app. Add the following CORS middleware configuration to the web API's service's <code>Startup.Configure</code> method before it calls <code>UseMvc</code>:</p>
 
@@ -38,14 +35,14 @@ else
         <tbody>
             <tr id="editRow" style="display:@_editRowStyle">
                 <td class="text-center">
-                    <input type="checkbox" bind="@_editItem.IsComplete" />
+                    <input type="checkbox" @bind="_editItem.IsComplete" />
                 </td>
                 <td>
-                    <input type="text" bind="@_editItem.Name" />
+                    <input @bind="_editItem.Name" />
                 </td>
                 <td class="text-center">
-                    <button class="btn btn-success" onclick="@(async () => await SaveItem())">Save</button>
-                    <button class="btn btn-danger" onclick="@(() => _editRowStyle = "none")">Cancel</button>
+                    <button class="btn btn-success" @onclick="@SaveItem">Save</button>
+                    <button class="btn btn-danger" @onclick="@(() => _editRowStyle = "none")">Cancel</button>
                 </td>
             </tr>
             @foreach (var item in _todoItems)
@@ -59,18 +56,18 @@ else
                     </td>
                     <td>@item.Name</td>
                     <td class="text-center">
-                        <button class="btn btn-warning" onclick="@(() => EditItem(item.Id))">Edit</button>
-                        <button class="btn btn-danger" onclick="@(async () => await DeleteItem(item.Id))">Delete</button>
+                        <button class="btn btn-warning" @onclick="@(() => EditItem(item.Id))">Edit</button>
+                        <button class="btn btn-danger" @onclick="@(async () => await DeleteItem(item.Id))">Delete</button>
                     </td>
                 </tr>
             }
             <tr id="addRow">
                 <td></td>
                 <td>
-                    <input type="text" bind="@_newItemName" placeholder="New Todo Item" />
+                    <input @bind="_newItemName" placeholder="New Todo Item" />
                 </td>
                 <td class="text-center">
-                    <button class="btn btn-success" onclick="@(async () => await AddItem())">Add</button>
+                    <button class="btn btn-success" @onclick="@AddItem">Add</button>
                 </td>
             </tr>
         </tbody>
@@ -79,7 +76,7 @@ else
 
 <HTTPRequestTester />
 
-@functions {
+@code {
     private const string ServiceEndpoint = "https://localhost:10000/api/todo";
     private TodoItem[] _todoItems;
     private TodoItem _editItem = new TodoItem();
@@ -108,14 +105,14 @@ else
 
     private async Task SaveItem()
     {
-        await Http.PutJsonAsync(Path.Combine(ServiceEndpoint, _editItem.Id.ToString()), _editItem);
+        await Http.PutJsonAsync($"{ServiceEndpoint}/{_editItem.Id}", _editItem);
         await GetTodoItems();
         _editRowStyle = "none";
     }
 
     private async Task DeleteItem(long id)
     {
-        await Http.DeleteAsync(Path.Combine(ServiceEndpoint, id.ToString()));
+        await Http.DeleteAsync($"{ServiceEndpoint}/{id}");
         await GetTodoItems();
         _editRowStyle = "none";
     }

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/README.md
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/README.md
@@ -1,3 +1,21 @@
 # Blazor (client-side) Sample App
 
 This sample illustrates the use of Blazor scenarios described in the Blazor documentation.
+
+## Call web API example
+
+The web API example requires a running web API service based on the sample app for the <a href="https://docs.microsoft.com/aspnet/core/tutorials/first-web-api">Tutorial: Create a web API with ASP.NET Core MVC</a> topic. The sample app makes requests to the web API service at `https://localhost:10000/api/todo`. If a different service address is used, update the `ServiceEndpoint` constant value in the Razor component's `@functions` block.</p>
+
+The sample app makes a <a href="https://docs.microsoft.com/aspnet/core/security/cors">cross-origin resource sharing (CORS)</a> request from `http://localhost:5000` or `https://localhost:5001` to the web API service app. Credentials (authorization cookies/headers) are permitted. Add the following CORS middleware configuration to the web API service's `Startup.Configure` method before it calls `UseMvc`:</p>
+
+```csharp
+app.UseCors(policy => 
+    policy.WithOrigins("http://localhost:5000", "https://localhost:5001")
+    .AllowAnyMethod()
+    .WithHeaders(HeaderNames.ContentType, HeaderNames.Authorization)
+    .AllowCredentials());
+```
+
+Adjust the domains and ports of `WithOrigins` as needed for the Blazor app.
+
+The web API service is configured for CORS to permit authorization cookies/headers and requests from client code, but the service as created by the tutorial doesn't actually authorize requests. See the <a href="https://docs.microsoft.com/aspnet/core/security/">ASP.NET Core Security and Identity articles</a> for implementation guidance.

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/README.md
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/README.md
@@ -4,9 +4,9 @@ This sample illustrates the use of Blazor scenarios described in the Blazor docu
 
 ## Call web API example
 
-The web API example requires a running web API service based on the sample app for the <a href="https://docs.microsoft.com/aspnet/core/tutorials/first-web-api">Tutorial: Create a web API with ASP.NET Core MVC</a> topic. The sample app makes requests to the web API service at `https://localhost:10000/api/todo`. If a different service address is used, update the `ServiceEndpoint` constant value in the Razor component's `@functions` block.</p>
+The web API example requires a running web API based on the sample app for the <a href="https://docs.microsoft.com/aspnet/core/tutorials/first-web-api">Tutorial: Create a web API with ASP.NET Core MVC</a> topic. The sample app makes requests to the web API at `https://localhost:10000/api/todo`. If a different web API address is used, update the `ServiceEndpoint` constant value in the Razor component's `@functions` block.</p>
 
-The sample app makes a <a href="https://docs.microsoft.com/aspnet/core/security/cors">cross-origin resource sharing (CORS)</a> request from `http://localhost:5000` or `https://localhost:5001` to the web API service app. Credentials (authorization cookies/headers) are permitted. Add the following CORS middleware configuration to the web API service's `Startup.Configure` method before it calls `UseMvc`:</p>
+The sample app makes a <a href="https://docs.microsoft.com/aspnet/core/security/cors">cross-origin resource sharing (CORS)</a> request from `http://localhost:5000` or `https://localhost:5001` to the web API. Credentials (authorization cookies/headers) are permitted. Add the following CORS middleware configuration to the web API's `Startup.Configure` method before it calls `UseMvc`:</p>
 
 ```csharp
 app.UseCors(policy => 
@@ -18,4 +18,4 @@ app.UseCors(policy =>
 
 Adjust the domains and ports of `WithOrigins` as needed for the Blazor app.
 
-The web API service is configured for CORS to permit authorization cookies/headers and requests from client code, but the service as created by the tutorial doesn't actually authorize requests. See the <a href="https://docs.microsoft.com/aspnet/core/security/">ASP.NET Core Security and Identity articles</a> for implementation guidance.
+The web API is configured for CORS to permit authorization cookies/headers and requests from client code, but the web API as created by the tutorial doesn't actually authorize requests. See the <a href="https://docs.microsoft.com/aspnet/core/security/">ASP.NET Core Security and Identity articles</a> for implementation guidance.

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/Shared/NavMenu.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/Shared/NavMenu.razor
@@ -64,6 +64,11 @@
                 <span class="oi oi-plus" aria-hidden="true"></span> JavaScript Interop
             </NavLink>
         </li>
+        <li class="nav-item px-3">
+            <NavLink class="nav-link" href="CallWebAPI">
+                <span class="oi oi-plus" aria-hidden="true"></span> Call a Web API
+            </NavLink>
+        </li>
     </ul>
 </div>
 

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/wwwroot/css/site.css
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/wwwroot/css/site.css
@@ -4,6 +4,11 @@ html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
+textarea {
+    width: 100%;
+    height: 60px;
+}
+
 app {
     position: relative;
     display: flex;
@@ -153,6 +158,22 @@ app {
 .nav-tabs-body {
     border: 1px solid #dee2e6;
     border-top-width: 0;
+}
+
+.table td {
+    vertical-align: middle;
+}
+
+.table input {
+    width: 100%;
+}
+
+.table #editRow {
+    background-color: lightyellow;
+}
+
+.table #addRow {
+    background-color: palegreen;
 }
 
 @media (max-width: 767.98px) {

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/wwwroot/css/site.css
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/wwwroot/css/site.css
@@ -89,6 +89,18 @@ app {
     background-color: rgba(255, 255, 255, 0.1);
 }
 
+.valid.modified:not([type=checkbox]) {
+    outline: 1px solid #26b050;
+}
+
+.invalid {
+    outline: 1px solid red;
+}
+
+.validation-message {
+    color: red;
+}
+
 .panel {
     margin-bottom: 20px;
     border: 1px solid transparent;

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -299,6 +299,8 @@
           uid: blazor/javascript-interop
         - name: Debug
           uid: blazor/debug
+        - name: Call a web API
+          uid: blazor/call-web-api
         - name: Host and deploy
           items:
             - name: Overview


### PR DESCRIPTION
Fixes #10743

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/call-web-api?view=aspnetcore-3.0&branch=pr-en-us-12477)

* Not crazy about the title, but we can work on that.
* The sample app component (*Pages/CallWebAPI.razor*) is built in concert with our [web API tutorial](https://docs.microsoft.com/aspnet/core/tutorials/first-web-api). The examples in the topic and the sample app code are set up for a happy path by merely running the web API tutorial app and then running the code in the topic or the Razor component in sample against that service.
* I'm mostly concerned about the *HttpClient and HttpRequestMessage with Fetch API request options* section. It's the most challenging bit to organize and explain ... *lot's 'o concepts* there ... and there are probably *more concepts* to add.
* This 1st draft is *client-side-y* in nature. `There is no registered service of type 'System.Net.Http.HttpClient'.` ... I see what you mean on the engineering issue. Will take ur advice ... `IHttpClientFactory` for server-side.