### PR TITLE
Update gRPC tutorial for preview 6

### DIFF
--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -4,7 +4,7 @@ author: juntaoluo
 description: This tutorial shows how to create a gRPC Service and gRPC client on ASP.NET Core. Learn how to create a gRPC Service project, edit a proto file, and add a duplex streaming call.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: johluo
-ms.date: 08/06/2019
+ms.date: 06/12/2019
 uid: tutorials/grpc/grpc-start
 ---
 # Tutorial: Create a gRPC client and server in ASP.NET Core
@@ -80,13 +80,13 @@ From Visual Studio, select **File > Open**, and then select the *GrpcGreeter.sln
 
 # [Visual Studio](#tab/visual-studio)
 
-* Press Ctrl+F5 to run the gRPC service without the debugger.
+* Press `Ctrl+F5` to run the gRPC service without the debugger.
 
   Visual Studio runs the service in a command prompt.
 
 # [Visual Studio Code / Visual Studio for Mac](#tab/visual-studio-code+visual-studio-mac)
 
-* Run the gRPC Greeter project GrpcGreeter from the command line using `dotnet run`.
+* Run the gRPC Greeter project *GrpcGreeter* from the command line using `dotnet run`.
 
 <!-- End of combined VS/Mac tabs -->
 
@@ -106,7 +106,7 @@ info: Microsoft.Hosting.Lifetime[0]
 
 ### Examine the project files
 
-GrpcGreeter files:
+*GrpcGreeter* project files:
 
 * *greet.proto*: The *Protos/greet.proto* file defines the `Greeter` gRPC and is used to generate the gRPC server assets. For more information, see [Introduction to gRPC](xref:grpc/index).
 * *Services* folder: Contains the implementation of the `Greeter` service.
@@ -153,7 +153,7 @@ Add the following packages to the gRPC client project:
 
 ### [Visual Studio](#tab/visual-studio)
 
-Install the packages using either the Package Manager Console (PMC) or Manage NuGet Package
+Install the packages using either the Package Manager Console (PMC) or Manage NuGet Packages.
 
 #### PMC option to install packages
 
@@ -210,7 +210,7 @@ dotnet add GrpcGreeterClient.csproj package Grpc.Tools
 
   # [Visual Studio for Mac](#tab/visual-studio-mac)
 
-  Right click the project and select **Tools > Edit File**.
+  Right-click the project and select **Tools > Edit File**.
 
   ---
 
@@ -236,7 +236,7 @@ Update the gRPC client *Program.cs* file with the following code:
 
 The Greeter client is created by:
 
-* Instantiating a `HttpClient` containing the information for creating the connection to the gRPC service.
+* Instantiating an `HttpClient` containing the information for creating the connection to the gRPC service.
 * Using the `HttpClient` to construct the Greeter client:
 
 [!code-cs[](~/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/Program.cs?name=snippet&highlight=3-9)]
@@ -249,8 +249,8 @@ The Greeter client calls the asynchronous `SayHello` method. The result of the `
 
 ### [Visual Studio](#tab/visual-studio)
 
-* In the Greeter service, press Ctrl+F5 to start the server without the debugger.
-* In the GrpcGreeterClient project, press Ctrl+F5 to start the server without the debugger.
+* In the Greeter service, press `Ctrl+F5` to start the server without the debugger.
+* In the `GrpcGreeterClient` project, press `Ctrl+F5` to start the server without the debugger.
 
 ### [Visual Studio Code / Visual Studio for Mac](#tab/visual-studio-code+visual-studio-mac)
 

--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -4,7 +4,7 @@ author: juntaoluo
 description: This tutorial shows how to create a gRPC Service and gRPC client on ASP.NET Core. Learn how to create a gRPC Service project, edit a proto file, and add a duplex streaming call.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: johluo
-ms.date: 06/05/2019
+ms.date: 08/06/2019
 uid: tutorials/grpc/grpc-start
 ---
 # Tutorial: Create a gRPC client and server in ASP.NET Core
@@ -147,7 +147,7 @@ Follow the instructions [here](/dotnet/core/tutorials/using-on-mac-vs-full-solut
 
 Add the following packages to the gRPC client project:
 
-* [Grpc.Core](https://www.nuget.org/packages/Grpc.Core), which contains the C# API for the C-core client.
+* [Grpc.Net.Client](https://www.nuget.org/packages/Grpc.Net.Client), which contains the .NET Core client.
 * [Google.Protobuf](https://www.nuget.org/packages/Google.Protobuf/), which contains protobuf message APIs for C#.
 * [Grpc.Tools](https://www.nuget.org/packages/Grpc.Tools/), which contains C# tooling support for protobuf files. The tooling package isn't required at runtime, so the dependency is marked with `PrivateAssets="All"`.
 
@@ -162,7 +162,7 @@ Install the packages using either the Package Manager Console (PMC) or Manage Nu
 * Run the following commands:
 
  ```powershell
-Install-Package Grpc.Core
+Install-Package Grpc.Net.Client
 Install-Package Google.Protobuf
 Install-Package Grpc.Tools
 ```
@@ -180,7 +180,7 @@ Install-Package Grpc.Tools
 Run the following commands from the **Integrated Terminal**:
 
 ```console
