### PR TITLE
Update 20_21.md

### DIFF
--- a/aspnetcore/migration/20_21.md
+++ b/aspnetcore/migration/20_21.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: This article covers the basics of migrating an ASP.NET Core 2.0 app to 2.1.
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/13/2019
+ms.date: 06/09/2019
 uid: migration/20_21
 ---
 # Migrate from ASP.NET Core 2.0 to 2.1
@@ -54,6 +54,7 @@ The following markup shows the template-generated 2.1 project file:
 ## Rules for projects targeting the shared framework
 
 A *shared framework* is a set of assemblies (*.dll* files) that are not in the app's folders. The shared framework must be installed on the machine to run the app. For more information, see [The shared framework](https://natemcmaster.com/blog/2018/08/29/netcore-primitives-2/).
+
 ASP.NET Core 2.1 includes the following shared frameworks:
 
 * [Microsoft.AspNetCore.App](xref:fundamentals/metapackage-app)
@@ -167,11 +168,11 @@ This section outlines the steps to replace the ASP.NET Core 2.0 template generat
 ### Update after scaffolding Identity
 
 * Delete the Identity scaffolder generated `IdentityDbContext` derived class in the *Areas/Identity/Data/* folder.
-* Delete *Areas/Identity/IdentityHostingStartup.cs*
+* Delete *Areas/Identity/IdentityHostingStartup.cs*.
 * Update the *\_LoginPartial.cshtml* file:
-  * Move *Pages/\_LoginPartial.cshtml* to *Pages/Shared/\_LoginPartial.cshtml*
+  * Move *Pages/\_LoginPartial.cshtml* to *Pages/Shared/\_LoginPartial.cshtml*.
   * Add `asp-area="Identity"` to the form and anchor links.
-  * Update the `<form />` element to `<form asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Page("/Index", new { area = "" })" method="post" id="logoutForm" class="navbar-right">`
+  * Update the `<form />` element to `<form asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Page("/Index", new { area = "" })" method="post" id="logoutForm" class="navbar-right">`.
 
   The following code shows the updated *\_LoginPartial.cshtml* file:
 
@@ -186,16 +187,16 @@ Update `ConfigureServices` with the following code:
 ### The layout file
 
 * Move *Pages/\_Layout.cshtml* to *Pages/Shared/\_Layout.cshtml*
-* Edit the file called *_ViewStart* located in *Areas/Identity/Pages/* and change *Layout = "/Pages/_Layout.cshtml"* to *Layout = "/Pages/Shared/_Layout.cshtml"*
-* The *Layout.cshtml* file has the following changes:
+* In *Areas/Identity/Pages/\_ViewStart.cshtml*, change `Layout = "/Pages/_Layout.cshtml"` to `Layout = "/Pages/Shared/_Layout.cshtml"`.
+* The *\_Layout.cshtml* file has the following changes:
 
   * `<partial name="_CookieConsentPartial" />` is added. For more information, see [GDPR support in ASP.NET Core](xref:security/gdpr).
-  * jQuery changes from 2.2.0 to 3.3.1
+  * jQuery changes from 2.2.0 to 3.3.1.
 
 ### \_ValidationScriptsPartial.cshtml
 
-* *Pages/\_ValidationScriptsPartial.cshtml* moves to *Pages/Shared/\_ValidationScriptsPartial.cshtml*
-* *jquery.validate/1.14.0* changes to *jquery.validate/1.17.0*
+* *Pages/\_ValidationScriptsPartial.cshtml* moves to *Pages/Shared/\_ValidationScriptsPartial.cshtml*.
+* *jquery.validate/1.14.0* changes to *jquery.validate/1.17.0*.
 
 ### New files
 

--- a/aspnetcore/migration/20_21.md
+++ b/aspnetcore/migration/20_21.md
@@ -186,6 +186,7 @@ Update `ConfigureServices` with the following code:
 ### The layout file
 
 * Move *Pages/\_Layout.cshtml* to *Pages/Shared/\_Layout.cshtml*
+* Edit the file called *_ViewStart* located in *Areas/Identity/Pages/* and change *Layout = "/Pages/_Layout.cshtml"* to *Layout = "/Pages/Shared/_Layout.cshtml"*
 * The *Layout.cshtml* file has the following changes:
 
   * `<partial name="_CookieConsentPartial" />` is added. For more information, see [GDPR support in ASP.NET Core](xref:security/gdpr).


### PR DESCRIPTION
I ran into an issue in that if you forget to change the layout path in _ViewStart.cshtml you will get a 404 error when trying to navigate to a page that uses the [Authorize] attribute and the user has not entered in their user credentials. By adding the correct path, the user will be redirected to the login page.  This edit provides the step to correct this issue.
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->