### PR TITLE
Update ANCM error pages and diagnostics

### DIFF
--- a/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
+++ b/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
@@ -32,6 +32,90 @@ The app starts, but an error prevents the server from fulfilling the request.
 
 This error occurs within the app's code during startup or while creating a response. The response may contain no content, or the response may appear as a *500 Internal Server Error* in the browser. The Application Event Log usually states that the app started normally. From the server's perspective, that's correct. The app did start, but it can't generate a valid response. [Run the app in the Kudu console](#run-the-app-in-the-kudu-console) or [enable the ASP.NET Core Module stdout log](#aspnet-core-module-stdout-log) to troubleshoot the problem.
 
+::: moniker range=">= aspnetcore-2.2"
+
+### 500.30 In-Process Startup Failure
+
+The worker process fails. The app doesn't start.
+
+The ASP.NET Core Module attempts to start the .NET Core CLR in-process, but it fails to start. The cause of a process startup failure can usually be determined from entries in the [Application Event Log](#application-event-log) and the [ASP.NET Core Module stdout log](#aspnet-core-module-stdout-log).
+
+::: moniker-end
+
+::: moniker range=">= aspnetcore-3.0"
+
+### 500.31 ANCM Failed to Find Native Dependencies
+
+The worker process fails. The app doesn't start.
+
+The ASP.NET Core Module attempts to start the .NET Core CLR in-process, but it fails to start. The cause of this startup failure most likely due to the version of `Microsoft.NETCore.App` or `Microsoft.AspNetCore.App` not being found. For example, if the application is deployed to target 3.0 and that version doesn't exist on the machine, this error can occur. The specific error will look like the following:
+
+```
+The specified framework 'Microsoft.NETCore.App', version '3.0.0' was not found.
+  - The following frameworks were found:
+      2.2.1 at [C:\Program Files\dotnet\x64\shared\Microsoft.NETCore.App]
+      3.0.0-preview5-27626-15 at [C:\Program Files\dotnet\x64\shared\Microsoft.NETCore.App]
+      3.0.0-preview6-27713-13 at [C:\Program Files\dotnet\x64\shared\Microsoft.NETCore.App]
+      3.0.0-preview6-27714-15 at [C:\Program Files\dotnet\x64\shared\Microsoft.NETCore.App]
+      3.0.0-preview6-27723-08 at [C:\Program Files\dotnet\x64\shared\Microsoft.NETCore.App]
+```
+
+To fix this error, either:
+* Install the appropriate version of dotnet on the machine.
+* Target the correct version of dotnet.
+* Publish the application as Standalone.
+
+When running in development (ASPNETCORE_ENVIRONMENT is set to Development), the specific error that occured will be written to the HTTP response. The cause of a process startup failure can also be found in the [Application Event Log](#application-event-log).
+
+### 500.32 ANCM Failed to Load dll
+
+The worker process fails. The app doesn't start.
+
+The application was likely published for a different bitness than w3wp.exe/iisexpress.exe is running as. For example, if the worker process is running as a 32-bit application and the application was published to target 64-bit, this error will occur. The first dll that will hit this error will be `hostfxr.dll`, which is responsible for starting the dotnet application.
+
+To fix this error, either:
+* Publish the application for the same bitness as the worker process
+* Publish the application as portable.
+
+### 500.33 ANCM Request Handler Load Failure
+
+The worker process fails. The app doesn't start.
+
+The application didn't reference a package or shared framework that included the native handler used by ANCM. 
+
+To fix this error, make sure Microsoft.AspNetCore.App is referenced by the application.
+
+### 500.34 ANCM Mixed Hosting Models Not Supported
+
+The worker process cannot run both an inprocess and out of process application in the same worker process.
+
+To fix this error, please target a different application pool for the second application.
+
+### 500.35 ANCM Multiple In-Process Applications in same Process
+
+The worker process cannot run two inprocess applications in the same worker process.
+
+To fix this error, please target a different application pool for the second application.
+### 500.36 ANCM Out-Of-Process Handler Load Failure
+
+The out of process request handler, aspnetcorev2_outofprocess.dll, could not be found next to the aspnetcorev2.dll.
+
+To fix this error, please confirm that the dll aspnetcorev2_outofprocess.dll in a directory with a version number next to aspnetcorev2.dll
+
+### 500.37 ANCM Failed to Start Within Startup Time Limit
+
+ANCM failed to start within the provied startup time limit. By default, the timeout is 120 seconds.
+
+This can occur if multiple inprocess applications are being started at the same time. 
+
+### 500.0 In-Process Handler Load Failure
+
+The worker process fails. The app doesn't start.
+
+The cause of a process startup failure can also be found in the [Application Event Log](#application-event-log).
+
+::: moniker-end
+
 **Connection reset**
 
 If an error occurs after the headers are sent, it's too late for the server to send a **500 Internal Server Error** when an error occurs. This often happens when an error occurs during the serialization of complex objects for a response. This type of error appears as a *connection reset* error on the client. [Application logging](xref:fundamentals/logging/index) can help troubleshoot these types of errors.

--- a/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
+++ b/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
@@ -32,7 +32,7 @@ The app starts, but an error prevents the server from fulfilling the request.
 
 This error occurs within the app's code during startup or while creating a response. The response may contain no content, or the response may appear as a *500 Internal Server Error* in the browser. The Application Event Log usually states that the app started normally. From the server's perspective, that's correct. The app did start, but it can't generate a valid response. [Run the app in the Kudu console](#run-the-app-in-the-kudu-console) or [enable the ASP.NET Core Module stdout log](#aspnet-core-module-stdout-log) to troubleshoot the problem.
 
-::: moniker range=">= aspnetcore-2.2"
+::: moniker range="= aspnetcore-2.2"
 
 ### 500.30 In-Process Startup Failure
 
@@ -48,7 +48,7 @@ The ASP.NET Core Module attempts to start the .NET Core CLR in-process, but it f
 
 The worker process fails. The app doesn't start.
 
-The ASP.NET Core Module attempts to start the .NET Core CLR in-process, but it fails to start. The cause of this startup failure most likely due to a missing native dependencies for `Microsoft.NETCore.App` or `Microsoft.AspNetCore.App`. If the app is deployed to target 3.0 and that version doesn't exist on the machine, this error occurs. The following is an example of how this error is logged:
+The ASP.NET Core Module attempts to start the .NET Core runtime in-process, but it fails to start. The most common cause of this startup failure is when the `Microsoft.NETCore.App` or `Microsoft.AspNetCore.App` runtime isn't installed. If the app is deployed to target ASP.NET Core 3.0 and that version doesn't exist on the machine, this error occurs. An example error message follows:
 
 ```
 The specified framework 'Microsoft.NETCore.App', version '3.0.0' was not found.
@@ -60,56 +60,62 @@ The specified framework 'Microsoft.NETCore.App', version '3.0.0' was not found.
       3.0.0-preview6-27723-08 at [C:\Program Files\dotnet\x64\shared\Microsoft.NETCore.App]
 ```
 
-To fix this error, either:
+The error message lists all the installed .NET Core versions and the version requested by the app. To fix this error, either:
 
 * Install the appropriate version of .NET Core on the machine.
-* Target the correct version of .NET Core.
-Publish the app as a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd).
+* Change the app to target a version of .NET Core that's present on the machine.
+* Publish the app as a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd).
 
-When running in the Development environment (`ASPNETCORE_ENVIRONMENT` is set to `Development`), the specific error that occured is written to the HTTP response. The cause of a process startup failure is also found in the [Application Event Log](#application-event-log).
+When running in development (the `ASPNETCORE_ENVIRONMENT` environment variable is set to `Development`), the specific error is written to the HTTP response. The cause of a process startup failure is also found in the [Application Event Log](#application-event-log).
 
 ### 500.32 ANCM Failed to Load dll
 
 The worker process fails. The app doesn't start.
 
-The app was likely published for a different bitness than the worker process (*w3wp.exe*/*iisexpress.exe*). If the worker process is running as a 32-bit app and the app was published to target 64-bit, this error occurs. The first dll that hits this error is `hostfxr.dll`, which is responsible for starting the app.
+The most common cause for this error is that the app is published for an incompatible processor architecture. If the worker process is running as a 32-bit app and the app was published to target 64-bit, this error occurs.
 
 To fix this error, either:
 
-* Publish the app for the same bitness as the worker process.
+* Republish the app for the same processor architecture as the worker process.
 * Publish the app as a [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-executables-fde).
 
 ### 500.33 ANCM Request Handler Load Failure
 
 The worker process fails. The app doesn't start.
 
-The app doesn't reference a package or shared framework that includes the native handler used by the ASP.NET Core Module.
+The app didn't reference the `Microsoft.AspNetCore.App` framework. Only apps targeting the `Microsoft.AspNetCore.App` framework can be hosted by the ASP.NET Core Module.
 
-To fix this error, confirm that the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app) is referenced by the app.
+To fix this error, confirm that the app is targeting the `Microsoft.AspNetCore.App` framework. Check the `.runtimeconfig.json` to verify the framework targeted by the app.
 
 ### 500.34 ANCM Mixed Hosting Models Not Supported
 
-A single worker process can't run both an in-process app and an out-of-process app in the same process.
+The worker process can't run both an in-process app and an out-of-process app in the same process.
 
-To fix this error, target a different application pool for the second app.
+To fix this error, run apps in separate IIS application pools.
 
 ### 500.35 ANCM Multiple In-Process Applications in same Process
 
-A single worker process can't run both an in-process app and an out-of-process app in the same process.
+The worker process can't run both an in-process app and an out-of-process app in the same process.
 
-To fix this error, target a different application pool for the second app.
+To fix this error, run apps in separate IIS application pools.
 
 ### 500.36 ANCM Out-Of-Process Handler Load Failure
 
-The out-of-process request handler, *aspnetcorev2_outofprocess.dll*, couldn't be found next to the *aspnetcorev2.dll* file.
+The out-of-process request handler, *aspnetcorev2_outofprocess.dll*, isn't next to the *aspnetcorev2.dll* file. This indicates a corrupted installation of the ASP.NET Core Module.
 
-To fix this error, confirm that the *aspnetcorev2_outofprocess.dll* file is in a directory with a version number next to *aspnetcorev2.dll*.
+To fix this error, repair the installation of the [.NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle) (for IIS) or Visual Studio (for IIS Express).
 
 ### 500.37 ANCM Failed to Start Within Startup Time Limit
 
 ANCM failed to start within the provied startup time limit. By default, the timeout is 120 seconds.
 
-This occurs if multiple in-process apps are started at the same time.
+This error can occur when starting a large number of apps on the same machine. Check for CPU/Memory usage spikes on the server during startup. You may need to stagger the startup process of multiple apps.
+
+### 500.30 In-Process Startup Failure
+
+The worker process fails. The app doesn't start.
+
+The ASP.NET Core Module attempts to start the .NET Core runtime in-process, but it fails to start. The cause of a process startup failure is usually determined from entries in the [Application Event Log](#application-event-log) and the [ASP.NET Core Module stdout log](#aspnet-core-module-stdout-log).
 
 ### 500.0 In-Process Handler Load Failure
 

--- a/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
+++ b/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
@@ -38,7 +38,7 @@ This error occurs within the app's code during startup or while creating a respo
 
 The worker process fails. The app doesn't start.
 
-The ASP.NET Core Module attempts to start the .NET Core CLR in-process, but it fails to start. The cause of a process startup failure can usually be determined from entries in the [Application Event Log](#application-event-log) and the [ASP.NET Core Module stdout log](#aspnet-core-module-stdout-log).
+The ASP.NET Core Module attempts to start the .NET Core CLR in-process, but it fails to start. The cause of a process startup failure is usually determined from entries in the [Application Event Log](#application-event-log) and the [ASP.NET Core Module stdout log](#aspnet-core-module-stdout-log).
 
 ::: moniker-end
 
@@ -48,7 +48,7 @@ The ASP.NET Core Module attempts to start the .NET Core CLR in-process, but it f
 
 The worker process fails. The app doesn't start.
 
-The ASP.NET Core Module attempts to start the .NET Core CLR in-process, but it fails to start. The cause of this startup failure most likely due to the version of `Microsoft.NETCore.App` or `Microsoft.AspNetCore.App` not being found. For example, if the application is deployed to target 3.0 and that version doesn't exist on the machine, this error can occur. The specific error will look like the following:
+The ASP.NET Core Module attempts to start the .NET Core CLR in-process, but it fails to start. The cause of this startup failure most likely due to a missing native dependencies for `Microsoft.NETCore.App` or `Microsoft.AspNetCore.App`. If the app is deployed to target 3.0 and that version doesn't exist on the machine, this error occurs. The following is an example of how this error is logged:
 
 ```
 The specified framework 'Microsoft.NETCore.App', version '3.0.0' was not found.
@@ -61,58 +61,61 @@ The specified framework 'Microsoft.NETCore.App', version '3.0.0' was not found.
 ```
 
 To fix this error, either:
-* Install the appropriate version of dotnet on the machine.
-* Target the correct version of dotnet.
-* Publish the application as Standalone.
 
-When running in development (ASPNETCORE_ENVIRONMENT is set to Development), the specific error that occured will be written to the HTTP response. The cause of a process startup failure can also be found in the [Application Event Log](#application-event-log).
+* Install the appropriate version of .NET Core on the machine.
+* Target the correct version of .NET Core.
+Publish the app as a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd).
+
+When running in the Development environment (`ASPNETCORE_ENVIRONMENT` is set to `Development`), the specific error that occured is written to the HTTP response. The cause of a process startup failure is also found in the [Application Event Log](#application-event-log).
 
 ### 500.32 ANCM Failed to Load dll
 
 The worker process fails. The app doesn't start.
 
-The application was likely published for a different bitness than w3wp.exe/iisexpress.exe is running as. For example, if the worker process is running as a 32-bit application and the application was published to target 64-bit, this error will occur. The first dll that will hit this error will be `hostfxr.dll`, which is responsible for starting the dotnet application.
+The app was likely published for a different bitness than the worker process (*w3wp.exe*/*iisexpress.exe*). If the worker process is running as a 32-bit app and the app was published to target 64-bit, this error occurs. The first dll that hits this error is `hostfxr.dll`, which is responsible for starting the app.
 
 To fix this error, either:
-* Publish the application for the same bitness as the worker process
-* Publish the application as portable.
+
+* Publish the app for the same bitness as the worker process.
+* Publish the app as a [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-executables-fde).
 
 ### 500.33 ANCM Request Handler Load Failure
 
 The worker process fails. The app doesn't start.
 
-The application didn't reference a package or shared framework that included the native handler used by ANCM. 
+The app doesn't reference a package or shared framework that includes the native handler used by the ASP.NET Core Module.
 
-To fix this error, make sure Microsoft.AspNetCore.App is referenced by the application.
+To fix this error, confirm that the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app) is referenced by the app.
 
 ### 500.34 ANCM Mixed Hosting Models Not Supported
 
-The worker process cannot run both an inprocess and out of process application in the same worker process.
+A single worker process can't run both an in-process app and an out-of-process app in the same process.
 
-To fix this error, please target a different application pool for the second application.
+To fix this error, target a different application pool for the second app.
 
 ### 500.35 ANCM Multiple In-Process Applications in same Process
 
-The worker process cannot run two inprocess applications in the same worker process.
+A single worker process can't run both an in-process app and an out-of-process app in the same process.
 
-To fix this error, please target a different application pool for the second application.
+To fix this error, target a different application pool for the second app.
+
 ### 500.36 ANCM Out-Of-Process Handler Load Failure
 
-The out of process request handler, aspnetcorev2_outofprocess.dll, could not be found next to the aspnetcorev2.dll.
+The out-of-process request handler, *aspnetcorev2_outofprocess.dll*, couldn't be found next to the *aspnetcorev2.dll* file.
 
-To fix this error, please confirm that the dll aspnetcorev2_outofprocess.dll in a directory with a version number next to aspnetcorev2.dll
+To fix this error, confirm that the *aspnetcorev2_outofprocess.dll* file is in a directory with a version number next to *aspnetcorev2.dll*.
 
 ### 500.37 ANCM Failed to Start Within Startup Time Limit
 
 ANCM failed to start within the provied startup time limit. By default, the timeout is 120 seconds.
 
-This can occur if multiple inprocess applications are being started at the same time. 
+This occurs if multiple in-process apps are started at the same time.
 
 ### 500.0 In-Process Handler Load Failure
 
 The worker process fails. The app doesn't start.
 
-The cause of a process startup failure can also be found in the [Application Event Log](#application-event-log).
+The cause of a process startup failure is also found in the [Application Event Log](#application-event-log).
 
 ::: moniker-end
 

--- a/aspnetcore/host-and-deploy/iis/troubleshoot.md
+++ b/aspnetcore/host-and-deploy/iis/troubleshoot.md
@@ -54,7 +54,7 @@ The *502.5 Process Failure* error page is returned when a hosting or app misconf
 
 ![Browser window showing the 502.5 Process Failure page](troubleshoot/_static/process-failure-page.png)
 
-::: moniker range=">= aspnetcore-2.2"
+::: moniker range="= aspnetcore-2.2"
 
 ### 500.30 In-Process Startup Failure
 
@@ -78,6 +78,86 @@ The ASP.NET Core Module fails to find the .NET Core CLR and find the in-process 
 The worker process fails. The app doesn't start.
 
 The ASP.NET Core Module fails to find the out-of-process hosting request handler. Make sure the *aspnetcorev2_outofprocess.dll* is present in a subfolder next to *aspnetcorev2.dll*.
+
+::: moniker-end
+
+::: moniker range="= aspnetcore-3.0"
+
+### 500.30 In-Process Startup Failure
+
+The worker process fails. The app doesn't start.
+
+The ASP.NET Core Module attempts to start the .NET Core CLR in-process, but it fails to start. The cause of a process startup failure can usually be determined from entries in the [Application Event Log](#application-event-log) and the [ASP.NET Core Module stdout log](#aspnet-core-module-stdout-log).
+
+### 500.31 ANCM Failed to Find Native Dependencies
+
+The worker process fails. The app doesn't start.
+
+The ASP.NET Core Module attempts to start the .NET Core CLR in-process, but it fails to start. The cause of this startup failure most likely due to the version of `Microsoft.NETCore.App` or `Microsoft.AspNetCore.App` not being found. For example, if the application is deployed to target 3.0 and that version doesn't exist on the machine, this error can occur. The specific error will look like the following:
+
+```
+The specified framework 'Microsoft.NETCore.App', version '3.0.0' was not found.
+  - The following frameworks were found:
+      2.2.1 at [C:\Program Files\dotnet\x64\shared\Microsoft.NETCore.App]
+      3.0.0-preview5-27626-15 at [C:\Program Files\dotnet\x64\shared\Microsoft.NETCore.App]
+      3.0.0-preview6-27713-13 at [C:\Program Files\dotnet\x64\shared\Microsoft.NETCore.App]
+      3.0.0-preview6-27714-15 at [C:\Program Files\dotnet\x64\shared\Microsoft.NETCore.App]
+      3.0.0-preview6-27723-08 at [C:\Program Files\dotnet\x64\shared\Microsoft.NETCore.App]
+```
+
+To fix this error, either:
+* Install the appropriate version of dotnet on the machine.
+* Target the correct version of dotnet.
+* Publish the application as Standalone.
+
+When running in development (ASPNETCORE_ENVIRONMENT is set to Development), the specific error that occured will be written to the HTTP response. The cause of a process startup failure can also be found in the [Application Event Log](#application-event-log).
+
+### 500.32 ANCM Failed to Load dll
+
+The worker process fails. The app doesn't start.
+
+The application was likely published for a different bitness than w3wp.exe/iisexpress.exe is running as. For example, if the worker process is running as a 32-bit application and the application was published to target 64-bit, this error will occur. The first dll that will hit this error will be `hostfxr.dll`, which is responsible for starting the dotnet application.
+
+To fix this error, either:
+* Publish the application for the same bitness as the worker process
+* Publish the application as portable.
+
+### 500.33 ANCM Request Handler Load Failure
+
+The worker process fails. The app doesn't start.
+
+The application didn't reference a package or shared framework that included the native handler used by ANCM. 
+
+To fix this error, make sure Microsoft.AspNetCore.App is referenced by the application.
+
+### 500.34 ANCM Mixed Hosting Models Not Supported
+
+The worker process cannot run both an inprocess and out of process application in the same worker process.
+
+To fix this error, please target a different application pool for the second application.
+
+### 500.35 ANCM Multiple In-Process Applications in same Process
+
+The worker process cannot run two inprocess applications in the same worker process.
+
+To fix this error, please target a different application pool for the second application.
+### 500.36 ANCM Out-Of-Process Handler Load Failure
+
+The out of process request handler, aspnetcorev2_outofprocess.dll, could not be found next to the aspnetcorev2.dll.
+
+To fix this error, please confirm that the dll aspnetcorev2_outofprocess.dll in a directory with a version number next to aspnetcorev2.dll
+
+### 500.37 ANCM Failed to Start Within Startup Time Limit
+
+ANCM failed to start within the provied startup time limit. By default, the timeout is 120 seconds.
+
+This can occur if multiple inprocess applications are being started at the same time. 
+
+### 500.0 In-Process Handler Load Failure
+
+The worker process fails. The app doesn't start.
+
+The cause of a process startup failure can also be found in the [Application Event Log](#application-event-log).
 
 ::: moniker-end
 

--- a/aspnetcore/host-and-deploy/iis/troubleshoot.md
+++ b/aspnetcore/host-and-deploy/iis/troubleshoot.md
@@ -81,13 +81,13 @@ The ASP.NET Core Module fails to find the out-of-process hosting request handler
 
 ::: moniker-end
 
-::: moniker range="= aspnetcore-3.0"
+::: moniker range=">= aspnetcore-3.0"
 
 ### 500.31 ANCM Failed to Find Native Dependencies
 
 The worker process fails. The app doesn't start.
 
-The ASP.NET Core Module attempts to start the .NET Core runtime in-process, but it fails to start. The most common cause of this startup failure is when the `Microsoft.NETCore.App` or `Microsoft.AspNetCore.App` runtime is not installed. For example, if the application is deployed to target ASP.NET Core 3.0 and that version doesn't exist on the machine, this error can occur. An example error message is shown below:
+The ASP.NET Core Module attempts to start the .NET Core runtime in-process, but it fails to start. The most common cause of this startup failure is when the `Microsoft.NETCore.App` or `Microsoft.AspNetCore.App` runtime isn't installed. If the app is deployed to target ASP.NET Core 3.0 and that version doesn't exist on the machine, this error occurs. An example error message follows:
 
 ```
 The specified framework 'Microsoft.NETCore.App', version '3.0.0' was not found.
@@ -99,66 +99,72 @@ The specified framework 'Microsoft.NETCore.App', version '3.0.0' was not found.
       3.0.0-preview6-27723-08 at [C:\Program Files\dotnet\x64\shared\Microsoft.NETCore.App]
 ```
 
-The error message lists all the installed versions, as well as the version requested by the application. To fix this error, either:
+The error message lists all the installed .NET Core versions and the version requested by the app. To fix this error, either:
+
 * Install the appropriate version of .NET Core on the machine.
-* Change the app to target a version of .NET Core that is present on the machine.
+* Change the app to target a version of .NET Core that's present on the machine.
 * Publish the app as a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd).
 
-When running in development (the `ASPNETCORE_ENVIRONMENT` environment variable is set to Development), the specific error that occurred will be written to the HTTP response. The cause of a process startup failure can also be found in the [Application Event Log](#application-event-log).
+When running in development (the `ASPNETCORE_ENVIRONMENT` environment variable is set to `Development`), the specific error is written to the HTTP response. The cause of a process startup failure is also found in the [Application Event Log](#application-event-log).
 
 ### 500.32 ANCM Failed to Load dll
 
 The worker process fails. The app doesn't start.
 
-The most common cause for this is that the app was published for an incompatible processor architecture. For example, if the worker process is running as a 32-bit application and the application was published to target 64-bit, this error will occur.
+The most common cause for this error is that the app is published for an incompatible processor architecture. If the worker process is running as a 32-bit app and the app was published to target 64-bit, this error occurs.
 
 To fix this error, either:
-* Re-publish the app for the same processor architecture as the worker process.
+
+* Republish the app for the same processor architecture as the worker process.
 * Publish the app as a [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-executables-fde).
 
 ### 500.33 ANCM Request Handler Load Failure
 
 The worker process fails. The app doesn't start.
 
-The app didn't reference the `Microsoft.AspNetCore.App` framework. Only apps targeting that framework can be hosted by ANCM.
+The app didn't reference the `Microsoft.AspNetCore.App` framework. Only apps targeting the `Microsoft.AspNetCore.App` framework can be hosted by the ASP.NET Core Module.
 
-To fix this error, make sure the app is targeting the `Microsoft.AspNetCore.App` framework. Check the `.runtimeconfig.json` to verify the framework targeted by the app.
+To fix this error, confirm that the app is targeting the `Microsoft.AspNetCore.App` framework. Check the `.runtimeconfig.json` to verify the framework targeted by the app.
 
 ### 500.34 ANCM Mixed Hosting Models Not Supported
 
-The worker process cannot run both an in-process and out-of-process application in the same worker process.
+The worker process can't run both an in-process app and an out-of-process app in the same process.
 
 To fix this error, run apps in separate IIS application pools.
 
 ### 500.35 ANCM Multiple In-Process Applications in same Process
 
-The worker process cannot run two inprocess applications in the same worker process.
+The worker process can't run both an in-process app and an out-of-process app in the same process.
 
 To fix this error, run apps in separate IIS application pools.
 
 ### 500.36 ANCM Out-Of-Process Handler Load Failure
 
-The out-of-process request handler, `aspnetcorev2_outofprocess.dll`, could not be found next to the `aspnetcorev2.dll`. This indicates a corrupted installation of the ASP.NET Core Module.
+The out-of-process request handler, *aspnetcorev2_outofprocess.dll*, isn't next to the *aspnetcorev2.dll* file. This indicates a corrupted installation of the ASP.NET Core Module.
 
-To fix this error, repair your installation of the Windows Hosting Bundle (for IIS) or Visual Studio (for IIS Express).
+To fix this error, repair the installation of the [.NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle) (for IIS) or Visual Studio (for IIS Express).
 
 ### 500.37 ANCM Failed to Start Within Startup Time Limit
 
 ANCM failed to start within the provied startup time limit. By default, the timeout is 120 seconds.
 
-This can occur when starting a large number of apps on the same machine. Check for CPU/Memory usage spikes on the server during startup. You may need to stagger the startup process of multiple apps.
+This error can occur when starting a large number of apps on the same machine. Check for CPU/Memory usage spikes on the server during startup. You may need to stagger the startup process of multiple apps.
 
 ### 500.30 In-Process Startup Failure
 
 The worker process fails. The app doesn't start.
 
-The ASP.NET Core Module attempts to start the .NET Core CLR in-process, but it fails to start. The cause of a process startup failure can usually be determined from entries in the [Application Event Log](#application-event-log) and the [ASP.NET Core Module stdout log](#aspnet-core-module-stdout-log).
+The ASP.NET Core Module attempts to start the .NET Core runtime in-process, but it fails to start. The cause of a process startup failure is usually determined from entries in the [Application Event Log](#application-event-log) and the [ASP.NET Core Module stdout log](#aspnet-core-module-stdout-log).
 
 ### 500.0 In-Process Handler Load Failure
 
 The worker process fails. The app doesn't start.
 
-An unknown error occurred loading ANCM components. Contact [Microsoft Support](https://support.microsoft.com/oas/default.aspx?prid=15832) (select "Developer Tools" then "ASP.NET Core") for assistance, ask on Stack Overflow, or file an issue on our [GitHub repository](https://github.com/aspnet/AspNetCore).
+An unknown error occurred loading ASP.NET Core Module components. Take one of the following actions:
+
+* Contact [Microsoft Support](https://support.microsoft.com/oas/default.aspx?prid=15832) (select **Developer Tools** then **ASP.NET Core**).
+* Ask a question on Stack Overflow.
+* File an issue on our [GitHub repository](https://github.com/aspnet/AspNetCore).
 
 ::: moniker-end
 

--- a/aspnetcore/host-and-deploy/iis/troubleshoot.md
+++ b/aspnetcore/host-and-deploy/iis/troubleshoot.md
@@ -83,12 +83,6 @@ The ASP.NET Core Module fails to find the out-of-process hosting request handler
 
 ::: moniker range="= aspnetcore-3.0"
 
-### 500.30 In-Process Startup Failure
-
-The worker process fails. The app doesn't start.
-
-The ASP.NET Core Module attempts to start the .NET Core CLR in-process, but it fails to start. The cause of a process startup failure can usually be determined from entries in the [Application Event Log](#application-event-log) and the [ASP.NET Core Module stdout log](#aspnet-core-module-stdout-log).
-
 ### 500.31 ANCM Failed to Find Native Dependencies
 
 The worker process fails. The app doesn't start.
@@ -153,6 +147,12 @@ To fix this error, repair your installation of the Windows Hosting Bundle (for I
 ANCM failed to start within the provied startup time limit. By default, the timeout is 120 seconds.
 
 This can occur when starting a large number of apps on the same machine. Check for CPU/Memory usage spikes on the server during startup. You may need to stagger the startup process of multiple apps.
+
+### 500.30 In-Process Startup Failure
+
+The worker process fails. The app doesn't start.
+
+The ASP.NET Core Module attempts to start the .NET Core CLR in-process, but it fails to start. The cause of a process startup failure can usually be determined from entries in the [Application Event Log](#application-event-log) and the [ASP.NET Core Module stdout log](#aspnet-core-module-stdout-log).
 
 ### 500.0 In-Process Handler Load Failure
 

--- a/aspnetcore/host-and-deploy/iis/troubleshoot.md
+++ b/aspnetcore/host-and-deploy/iis/troubleshoot.md
@@ -93,7 +93,7 @@ The ASP.NET Core Module attempts to start the .NET Core CLR in-process, but it f
 
 The worker process fails. The app doesn't start.
 
-The ASP.NET Core Module attempts to start the .NET Core CLR in-process, but it fails to start. The cause of this startup failure most likely due to the version of `Microsoft.NETCore.App` or `Microsoft.AspNetCore.App` not being found. For example, if the application is deployed to target 3.0 and that version doesn't exist on the machine, this error can occur. The specific error will look like the following:
+The ASP.NET Core Module attempts to start the .NET Core runtime in-process, but it fails to start. The most common cause of this startup failure is when the `Microsoft.NETCore.App` or `Microsoft.AspNetCore.App` runtime is not installed. For example, if the application is deployed to target ASP.NET Core 3.0 and that version doesn't exist on the machine, this error can occur. An example error message is shown below:
 
 ```
 The specified framework 'Microsoft.NETCore.App', version '3.0.0' was not found.
@@ -105,59 +105,60 @@ The specified framework 'Microsoft.NETCore.App', version '3.0.0' was not found.
       3.0.0-preview6-27723-08 at [C:\Program Files\dotnet\x64\shared\Microsoft.NETCore.App]
 ```
 
-To fix this error, either:
-* Install the appropriate version of dotnet on the machine.
-* Target the correct version of dotnet.
-* Publish the application as Standalone.
+The error message lists all the installed versions, as well as the version requested by the application. To fix this error, either:
+* Install the appropriate version of .NET Core on the machine.
+* Change the app to target a version of .NET Core that is present on the machine.
+* Publish the app as a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd).
 
-When running in development (ASPNETCORE_ENVIRONMENT is set to Development), the specific error that occured will be written to the HTTP response. The cause of a process startup failure can also be found in the [Application Event Log](#application-event-log).
+When running in development (the `ASPNETCORE_ENVIRONMENT` environment variable is set to Development), the specific error that occurred will be written to the HTTP response. The cause of a process startup failure can also be found in the [Application Event Log](#application-event-log).
 
 ### 500.32 ANCM Failed to Load dll
 
 The worker process fails. The app doesn't start.
 
-The application was likely published for a different bitness than w3wp.exe/iisexpress.exe is running as. For example, if the worker process is running as a 32-bit application and the application was published to target 64-bit, this error will occur. The first dll that will hit this error will be `hostfxr.dll`, which is responsible for starting the dotnet application.
+The most common cause for this is that the app was published for an incompatible processor architecture. For example, if the worker process is running as a 32-bit application and the application was published to target 64-bit, this error will occur.
 
 To fix this error, either:
-* Publish the application for the same bitness as the worker process
-* Publish the application as portable.
+* Re-publish the app for the same processor architecture as the worker process.
+* Publish the app as a [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-executables-fde).
 
 ### 500.33 ANCM Request Handler Load Failure
 
 The worker process fails. The app doesn't start.
 
-The application didn't reference a package or shared framework that included the native handler used by ANCM. 
+The app didn't reference the `Microsoft.AspNetCore.App` framework. Only apps targeting that framework can be hosted by ANCM.
 
-To fix this error, make sure Microsoft.AspNetCore.App is referenced by the application.
+To fix this error, make sure the app is targeting the `Microsoft.AspNetCore.App` framework. Check the `.runtimeconfig.json` to verify the framework targeted by the app.
 
 ### 500.34 ANCM Mixed Hosting Models Not Supported
 
-The worker process cannot run both an inprocess and out of process application in the same worker process.
+The worker process cannot run both an in-process and out-of-process application in the same worker process.
 
-To fix this error, please target a different application pool for the second application.
+To fix this error, run apps in separate IIS application pools.
 
 ### 500.35 ANCM Multiple In-Process Applications in same Process
 
 The worker process cannot run two inprocess applications in the same worker process.
 
-To fix this error, please target a different application pool for the second application.
+To fix this error, run apps in separate IIS application pools.
+
 ### 500.36 ANCM Out-Of-Process Handler Load Failure
 
-The out of process request handler, aspnetcorev2_outofprocess.dll, could not be found next to the aspnetcorev2.dll.
+The out-of-process request handler, `aspnetcorev2_outofprocess.dll`, could not be found next to the `aspnetcorev2.dll`. This indicates a corrupted installation of the ASP.NET Core Module.
 
-To fix this error, please confirm that the dll aspnetcorev2_outofprocess.dll in a directory with a version number next to aspnetcorev2.dll
+To fix this error, repair your installation of the Windows Hosting Bundle (for IIS) or Visual Studio (for IIS Express).
 
 ### 500.37 ANCM Failed to Start Within Startup Time Limit
 
 ANCM failed to start within the provied startup time limit. By default, the timeout is 120 seconds.
 
-This can occur if multiple inprocess applications are being started at the same time. 
+This can occur when starting a large number of apps on the same machine. Check for CPU/Memory usage spikes on the server during startup. You may need to stagger the startup process of multiple apps.
 
 ### 500.0 In-Process Handler Load Failure
 
 The worker process fails. The app doesn't start.
 
-The cause of a process startup failure can also be found in the [Application Event Log](#application-event-log).
+An unknown error occurred loading ANCM components. Contact [Microsoft Support](https://support.microsoft.com/oas/default.aspx?prid=15832) (select "Developer Tools" then "ASP.NET Core") for assistance, ask on Stack Overflow, or file an issue on our [GitHub repository](https://github.com/aspnet/AspNetCore).
 
 ::: moniker-end
 


### PR DESCRIPTION
This is a super rough draft for improvements we made for ANCM startup error pages. 

High level goals:
- Make ANCM startup pages have different error codes based on error condition
- Provided diagnostic information in the HTTP response in development

Right now, we have two troubleshooting guides, one for app services, and one for local IIS. We would like to have both of these have information (or ideally, consolidate these docs).

@guardrex I'll let you decide the best way to organize this information 😄 