-dotnet add GrpcGreeterClient.csproj package Grpc.Core
+dotnet add GrpcGreeterClient.csproj package Grpc.Net.Client
 dotnet add GrpcGreeterClient.csproj package Google.Protobuf
 dotnet add GrpcGreeterClient.csproj package Grpc.Tools
 ```
@@ -188,8 +188,8 @@ dotnet add GrpcGreeterClient.csproj package Grpc.Tools
 ### [Visual Studio for Mac](#tab/visual-studio-mac)
 
 * Right-click the **Packages** folder in **Solution Pad** > **Add Packages**
-* Enter **Grpc.Core** in the search box.
-* Select the **Grpc.Core** package from the results pane and select **Add Package**
+* Enter **Grpc.Net.Client** in the search box.
+* Select the **Grpc.Net.Client** package from the results pane and select **Add Package**
 * Repeat for `Google.Protobuf` and `Grpc.Tools`.
 
 ---
@@ -236,8 +236,8 @@ Update the gRPC client *Program.cs* file with the following code:
 
 The Greeter client is created by:
 
-* Instantiating a `Channel` containing the information for creating the connection to the gRPC service.
-* Using the `Channel` to construct the Greeter client:
+* Instantiating a `HttpClient` containing the information for creating the connection to the gRPC service.
+* Using the `HttpClient` to construct the Greeter client:
 
 [!code-cs[](~/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/Program.cs?name=snippet&highlight=4-6)]
 

--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -239,13 +239,11 @@ The Greeter client is created by:
 * Instantiating a `HttpClient` containing the information for creating the connection to the gRPC service.
 * Using the `HttpClient` to construct the Greeter client:
 
-[!code-cs[](~/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/Program.cs?name=snippet&highlight=4-6)]
+[!code-cs[](~/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/Program.cs?name=snippet&highlight=3-9)]
 
 The Greeter client calls the asynchronous `SayHello` method. The result of the `SayHello` call is displayed:
 
-[!code-cs[](~/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/Program.cs?name=snippet&highlight=7-9)]
-
-Shut down the `Channel` used by the client when operations have finished to release all resources.
+[!code-cs[](~/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/Program.cs?name=snippet&highlight=10-12)]
 
 ## Test the gRPC client with the gRPC Greeter service
 

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeter/GrpcGreeter.csproj
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeter/GrpcGreeter.csproj
@@ -1,20 +1,18 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="Protos\greet.proto" GrpcServices="Server" Generator="MSBuild:Compile"/>
-    <Content Include="@(Protobuf)" />
-    <None Remove="@(Protobuf)" />
+    <Protobuf Include="Protos\greet.proto" GrpcServices="Server"/>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore.Server" Version="0.1.20-pre1" />
-    <PackageReference Include="Google.Protobuf" Version="3.7.0" />
+    <PackageReference Include="Grpc.AspNetCore.Server" Version="0.1.21-pre1" />
+    <PackageReference Include="Google.Protobuf" Version="3.8.0" />
 
-    <PackageReference Include="Grpc.Tools" Version="1.20.0-pre3" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Tools" Version="1.21.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/GrpcGreeterClient.csproj
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/GrpcGreeterClient.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.7.0" />
-    <PackageReference Include="Grpc.Core" Version="1.21.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.8.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="0.1.21-pre1" />
     <PackageReference Include="Grpc.Tools" Version="1.21.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/Program.cs
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/Program.cs
@@ -1,8 +1,9 @@
 ﻿#region snippet2
 using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Greet;
-using Grpc.Core;
+using Grpc.Net.Client;
 
 namespace GrpcGreeterClient
 {
@@ -11,14 +12,16 @@ namespace GrpcGreeterClient
         #region snippet
         static async Task Main(string[] args)
         {
+            AppContext.SetSwitch(
+                "System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport",
+                true);
+            var httpClient = new HttpClient();
             // The port number(50051) must match the port of the gRPC server.
-            var channel = new Channel("localhost:50051", 
-                                       ChannelCredentials.Insecure);
-            var client = new Greeter.GreeterClient(channel);
+            httpClient.BaseAddress = new Uri("http://localhost:49989");
+            var client = GrpcClient.Create<Greeter.GreeterClient>(httpClient);
             var reply = await client.SayHelloAsync(
                               new HelloRequest { Name = "GreeterClient" });
             Console.WriteLine("Greeting: " + reply.Message);
-            await channel.ShutdownAsync();
             Console.WriteLine("Press any key to exit...");
             Console.ReadKey();
         }

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/Program.cs
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/Program.cs
@@ -17,7 +17,7 @@ namespace GrpcGreeterClient
                 true);
             var httpClient = new HttpClient();
             // The port number(50051) must match the port of the gRPC server.
-            httpClient.BaseAddress = new Uri("http://localhost:49989");
+            httpClient.BaseAddress = new Uri("http://localhost:50051");
             var client = GrpcClient.Create<Greeter.GreeterClient>(httpClient);
             var reply = await client.SayHelloAsync(
                               new HelloRequest { Name = "GreeterClient" });


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-dotnet/issues/296

Should the client use TLS by default? The server template in preview 6 is not so we'd need to include instructions for adding TLS to the server.