### PR TITLE
Close void elements in Razor components

### DIFF
--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -5,7 +5,7 @@ description: Learn how to create and use Razor components, including how to bind
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/10/2019
+ms.date: 05/21/2019
 uid: blazor/components
 ---
 # Create and use Razor components
@@ -110,18 +110,18 @@ Data binding to both components and DOM elements is accomplished with the `bind`
 
 ```cshtml
 <input type="checkbox" class="form-check-input" id="italicsCheck" 
-    bind="@_italicsCheck">
+    bind="@_italicsCheck" />
 ```
 
 When the check box is selected and cleared, the property's value is updated to `true` and `false`, respectively.
 
 The check box is updated in the UI only when the component is rendered, not in response to changing the property's value. Since components render themselves after event handler code executes, property updates are usually reflected in the UI immediately.
 
-Using `bind` with a `CurrentValue` property (`<input bind="@CurrentValue">`) is essentially equivalent to the following:
+Using `bind` with a `CurrentValue` property (`<input bind="@CurrentValue" />`) is essentially equivalent to the following:
 
 ```cshtml
 <input value="@CurrentValue" 
-    onchange="@((UIChangeEventArgs __e) => CurrentValue = __e.Value)">
+    onchange="@((UIChangeEventArgs __e) => CurrentValue = __e.Value)" />
 ```
 
 When the component is rendered, the `value` of the input element comes from the `CurrentValue` property. When the user types in the text box, the `onchange` event is fired and the `CurrentValue` property is set to the changed value. In reality, the code generation is a little more complex because `bind` handles a few cases where type conversions are performed. In principle, `bind` associates the current value of an expression with a `value` attribute and handles changes using the registered handler.
@@ -129,7 +129,7 @@ When the component is rendered, the `value` of the input element comes from the 
 In addition to `onchange`, the property can be bound using other events like `oninput` by being more explicit about what to bind to:
 
 ```cshtml
-<input type="text" bind-value-oninput="@CurrentValue">
+<input type="text" bind-value-oninput="@CurrentValue" />
 ```
 
 Unlike `onchange`, `oninput` fires for every character that is input into the text box.
@@ -139,7 +139,7 @@ Unlike `onchange`, `oninput` fires for every character that is input into the te
 Data binding works with <xref:System.DateTime> format strings. Other format expressions, such as currency or number formats, aren't available at this time.
 
 ```cshtml
-<input bind="@StartDate" format-value="yyyy-MM-dd">
+<input bind="@StartDate" format-value="yyyy-MM-dd" />
 
 @functions {
     [Parameter]
@@ -255,7 +255,7 @@ The following code calls the `UpdateHeading` method when the button is selected 
 The following code calls the `CheckboxChanged` method when the check box is changed in the UI:
 
 ```cshtml
-<input type="checkbox" class="form-check-input" onchange="@CheckboxChanged">
+<input type="checkbox" class="form-check-input" onchange="@CheckboxChanged" />
 
 @functions {
     private void CheckboxChanged()
@@ -580,7 +580,7 @@ Attributes are conditionally rendered based on the .NET value. If the value is `
 In the following example, `IsCompleted` determines if `checked` is rendered in the control's markup:
 
 ```cshtml
-<input type="checkbox" checked="@IsCompleted">
+<input type="checkbox" checked="@IsCompleted" />
 
 @functions {
     [Parameter]
@@ -591,13 +591,13 @@ In the following example, `IsCompleted` determines if `checked` is rendered in t
 If `IsCompleted` is `true`, the check box is rendered as:
 
 ```html
-<input type="checkbox" checked>
+<input type="checkbox" checked />
 ```
 
 If `IsCompleted` is `false`, the check box is rendered as:
 
 ```html
-<input type="checkbox">
+<input type="checkbox" />
 ```
 
 **Additional information on Razor**

--- a/aspnetcore/blazor/javascript-interop.md
+++ b/aspnetcore/blazor/javascript-interop.md
@@ -5,7 +5,7 @@ description: Learn how to invoke JavaScript functions from .NET and .NET methods
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/13/2019
+ms.date: 05/21/2019
 uid: blazor/javascript-interop
 ---
 # Blazor JavaScript interop
@@ -117,7 +117,7 @@ You can capture references to HTML elements in a component using the following a
 The following example shows capturing a reference to the `username` `<input>` element:
 
 ```cshtml
-<input ref="username" ...>
+<input ref="username" ... />
 
 @functions {
     ElementRef username;


### PR DESCRIPTION
Fixes #12481 

Engineering resolved unclosed void elements on https://github.com/aspnet/Mvc/pull/2956.

Docs have moved in that direction (for example, [Unclosed void elements in topics (aspnet/AspNetCore.Docs #11881](https://github.com/aspnet/AspNetCore.Docs/pull/11881)).

Is this a point-in-time problem for Blazor, or will they always require closure?

btw - There are two spots where `<base>` tags are still unclosed. I think those don't suffer from this issue; but if I'm incorrect, I can add those two on another commit here before we merge this. :ear: