### PR TITLE
Workaround designer issue in VS

### DIFF
--- a/aspnetcore/host-and-deploy/windows-service/samples/2.x/AspNetCoreService/CustomWebHostService.cs
+++ b/aspnetcore/host-and-deploy/windows-service/samples/2.x/AspNetCoreService/CustomWebHostService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Hosting;
+﻿using System.ComponentModel;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.WindowsServices;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -6,6 +7,7 @@ using Microsoft.Extensions.Logging;
 namespace SampleApp
 {
     #region snippet_CustomWebHostService
+    [DesignerCategory("Code")]
     internal class CustomWebHostService : WebHostService
     {
         private ILogger _logger;


### PR DESCRIPTION
Because it inherits from `ServiceBase` (via `WebHostService`), VS treats this `CustomWebHostService` class like a "Component" and tries to open a design surface for it. This causes problems because the designer can't load properly over this type (it has a constructor). We are fixing `WebHostService` in 3.0 (and it's no longer recommended anyway, with Worker Service), but the 2.x sample should be updated to lead people down the happy path.

Addresses aspnet/AspNetCore#11114 for 2.1/2.2.