### PR TITLE
JavaScript Services topic updates

### DIFF
--- a/aspnetcore/client-side/spa-services.md
+++ b/aspnetcore/client-side/spa-services.md
@@ -1,32 +1,29 @@
 ---
-title: Use JavaScriptServices to Create Single Page Applications in ASP.NET Core
+title: Use JavaScript Services to Create Single Page Applications in ASP.NET Core
 author: scottaddie
-description: Learn about the benefits of using JavaScriptServices to create a Single Page Application (SPA) backed by ASP.NET Core.
+description: Learn about the benefits of using JavaScript Services to create a Single Page Application (SPA) backed by ASP.NET Core.
+monikerRange: '>= aspnetcore-2.1'
 ms.author: scaddie
 ms.custom: H1Hack27Feb2017
-ms.date: 08/02/2017
+ms.date: 05/28/2019
 uid: client-side/spa-services
 ---
-
-# Use JavaScriptServices to Create Single Page Applications in ASP.NET Core
+# Use JavaScript Services to Create Single Page Applications in ASP.NET Core
 
 By [Scott Addie](https://github.com/scottaddie) and [Fiyaz Hasan](http://fiyazhasan.me/)
 
-A Single Page Application (SPA) is a popular type of web application due to its inherent rich user experience. Integrating client-side SPA frameworks or libraries, such as [Angular](https://angular.io/) or [React](https://facebook.github.io/react/), with server-side frameworks like ASP.NET Core can be difficult. [JavaScriptServices](https://github.com/aspnet/JavaScriptServices) was developed to reduce friction in the integration process. It enables seamless operation between the different client and server technology stacks.
+A Single Page Application (SPA) is a popular type of web application due to its inherent rich user experience. Integrating client-side SPA frameworks or libraries, such as [Angular](https://angular.io/) or [React](https://facebook.github.io/react/), with server-side frameworks such as ASP.NET Core can be difficult. JavaScript Services was developed to reduce friction in the integration process. It enables seamless operation between the different client and server technology stacks.
 
-<a name="what-is-js-services"></a>
+## What is JavaScript Services
 
-## What is JavaScriptServices
+JavaScript Services is a collection of client-side technologies for ASP.NET Core. Its goal is to position ASP.NET Core as developers' preferred server-side platform for building SPAs.
 
-JavaScriptServices is a collection of client-side technologies for ASP.NET Core. Its goal is to position ASP.NET Core as developers' preferred server-side platform for building SPAs.
-
-JavaScriptServices consists of three distinct NuGet packages:
+JavaScript Services consists of three distinct NuGet packages:
 
 * [Microsoft.AspNetCore.NodeServices](https://www.nuget.org/packages/Microsoft.AspNetCore.NodeServices/) (NodeServices)
 * [Microsoft.AspNetCore.SpaServices](https://www.nuget.org/packages/Microsoft.AspNetCore.SpaServices/) (SpaServices)
-* [Microsoft.AspNetCore.SpaTemplates](https://www.nuget.org/packages/Microsoft.AspNetCore.SpaTemplates/) (SpaTemplates)
 
-These packages are useful if you:
+These packages are useful in the following scenarios:
 
 * Run JavaScript on the server
 * Use a SPA framework or library
@@ -34,43 +31,38 @@ These packages are useful if you:
 
 Much of the focus in this article is placed on using the SpaServices package.
 
-<a name="what-is-spa-services"></a>
-
 ## What is SpaServices
 
-SpaServices was created to position ASP.NET Core as developers' preferred server-side platform for building SPAs. SpaServices isn't required to develop SPAs with ASP.NET Core, and it doesn't lock you into a particular client framework.
+SpaServices was created to position ASP.NET Core as developers' preferred server-side platform for building SPAs. SpaServices isn't required to develop SPAs with ASP.NET Core, and it doesn't lock developers into a particular client framework.
 
 SpaServices provides useful infrastructure such as:
 
-* [Server-side prerendering](#server-prerendering)
+* [Server-side prerendering](#server-side-prerendering)
 * [Webpack Dev Middleware](#webpack-dev-middleware)
 * [Hot Module Replacement](#hot-module-replacement)
 * [Routing helpers](#routing-helpers)
 
 Collectively, these infrastructure components enhance both the development workflow and the runtime experience. The components can be adopted individually.
 
-<a name="spa-services-prereqs"></a>
-
 ## Prerequisites for using SpaServices
 
 To work with SpaServices, install the following:
 
 * [Node.js](https://nodejs.org/) (version 6 or later) with npm
+
   * To verify these components are installed and can be found, run the following from the command line:
 
     ```console
     node -v && npm -v
     ```
 
-Note: If you're deploying to an Azure web site, you don't need to do anything here &mdash; Node.js is installed and available in the server environments.
+  * If deploying to an Azure web site, no action is required&mdash;Node.js is installed and available in the server environments.
 
 * [!INCLUDE [](~/includes/net-core-sdk-download-link.md)]
 
-  * If you're on Windows using Visual Studio 2017, the SDK is installed by selecting the **.NET Core cross-platform development** workload.
+  * On Windows using Visual Studio 2017, the SDK is installed by selecting the **.NET Core cross-platform development** workload.
 
 * [Microsoft.AspNetCore.SpaServices](https://www.nuget.org/packages/Microsoft.AspNetCore.SpaServices/) NuGet package
-
-<a name="server-prerendering"></a>
 
 ## Server-side prerendering
 
@@ -78,17 +70,15 @@ A universal (also known as isomorphic) application is a JavaScript application c
 
 ASP.NET Core [Tag Helpers](xref:mvc/views/tag-helpers/intro) provided by SpaServices simplify the implementation of server-side prerendering by invoking the JavaScript functions on the server.
 
-### Prerequisites
+### Server-side prerendering prerequisites
 
-Install the following:
+Install the [aspnet-prerendering](https://www.npmjs.com/package/aspnet-prerendering) npm package:
 
-* [aspnet-prerendering](https://www.npmjs.com/package/aspnet-prerendering) npm package:
+```console
+npm i -S aspnet-prerendering
+```
 
-    ```console
-    npm i -S aspnet-prerendering
-    ```
-
-### Configuration
+### Server-side prerendering configuration
 
 The Tag Helpers are made discoverable via namespace registration in the project's *_ViewImports.cshtml* file:
 
@@ -98,7 +88,7 @@ These Tag Helpers abstract away the intricacies of communicating directly with l
 
 [!code-cshtml[](../client-side/spa-services/sample/SpaServicesSampleApp/Views/Home/Index.cshtml?range=5)]
 
-### The `asp-prerender-module` Tag Helper
+### asp-prerender-module Tag Helper
 
 The `asp-prerender-module` Tag Helper, used in the preceding code example, executes *ClientApp/dist/main-server.js* on the server via Node.js. For clarity's sake, *main-server.js* file is an artifact of the TypeScript-to-JavaScript transpilation task in the [Webpack](http://webpack.github.io/) build process. Webpack defines an entry point alias of `main-server`; and, traversal of the dependency graph for this alias begins at the *ClientApp/boot-server.ts* file:
 
@@ -108,7 +98,7 @@ In the following Angular example, the *ClientApp/boot-server.ts* file utilizes t
 
 [!code-typescript[](../client-side/spa-services/sample/SpaServicesSampleApp/ClientApp/boot-server.ts?range=6,10-34,79-)]
 
-### The `asp-prerender-data` Tag Helper
+### asp-prerender-data Tag Helper
 
 When coupled with the `asp-prerender-module` Tag Helper, the `asp-prerender-data` Tag Helper can be used to pass contextual information from the Razor view to the server-side JavaScript. For example, the following markup passes user data to the `main-server` module:
 
@@ -118,7 +108,7 @@ The received `UserName` argument is serialized using the built-in JSON serialize
 
 [!code-typescript[](../client-side/spa-services/sample/SpaServicesSampleApp/ClientApp/boot-server.ts?range=6,10-21,38-52,79-)]
 
-Note: Property names passed in Tag Helpers are represented with **PascalCase** notation. Contrast that to JavaScript, where the same property names are represented with **camelCase**. The default JSON serialization configuration is responsible for this difference.
+Property names passed in Tag Helpers are represented with **PascalCase** notation. Contrast that to JavaScript, where the same property names are represented with **camelCase**. The default JSON serialization configuration is responsible for this difference.
 
 To expand upon the preceding code example, data can be passed from the server to the view by hydrating the `globals` property provided to the `resolve` function:
 
@@ -128,8 +118,6 @@ The `postList` array defined inside the `globals` object is attached to the brow
 
 ![global postList variable attached to window object](spa-services/_static/global_variable.png)
 
-<a name="webpack-dev-middleware"></a>
-
 ## Webpack Dev Middleware
 
 [Webpack Dev Middleware](https://webpack.github.io/docs/webpack-dev-middleware.html) introduces a streamlined development workflow whereby Webpack builds resources on demand. The middleware automatically compiles and serves client-side resources when a page is reloaded in the browser. The alternate approach is to manually invoke Webpack via the project's npm build script when a third-party dependency or the custom code changes. An npm build script in the *package.json* file is shown in the following example:
@@ -138,17 +126,15 @@ The `postList` array defined inside the `globals` object is attached to the brow
 "build": "npm run build:vendor && npm run build:custom",
 ```
 
-### Prerequisites
+### Webpack Dev Middleware prerequisites
 
-Install the following:
+Install the [aspnet-webpack](https://www.npmjs.com/package/aspnet-webpack) npm package:
 
-* [aspnet-webpack](https://www.npmjs.com/package/aspnet-webpack) npm package:
+```console
+npm i -D aspnet-webpack
+```
 
-    ```console
-    npm i -D aspnet-webpack
-    ```
-
-### Configuration
+### Webpack Dev Middleware configuration
 
 Webpack Dev Middleware is registered into the HTTP request pipeline via the following code in the *Startup.cs* file's `Configure` method:
 
@@ -160,23 +146,19 @@ The *webpack.config.js* file's `output.publicPath` property tells the middleware
 
 [!code-javascript[](../client-side/spa-services/sample/SpaServicesSampleApp/webpack.config.js?range=6,13-16)]
 
-<a name="hot-module-replacement"></a>
-
 ## Hot Module Replacement
 
 Think of Webpack's [Hot Module Replacement](https://webpack.js.org/concepts/hot-module-replacement/) (HMR) feature as an evolution of [Webpack Dev Middleware](#webpack-dev-middleware). HMR introduces all the same benefits, but it further streamlines the development workflow by automatically updating page content after compiling the changes. Don't confuse this with a refresh of the browser, which would interfere with the current in-memory state and debugging session of the SPA. There's a live link between the Webpack Dev Middleware service and the browser, which means changes are pushed to the browser.
 
-### Prerequisites
+### Hot Module Replacement prerequisites
 
-Install the following:
+Install the [webpack-hot-middleware](https://www.npmjs.com/package/webpack-hot-middleware) npm package:
 
-* [webpack-hot-middleware](https://www.npmjs.com/package/webpack-hot-middleware) npm package:
+```console
+npm i -D webpack-hot-middleware
+```
 
-    ```console
-    npm i -D webpack-hot-middleware
-    ```
-
-### Configuration
+### Hot Module Replacement configuration
 
 The HMR component must be registered into MVC's HTTP request pipeline in the `Configure` method:
 
@@ -196,37 +178,31 @@ After loading the app in the browser, the developer tools' Console tab provides 
 
 ![Hot Module Replacement connected message](spa-services/_static/hmr_connected.png)
 
-<a name="routing-helpers"></a>
-
 ## Routing helpers
 
-In most ASP.NET Core-based SPAs, you'll want client-side routing in addition to server-side routing. The SPA and MVC routing systems can work independently without interference. There's, however, one edge case posing challenges: identifying 404 HTTP responses.
+In most ASP.NET Core-based SPAs, client-side routing is often desired in addition to server-side routing. The SPA and MVC routing systems can work independently without interference. There's, however, one edge case posing challenges: identifying 404 HTTP responses.
 
-Consider the scenario in which an extensionless route of `/some/page` is used. Assume the request doesn't pattern-match a server-side route, but its pattern does match a client-side route. Now consider an incoming request for `/images/user-512.png`, which generally expects to find an image file on the server. If that requested resource path doesn't match any server-side route or static file, it's unlikely that the client-side application would handle it — you generally want to return a 404 HTTP status code.
+Consider the scenario in which an extensionless route of `/some/page` is used. Assume the request doesn't pattern-match a server-side route, but its pattern does match a client-side route. Now consider an incoming request for `/images/user-512.png`, which generally expects to find an image file on the server. If that requested resource path doesn't match any server-side route or static file, it's unlikely that the client-side application would handle it&mdash;generally returning a 404 HTTP status code is desired.
 
-### Prerequisites
+### Routing helpers prerequisites
 
-Install the following:
+Install the client-side routing npm package. Using Angular as an example:
 
-* The client-side routing npm package. Using Angular as an example:
+```console
+npm i -S @angular/router
+```
 
-    ```console
-    npm i -S @angular/router
-    ```
-
-### Configuration
+### Routing helpers configuration
 
 An extension method named `MapSpaFallbackRoute` is used in the `Configure` method:
 
 [!code-csharp[](../client-side/spa-services/sample/SpaServicesSampleApp/Startup.cs?name=snippet_MvcRoutingTable&highlight=7-9)]
 
-Tip: Routes are evaluated in the order in which they're configured. Consequently, the `default` route in the preceding code example is used first for pattern matching.
+Routes are evaluated in the order in which they're configured. Consequently, the `default` route in the preceding code example is used first for pattern matching.
 
-<a name="new-project-creation"></a>
+## Create a new project
 
-## Creating a new project
-
-JavaScriptServices provides pre-configured application templates. SpaServices is used in these templates, in conjunction with different frameworks and libraries such as Angular, React, and Redux.
+JavaScript Services provide pre-configured application templates. SpaServices is used in these templates in conjunction with different frameworks and libraries such as Angular, React, and Redux.
 
 These templates can be installed via the .NET Core CLI by running the following command:
 
@@ -237,7 +213,7 @@ dotnet new --install Microsoft.AspNetCore.SpaTemplates::*
 A list of available SPA templates is displayed:
 
 | Templates                                 | Short Name | Language | Tags        |
-|:------------------------------------------|:-----------|:---------|:------------|
+| ------------------------------------------| :--------: | :------: | :---------: |
 | MVC ASP.NET Core with Angular             | angular    | [C#]     | Web/MVC/SPA |
 | MVC ASP.NET Core with React.js            | react      | [C#]     | Web/MVC/SPA |
 | MVC ASP.NET Core with React.js and Redux  | reactredux | [C#]     | Web/MVC/SPA |
@@ -248,8 +224,6 @@ To create a new project using one of the SPA templates, include the **Short Name
 dotnet new angular
 ```
 
-<a name="runtime-config-mode"></a>
-
 ### Set the runtime configuration mode
 
 Two primary runtime configuration modes exist:
@@ -259,11 +233,11 @@ Two primary runtime configuration modes exist:
   * Doesn't optimize the client-side code for performance.
 * **Production**:
   * Excludes source maps.
-  * Optimizes the client-side code via bundling & minification.
+  * Optimizes the client-side code via bundling and minification.
 
-ASP.NET Core uses an environment variable named `ASPNETCORE_ENVIRONMENT` to store the configuration mode. See **[Set the environment](xref:fundamentals/environments#set-the-environment)** for more information.
+ASP.NET Core uses an environment variable named `ASPNETCORE_ENVIRONMENT` to store the configuration mode. For more information, see [Set the environment](xref:fundamentals/environments#set-the-environment).
 
-### Running with .NET Core CLI
+### Run with .NET Core CLI
 
 Restore the required NuGet and npm packages by running the following command at the project root:
 
@@ -277,15 +251,13 @@ Build and run the application:
 dotnet run
 ```
 
-The application starts on localhost according to the [runtime configuration mode](#runtime-config-mode). Navigating to `http://localhost:5000` in the browser displays the landing page.
+The application starts on localhost according to the [runtime configuration mode](#set-the-runtime-configuration-mode). Navigating to `http://localhost:5000` in the browser displays the landing page.
 
-### Running with Visual Studio 2017
+### Run with Visual Studio 2017
 
-Open the *.csproj* file generated by the [dotnet new](/dotnet/core/tools/dotnet-new) command. The required NuGet and npm packages are restored automatically upon project open. This restoration process may take up to a few minutes, and the application is ready to run when it completes. Click the green run button or press `Ctrl + F5`, and the browser opens to the application's landing page. The application runs on localhost according to the [runtime configuration mode](#runtime-config-mode).
+Open the *.csproj* file generated by the [dotnet new](/dotnet/core/tools/dotnet-new) command. The required NuGet and npm packages are restored automatically upon project open. This restoration process may take up to a few minutes, and the application is ready to run when it completes. Click the green run button or press `Ctrl + F5`, and the browser opens to the application's landing page. The application runs on localhost according to the [runtime configuration mode](#set-the-runtime-configuration-mode).
 
-<a name="app-testing"></a>
-
-## Testing the app
+## Test the app
 
 SpaServices templates are pre-configured to run client-side tests using [Karma](https://karma-runner.github.io/1.0/index.html) and [Jasmine](https://jasmine.github.io/). Jasmine is a popular unit testing framework for JavaScript, whereas Karma is a test runner for those tests. Karma is configured to work with the [Webpack Dev Middleware](#webpack-dev-middleware) such that the developer isn't required to stop and run the test every time changes are made. Whether it's the code running against the test case or the test case itself, the test runs automatically.
 
@@ -303,9 +275,7 @@ The script launches the Karma test runner, which reads the settings defined in t
 
 [!code-javascript[](../client-side/spa-services/sample/SpaServicesSampleApp/ClientApp/test/karma.conf.js?range=4-5,8-11)]
 
-<a name="app-publishing"></a>
-
-## Publishing the application
+## Publish the app
 
 Combining the generated client-side assets and the published ASP.NET Core artifacts into a ready-to-deploy package can be cumbersome. Thankfully, SpaServices orchestrates that entire publication process with a custom MSBuild target named `RunWebpack`:
 
@@ -313,10 +283,10 @@ Combining the generated client-side assets and the published ASP.NET Core artifa
 
 The MSBuild target has the following responsibilities:
 
-1. Restore the npm packages
-1. Create a production-grade build of the third-party, client-side assets
-1. Create a production-grade build of the custom client-side assets
-1. Copy the Webpack-generated assets to the publish folder
+1. Restore the npm packages.
+1. Create a production-grade build of the third-party, client-side assets.
+1. Create a production-grade build of the custom client-side assets.
+1. Copy the Webpack-generated assets to the publish folder.
 
 The MSBuild target is invoked when running:
 

--- a/aspnetcore/release-notes/aspnetcore-2.0.md
+++ b/aspnetcore/release-notes/aspnetcore-2.0.md
@@ -3,7 +3,8 @@ title: What's new in ASP.NET Core 2.0
 author: rick-anderson
 description: Learn about the new features in ASP.NET Core 2.0.
 ms.author: riande
-ms.date: 07/10/2017
+ms.custom: mvc
+ms.date: 05/28/2019
 uid: aspnetcore-2.0
 ---
 
@@ -71,7 +72,7 @@ For more information on authentication changes in 2.0, see the following resourc
 
 ## SPA templates
 
-Single Page Application (SPA) project templates for Angular, Aurelia, Knockout.js, React.js, and React.js with Redux are available. The Angular template has been updated to Angular 4. The Angular and React templates are available by default; for information about how to get the other templates, see [Create a new SPA project](xref:client-side/spa-services#creating-a-new-project). For information about how to build a SPA in ASP.NET Core, see [Use JavaScriptServices for Creating Single Page Applications](xref:client-side/spa-services).
+Single Page Application (SPA) project templates for Angular, Aurelia, Knockout.js, React.js, and React.js with Redux are available. The Angular template has been updated to Angular 4. The Angular and React templates are available by default; for information about how to get the other templates, see [Create a new SPA project](xref:client-side/spa-services#create-a-new-project). For information about how to build a SPA in ASP.NET Core, see <xref:client-side/spa-services>.
 
 ## Kestrel improvements
 

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -321,7 +321,7 @@
               uid: spa/react
             - name: React with Redux
               uid: spa/react-with-redux
-            - name: JavaScriptServices
+            - name: JavaScript Services
               uid: client-side/spa-services
         - name: LibMan
           items:


### PR DESCRIPTION
Fixes #12562 

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/client-side/spa-services?view=aspnetcore-2.1&branch=pr-en-us-12571)

@scottaddie This is your :baby: ... do u want to review?

* The main callout on the issue is getting the engineering link addressed, and I just remove it here. Linking to source is either (eventually) a bad experience when the engineering version changes or going with `master` or it's a pain point for the reader having to figure out how to substitute a version into an engineering repo link that has something like `{X.Y}` in it. Therefore, I just drop it.
* Took the naming from "JavaScriptServices" to "JavaScript Services" and maintained it as a singular proper noun.
* ... then, just nit updates. I made a *quick* 🏃 and **_not thorough_**&dagger; set of mini-updates that you might like ..... *or not* lol. Let me know, and I'll update/revert.
  * Took out the "you"/"your" bits.
  * Took out the gerunds in headings.
  * Fixed duplicate headings and styles in headings.
  * Dropped "Note:" and "Tip:" ... not really needed. They have to read those bits imo.
  * Named anchors? 🙈 lol


&dagger;I did **not** read every line here. I'm 🏃😅 at the moment. I'll be *free-er-ish* in two weeks. For example, code block line lengths could use a touch. I can come back later to fix if you want.

I left "application" over "app." I think that *what was a rule at one point in favor of "app"* has been loosened over time.