### PR TITLE
3.0 Cookie Consent updates

### DIFF
--- a/aspnetcore/security/gdpr.md
+++ b/aspnetcore/security/gdpr.md
@@ -28,7 +28,7 @@ The [sample app](https://github.com/aspnet/AspNetCore.Docs/tree/live/aspnetcore/
 
 ::: moniker range="< aspnetcore-2.2"
 
-Razor Pages and MVC projects created with the project templates have no support out of the box for GDPR or Cookie Consent. To add these features, reference the below samples:
+Razor Pages and MVC projects created with the project templates have no support for GDPR or cookie consent. To add GDPR, copy the code generated in the ASP.NET Core 2.2 templates.
 
 ::: moniker-end
 

--- a/aspnetcore/security/gdpr.md
+++ b/aspnetcore/security/gdpr.md
@@ -26,7 +26,17 @@ The [sample app](https://github.com/aspnet/AspNetCore.Docs/tree/live/aspnetcore/
 
 ## ASP.NET Core GDPR support in template-generated code
 
+::: moniker range="< aspnetcore-2.2"
+
+Razor Pages and MVC projects created with the project templates have no support out of the box for GDPR or Cookie Consent. To add these features, reference the below samples:
+
+::: moniker-end
+
+::: moniker range=">= aspnetcore-2.2"
+
 Razor Pages and MVC projects created with the project templates include the following GDPR support:
+
+::: moniker-end
 
 * [CookiePolicyOptions](/dotnet/api/microsoft.aspnetcore.builder.cookiepolicyoptions) and [UseCookiePolicy](/dotnet/api/microsoft.aspnetcore.builder.cookiepolicyappbuilderextensions.usecookiepolicy) are set in the `Startup` class.
 * The *\_CookieConsentPartial.cshtml* [partial view](xref:mvc/views/tag-helpers/builtin-th/partial-tag-helper). An **Accept** button is included in this file. When the user clicks the **Accept** button, consent to store cookies is provided.


### PR DESCRIPTION
Cookie consent has been removed from the templates in ASP.NET Core 3.0

Fixes #12720
