### PR TITLE
Remove anchor link from using-data-protection

### DIFF
--- a/aspnetcore/security/authentication/cookie.md
+++ b/aspnetcore/security/authentication/cookie.md
@@ -189,7 +189,7 @@ await HttpContext.Authentication.SignInAsync(
 
 `SignInAsync` creates an encrypted cookie and adds it to the current response. If you don't specify an `AuthenticationScheme`, the default scheme is used.
 
-Under the covers, the encryption used is ASP.NET Core's [Data Protection](xref:security/data-protection/using-data-protection#security-data-protection-getting-started) system. If you're hosting app on multiple machines, load balancing across apps, or using a web farm, then you must [configure data protection](xref:security/data-protection/configuration/overview) to use the same key ring and app identifier.
+Under the covers, the encryption used is ASP.NET Core's [Data Protection](xref:security/data-protection/using-data-protection) system. If you're hosting app on multiple machines, load balancing across apps, or using a web farm, then you must [configure data protection](xref:security/data-protection/configuration/overview) to use the same key ring and app identifier.
 
 ## Sign out
 


### PR DESCRIPTION
The anchor doesn't seem to add any value except for hiding the title of the page 😜.  The link is essentially to the top of the document.