### PR TITLE
'detonate' a package? Really?

### DIFF
--- a/aspnetcore/fundamentals/routing/samples/2.x/RoutingSample/Startup.cs
+++ b/aspnetcore/fundamentals/routing/samples/2.x/RoutingSample/Startup.cs
@@ -29,7 +29,7 @@ namespace RoutingSample
 
             routeBuilder.MapRoute(
                 "Track Package Route",
-                "package/{operation:regex(^track|create|detonate$)}/{id:int}");
+                "package/{operation:regex(^track|create$)}/{id:int}");
 
             routeBuilder.MapGet("hello/{name}", context =>
             {


### PR DESCRIPTION

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->
There is no open issue that this PR addresses. But it seems like bad form to have `detonate` as a package Action for a Microsoft sample.