### PR TITLE
Elaborate how view files are selected

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/adding-view.md
+++ b/aspnetcore/tutorials/first-mvc-app/adding-view.md
@@ -67,7 +67,7 @@ Replace the contents of the *Views/HelloWorld/Index.cshtml* Razor view file with
 
 [!code-HTML[](~/tutorials/first-mvc-app/start-mvc/sample/MvcMovie22/Views/HelloWorld/Index1.cshtml?highlight=7)]
 
-Navigate to `https://localhost:xxxx/HelloWorld`. The `Index` method in the `HelloWorldController` didn't do much; it ran the statement `return View();`, which specified that the method should use a view template file to render a response to the browser. Because you didn't explicitly specify the name of the view template file, MVC defaulted to using a view file with the same name as our caller method (`Index()` here) in the */Views/HelloWorld* folder, so the *Index.cshtml* view file will be used. The image below shows the string "Hello from our View Template!" hard-coded in the view.
+Navigate to `https://localhost:xxxx/HelloWorld`. The `Index` method in the `HelloWorldController` didn't do much; it ran the statement `return View();`, which specified that the method should use a view template file to render a response to the browser. Because a view template file name wasn't specified, MVC defaulted to using the default view file. The default view file has the same name as the method (`Index`), so in the */Views/HelloWorld/Index.cshtml* is used. The image below shows the string "Hello from our View Template!" hard-coded in the view.
 
 ![Browser window](~/tutorials/first-mvc-app/adding-view/_static/hell_template.png)
 

--- a/aspnetcore/tutorials/first-mvc-app/adding-view.md
+++ b/aspnetcore/tutorials/first-mvc-app/adding-view.md
@@ -67,7 +67,7 @@ Replace the contents of the *Views/HelloWorld/Index.cshtml* Razor view file with
 
 [!code-HTML[](~/tutorials/first-mvc-app/start-mvc/sample/MvcMovie22/Views/HelloWorld/Index1.cshtml?highlight=7)]
 
-Navigate to `https://localhost:xxxx/HelloWorld`. The `Index` method in the `HelloWorldController` didn't do much; it ran the statement `return View();`, which specified that the method should use a view template file to render a response to the browser. Because you didn't explicitly specify the name of the view template file, MVC defaulted to using the *Index.cshtml* view file in the */Views/HelloWorld* folder. The image below shows the string "Hello from our View Template!" hard-coded in the view.
+Navigate to `https://localhost:xxxx/HelloWorld`. The `Index` method in the `HelloWorldController` didn't do much; it ran the statement `return View();`, which specified that the method should use a view template file to render a response to the browser. Because you didn't explicitly specify the name of the view template file, MVC defaulted to using a view file with the same name as our caller method (`Index()` here) in the */Views/HelloWorld* folder, so the *Index.cshtml* view file will be used. The image below shows the string "Hello from our View Template!" hard-coded in the view.
 
 ![Browser window](~/tutorials/first-mvc-app/adding-view/_static/hell_template.png)
 


### PR DESCRIPTION
When no name parameter is provided to a `View()` method, a view file with the same name of the caller action will be used, not an `Index.cshtml` view file by default.