### PR TITLE
Clarify location and name of the MvcMovieContext

### DIFF
--- a/aspnetcore/includes/mvc-intro/model2.md
+++ b/aspnetcore/includes/mvc-intro/model2.md
@@ -1,6 +1,6 @@
 <a name="dc"></a>
-
-Add the following `MvcMovieContext` class to the *Models* folder:  
+* Add a new folder named *Data* 
+* Add the following `MvcMovieContext` class in *Data/MvcMovieContext.cs*:
 
 [!code-csharp[](~/tutorials/first-mvc-app/start-mvc/sample/MvcMovie22/Data/MvcMovieContext.cs)]
 


### PR DESCRIPTION
The build for the migrations fails when following the original instructions to place the MvcMovieContext.cs file in the Models directory. Further down the in the documentation it specifies that this file is expected in the Data directory.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->