### PR TITLE
Namespace+location for components

### DIFF
--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -5,7 +5,7 @@ description: Learn how to create and use Razor components, including how to bind
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/26/2019
+ms.date: 06/05/2019
 uid: blazor/components
 ---
 # Create and use Razor components
@@ -45,6 +45,12 @@ Component members can then be used as part of the component's rendering logic us
 ```
 
 After the component is initially rendered, the component regenerates its render tree in response to events. Blazor then compares the new render tree against the previous one and applies any modifications to the browser's Document Object Model (DOM).
+
+Components are ordinary C# classes and can be placed anywhere within a project. Components that produce webpages usually reside in the *Pages* folder. Non-page components are frequently placed into the *Shared* folder or a custom folder added to the project. To use a custom folder, either add the custom folder's namespace to the parent component or to the app's *\_Imports.razor* file. For example, the following namespace makes components in a *Components* folder available when the app's root namespace is `WebApplication`:
+
+```cshtml
+@using WebApplication.Components
+```
 
 ## Integrate components into Razor Pages and MVC apps
 


### PR DESCRIPTION
Fixes #12690 

From Dan on the issue ...

> Components are just classes. They really can go anywhere you want. I just figured we already had one random folder in the template for non-page components that there was no reason to create another one for this tutorial.

I hit this on a sample because I incorrectly assumed (and forgot) that these folders don't use the app's root namespace. Just a bit here surfaces the basic concepts, especially for newbies ... *like me!* :baby:
