### PR TITLE
WinAuth enhancements

### DIFF
--- a/aspnetcore/security/authentication/windowsauth.md
+++ b/aspnetcore/security/authentication/windowsauth.md
@@ -5,7 +5,7 @@ description: Learn how to configure Windows Authentication in ASP.NET Core for I
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: "mvc, seodec18"
-ms.date: 05/29/2019
+ms.date: 06/05/2019
 uid: security/authentication/windowsauth
 ---
 # Configure Windows Authentication in ASP.NET Core
@@ -16,9 +16,17 @@ By [Scott Addie](https://twitter.com/Scott_Addie) and [Luke Latham](https://gith
 
 Windows Authentication relies on the operating system to authenticate users of ASP.NET Core apps. You can use Windows Authentication when your server runs on a corporate network using Active Directory domain identities or Windows accounts to identify users. Windows Authentication is best suited to intranet environments where users, client apps, and web servers belong to the same Windows domain.
 
-## Launch settings (debugger)
+## IIS/IIS Express
 
-Configuration for launch settings only affects the *Properties/launchSettings.json* file and doesn't configure the IIS or HTTP.sys server for Windows Authentication. Configuration of the server is explained in the [Enable authentication services for IIS or HTTP.sys](#authentication-services-for-iis-or-httpsys) section.
+Add authentication services by invoking <xref:Microsoft.Extensions.DependencyInjection.AuthenticationServiceCollectionExtensions.AddAuthentication*> (<xref:Microsoft.AspNetCore.Server.IISIntegration?displayProperty=fullName> namespace) in `Startup.ConfigureServices`:
+
+```csharp
+services.AddAuthentication(IISDefaults.AuthenticationScheme);
+```
+
+### Launch settings (debugger)
+
+Configuration for launch settings only affects the *Properties/launchSettings.json* file for IIS Express and doesn't configure IIS for Windows Authentication. Server configuration is explained in the [IIS](#iis) section.
 
 The **Web Application** template available via Visual Studio or the .NET Core CLI can be configured to support Windows Authentication, which updates the *Properties/launchSettings.json* file automatically.
 
@@ -70,17 +78,7 @@ Update the `iisSettings` node of the *launchSettings.json* file:
 
 When modifying an existing project, confirm that the project file includes a package reference for the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app) **or** the [Microsoft.AspNetCore.Authentication](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication/) NuGet package.
 
-## Authentication services for IIS or HTTP.sys
-
-Depending on the hosting scenario, follow the guidance in **either** the [IIS](#iis) section **or** [HTTP.sys](#httpsys) section.
-
 ### IIS
-
-Add authentication services by invoking <xref:Microsoft.Extensions.DependencyInjection.AuthenticationServiceCollectionExtensions.AddAuthentication*> (<xref:Microsoft.AspNetCore.Server.IISIntegration?displayProperty=fullName> namespace) in `Startup.ConfigureServices`:
-
-```csharp
-services.AddAuthentication(IISDefaults.AuthenticationScheme);
-```
 
 IIS uses the [ASP.NET Core Module](xref:host-and-deploy/aspnet-core-module) to host ASP.NET Core apps. Windows Authentication is configured for IIS via the *web.config* file. The following sections show how to:
 
@@ -121,9 +119,9 @@ Use **either** of the following approaches:
   * Use IIS Manager to reset the settings in the *web.config* file after the file is overwritten on deployment.
   * Add a *web.config file* to the app locally with the settings.
 
-### HTTP.sys
+## HTTP.sys
 
-Although [Kestrel](xref:fundamentals/servers/kestrel) doesn't support Windows Authentication, you can use [HTTP.sys](xref:fundamentals/servers/httpsys) to support self-hosted scenarios on Windows.
+In self-hosted scenarios, the app is hosted by [Kestrel](xref:fundamentals/servers/kestrel) and not behind IIS. Although Kestrel doesn't support Windows Authentication, you can use [HTTP.sys](xref:fundamentals/servers/httpsys) to support self-hosted scenarios.
 
 Add authentication services by invoking <xref:Microsoft.Extensions.DependencyInjection.AuthenticationServiceCollectionExtensions.AddAuthentication*> (<xref:Microsoft.AspNetCore.Server.HttpSys?displayProperty=fullName> namespace) in `Startup.ConfigureServices`:
 

--- a/aspnetcore/security/authentication/windowsauth.md
+++ b/aspnetcore/security/authentication/windowsauth.md
@@ -121,7 +121,7 @@ Use **either** of the following approaches:
 
 ## HTTP.sys
 
-In self-hosted scenarios, the app is hosted by [Kestrel](xref:fundamentals/servers/kestrel) and not behind IIS. Although Kestrel doesn't support Windows Authentication, you can use [HTTP.sys](xref:fundamentals/servers/httpsys) to support self-hosted scenarios.
+In self-hosted scenarios, [Kestrel](xref:fundamentals/servers/kestrel) doesn't support Windows Authentication, but you can use [HTTP.sys](xref:fundamentals/servers/httpsys).
 
 Add authentication services by invoking <xref:Microsoft.Extensions.DependencyInjection.AuthenticationServiceCollectionExtensions.AddAuthentication*> (<xref:Microsoft.AspNetCore.Server.HttpSys?displayProperty=fullName> namespace) in `Startup.ConfigureServices`:
 


### PR DESCRIPTION
Fixes #12618

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/security/authentication/windowsauth?view=aspnetcore-2.1&branch=pr-en-us-12714)

* Re-org this a bit ... Let's try IIS/IIS Express first, then HTTP.sys separately.
* Should these sections say anything about in-proc vs. out-of-proc? Currently, we only address in-proc in the *Claims transformation* section at the bottom. It's also the only thing that pertains to WinAuth in the ANCM topic where in-proc/out-of-proc is covered.