### PR TITLE
Add WebSocket lifetime info

### DIFF
--- a/aspnetcore/fundamentals/websockets.md
+++ b/aspnetcore/fundamentals/websockets.md
@@ -14,9 +14,13 @@ By [Tom Dykstra](https://github.com/tdykstra) and [Andrew Stanton-Nurse](https:/
 
 This article explains how to get started with WebSockets in ASP.NET Core. [WebSocket](https://wikipedia.org/wiki/WebSocket) ([RFC 6455](https://tools.ietf.org/html/rfc6455)) is a protocol that enables two-way persistent communication channels over TCP connections. It's used in apps that benefit from fast, real-time communication, such as chat, dashboard, and game apps.
 
+[View or download sample code](https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/fundamentals/websockets/samples) ([how to download](xref:index#how-to-download-a-sample)). [How to run](#sample-app).
+
+## SignalR
+
 [ASP.NET Core SignalR](xref:signalr/introduction) is a library that simplifies adding real-time web functionality to apps. It uses WebSockets whenever possible.
 
-[View or download sample code](https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/fundamentals/websockets/samples) ([how to download](xref:index#how-to-download-a-sample)). [How to run](#sample-app).
+For most applications, we recommend SignalR over using WebSockets directly. SignalR provides transport fallback for environments where WebSockets is not available. It also provides a simple remote procedure call app model. And in most scenarios, SignalR has no significant performance disadvantage compared to using WebSockets directly.
 
 ## Prerequisites
 
@@ -39,11 +43,16 @@ This article explains how to get started with WebSockets in ASP.NET Core. [WebSo
 
 * For supported browsers, see https://caniuse.com/#feat=websockets.
 
+::: moniker range="< aspnetcore-2.1"
+
 ## NuGet package
 
 Install the [Microsoft.AspNetCore.WebSockets](https://www.nuget.org/packages/Microsoft.AspNetCore.WebSockets/) package.
 
+::: moniker-end
+
 ## Configure the middleware
+
 
 Add the WebSockets middleware in the `Configure` method of the `Startup` class:
 
@@ -101,7 +110,7 @@ app.Use(async (context, next) => {
 ```
 The WebSocket closed exception can also happen if you return too soon from an action method. If you accept a socket in an action method, wait for the code that uses the socket to complete before returning from the action method.
 
-Never use `Task.Wait()` or similar blocking calls to wait for the socket to complete, as that can cause serious threading issues. Always use `await`.
+Never use `Task.Wait()`, `Task.Result`, or similar blocking calls to wait for the socket to complete, as that can cause serious threading issues. Always use `await`.
 
 ## Send and receive messages
 

--- a/aspnetcore/fundamentals/websockets.md
+++ b/aspnetcore/fundamentals/websockets.md
@@ -87,7 +87,7 @@ System.Net.WebSockets.WebSocketException (0x80004005): The remote party closed t
 Object name: 'HttpResponseStream'.
 ```
 
-If you're using a background service to write data to a WebSocket, make sure you keep the middleware pipeline running. Do this by using a <xref:System.Threading.Tasks.TaskCompletionSource%601>. Pass the `TaskCompletionSource` to your background service and have it call <xref:System.Threading.Tasks.TaskCompletionSource%601.TrySetResult%2A> when you finish with the WebSocket. Then `await` the <xref:System.Threading.Tasks.TaskCompletionSource%601.Task> property during the request. For example:
+If you're using a background service to write data to a WebSocket, make sure you keep the middleware pipeline running. Do this by using a <xref:System.Threading.Tasks.TaskCompletionSource%601>. Pass the `TaskCompletionSource` to your background service and have it call <xref:System.Threading.Tasks.TaskCompletionSource%601.TrySetResult%2A> when you finish with the WebSocket. Then `await` the <xref:System.Threading.Tasks.TaskCompletionSource%601.Task> property during the request, as shown in the following example:
 
 ```csharp
 app.Use(async (context, next) => {

--- a/aspnetcore/fundamentals/websockets.md
+++ b/aspnetcore/fundamentals/websockets.md
@@ -45,17 +45,7 @@ Install the [Microsoft.AspNetCore.WebSockets](https://www.nuget.org/packages/Mic
 
 Add the WebSockets middleware in the `Configure` method of the `Startup` class:
 
-::: moniker range=">= aspnetcore-2.0"
-
 [!code-csharp[](websockets/samples/2.x/WebSocketsSample/Startup.cs?name=UseWebSockets)]
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-2.0"
-
-[!code-csharp[](websockets/samples/1.x/WebSocketsSample/Startup.cs?name=UseWebSockets)]
-
-::: moniker-end
 
 ::: moniker range="< aspnetcore-2.2"
 
@@ -76,17 +66,7 @@ The following settings can be configured:
 
 ::: moniker-end
 
-::: moniker range=">= aspnetcore-2.0"
-
 [!code-csharp[](websockets/samples/2.x/WebSocketsSample/Startup.cs?name=UseWebSocketsOptions)]
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-2.0"
-
-[!code-csharp[](websockets/samples/1.x/WebSocketsSample/Startup.cs?name=UseWebSocketsOptions)]
-
-::: moniker-end
 
 ## Accept WebSocket requests
 
@@ -94,17 +74,7 @@ Somewhere later in the request life cycle (later in the `Configure` method or in
 
 The following example is from later in the `Configure` method:
 
-::: moniker range=">= aspnetcore-2.0"
-
 [!code-csharp[](websockets/samples/2.x/WebSocketsSample/Startup.cs?name=AcceptWebSocket&highlight=7)]
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-2.0"
-
-[!code-csharp[](websockets/samples/1.x/WebSocketsSample/Startup.cs?name=AcceptWebSocket&highlight=7)]
-
-::: moniker-end
 
 A WebSocket request could come in on any URL, but this sample code only accepts requests for `/ws`.
 
@@ -123,21 +93,9 @@ The `AcceptWebSocketAsync` method upgrades the TCP connection to a WebSocket con
 
 The code shown earlier that accepts the WebSocket request passes the `WebSocket` object to an `Echo` method. The code receives a message and immediately sends back the same message. Messages are sent and received in a loop until the client closes the connection:
 
-::: moniker range=">= aspnetcore-2.0"
-
 [!code-csharp[](websockets/samples/2.x/WebSocketsSample/Startup.cs?name=Echo)]
 
-::: moniker-end
-
-::: moniker range="< aspnetcore-2.0"
-
-[!code-csharp[](websockets/samples/1.x/WebSocketsSample/Startup.cs?name=Echo)]
-
-::: moniker-end
-
 When accepting the WebSocket connection before beginning the loop, the middleware pipeline ends. Upon closing the socket, the pipeline unwinds. That is, the request stops moving forward in the pipeline when the WebSocket is accepted. When the loop is finished and the socket is closed, the request proceeds back up the pipeline.
-
-::: moniker range=">= aspnetcore-2.2"
 
 ## WebSocket lifetime
 
@@ -167,6 +125,8 @@ The `await socketFinishedTcs.Task` statement keeps the the request open until th
 The same WebSocket closed error can happen if you return too soon from an MVC controller action method. If you accept a socket in the action method, make sure you wait for the code that uses the socket to complete before you return from the action method.
 
 Never use `Task.Wait()` or similar blocking calls to wait for the socket to complete, as that can cause serious threading issues. Always use `await`.
+
+::: moniker range=">= aspnetcore-2.2"
 
 ## Handle client disconnects
 

--- a/aspnetcore/fundamentals/websockets.md
+++ b/aspnetcore/fundamentals/websockets.md
@@ -20,7 +20,7 @@ This article explains how to get started with WebSockets in ASP.NET Core. [WebSo
 
 [ASP.NET Core SignalR](xref:signalr/introduction) is a library that simplifies adding real-time web functionality to apps. It uses WebSockets whenever possible.
 
-For most applications, we recommend SignalR over using WebSockets directly. SignalR provides transport fallback for environments where WebSockets is not available. It also provides a simple remote procedure call app model. And in most scenarios, SignalR has no significant performance disadvantage compared to using WebSockets directly.
+For most applications, we recommend SignalR over raw WebSockets. SignalR provides transport fallback for environments where WebSockets is not available. It also provides a simple remote procedure call app model. And in most scenarios, SignalR has no significant performance disadvantage compared to using raw WebSockets.
 
 ## Prerequisites
 


### PR DESCRIPTION
Fixes #5466 

The bulk of #5466 was done in #12378, but this PR adds a few notes from #5466 that weren't included in the earlier PR. It also reorganizes a bit to promote H3s to H2s and removes 1.1 sections.

[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/websockets?branch=pr-en-us-12620)