### PR TITLE
Add tech name to Blazor topics

### DIFF
--- a/aspnetcore/blazor/class-libraries.md
+++ b/aspnetcore/blazor/class-libraries.md
@@ -1,14 +1,14 @@
 ---
-title: Razor components class libraries
+title: ASP.NET Core Razor components class libraries
 author: guardrex
 description: Discover how components can be included in Blazor apps from an external component library.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 06/09/2019
+ms.date: 06/14/2019
 uid: blazor/class-libraries
 ---
-# Razor components class libraries
+# ASP.NET Core Razor components class libraries
 
 By [Simon Timms](https://github.com/stimms)
 

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -1,14 +1,14 @@
 ---
-title: Debug Blazor
+title: Debug ASP.NET Core Blazor
 author: guardrex
 description: Learn how to debug Blazor apps.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/15/2019
+ms.date: 06/14/2019
 uid: blazor/debug
 ---
-# Debug Blazor
+# Debug ASP.NET Core Blazor
 
 [Daniel Roth](https://github.com/danroth27)
 

--- a/aspnetcore/blazor/dependency-injection.md
+++ b/aspnetcore/blazor/dependency-injection.md
@@ -1,14 +1,14 @@
 ---
-title: Blazor dependency injection
+title: ASP.NET Core Blazor dependency injection
 author: guardrex
 description: See how Blazor apps can inject services into components.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/24/2019
+ms.date: 06/14/2019
 uid: blazor/dependency-injection
 ---
-# Blazor dependency injection
+# ASP.NET Core Blazor dependency injection
 
 By [Rainer Stropek](https://www.timecockpit.com)
 

--- a/aspnetcore/blazor/forms-validation.md
+++ b/aspnetcore/blazor/forms-validation.md
@@ -1,14 +1,14 @@
 ---
-title: Blazor forms and validation
+title: ASP.NET Core Blazor forms and validation
 author: guardrex
 description: Learn how to use forms and field validation scenarios in Blazor.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 06/12/2019
+ms.date: 06/14/2019
 uid: blazor/forms-validation
 ---
-# Blazor forms and validation
+# ASP.NET Core Blazor forms and validation
 
 By [Daniel Roth](https://github.com/danroth27) and [Luke Latham](https://github.com/guardrex)
 

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -1,14 +1,14 @@
 ---
-title: Get started with Blazor
+title: Get started with ASP.NET Core Blazor
 author: guardrex
 description: Get started with Blazor by building a Blazor app with the tooling of your choice.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 06/05/2019
+ms.date: 06/14/2019
 uid: blazor/get-started
 ---
-# Get started with Blazor
+# Get started with ASP.NET Core Blazor
 
 By [Daniel Roth](https://github.com/danroth27) and [Luke Latham](https://github.com/guardrex)
 

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -1,14 +1,14 @@
 ---
-title: Blazor hosting models
+title: ASP.NET Core Blazor hosting models
 author: guardrex
 description: Understand client-side and server-side Blazor hosting models.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 06/05/2019
+ms.date: 06/14/2019
 uid: blazor/hosting-models
 ---
-# Blazor hosting models
+# ASP.NET Core Blazor hosting models
 
 By [Daniel Roth](https://github.com/danroth27)
 

--- a/aspnetcore/blazor/javascript-interop.md
+++ b/aspnetcore/blazor/javascript-interop.md
@@ -1,14 +1,14 @@
 ---
-title: Blazor JavaScript interop
+title: ASP.NET Core Blazor JavaScript interop
 author: guardrex
 description: Learn how to invoke JavaScript functions from .NET and .NET methods from JavaScript in Blazor apps.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/29/2019
+ms.date: 06/14/2019
 uid: blazor/javascript-interop
 ---
-# Blazor JavaScript interop
+# ASP.NET Core Blazor JavaScript interop
 
 By [Javier Calvarro Nelson](https://github.com/javiercn), [Daniel Roth](https://github.com/danroth27), and [Luke Latham](https://github.com/guardrex)
 

--- a/aspnetcore/blazor/layouts.md
+++ b/aspnetcore/blazor/layouts.md
@@ -1,14 +1,14 @@
 ---
-title: Blazor layouts
+title: ASP.NET Core Blazor layouts
 author: guardrex
 description: Learn how to create reusable layout components for Blazor apps.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/24/2019
+ms.date: 06/14/2019
 uid: blazor/layouts
 ---
-# Blazor layouts
+# ASP.NET Core Blazor layouts
 
 By [Rainer Stropek](https://www.timecockpit.com)
 

--- a/aspnetcore/blazor/routing.md
+++ b/aspnetcore/blazor/routing.md
@@ -1,14 +1,14 @@
 ---
-title: Blazor routing
+title: ASP.NET Core Blazor routing
 author: guardrex
 description: Learn how to route requests in apps and about the NavLink component.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/14/2019
+ms.date: 06/14/2019
 uid: blazor/routing
 ---
-# Blazor routing
+# ASP.NET Core Blazor routing
 
 By [Luke Latham](https://github.com/guardrex)
 

--- a/aspnetcore/host-and-deploy/blazor/client-side.md
+++ b/aspnetcore/host-and-deploy/blazor/client-side.md
@@ -1,14 +1,14 @@
 ---
-title: Host and deploy Blazor client-side
+title: Host and deploy ASP.NET Core Blazor client-side
 author: guardrex
 description: Learn how to host and deploy a Blazor app using ASP.NET Core, Content Delivery Networks (CDN), file servers, and GitHub Pages.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/21/2019
+ms.date: 06/14/2019
 uid: host-and-deploy/blazor/client-side
 ---
-# Host and deploy Blazor client-side
+# Host and deploy ASP.NET Core Blazor client-side
 
 By [Luke Latham](https://github.com/guardrex), [Rainer Stropek](https://www.timecockpit.com), and [Daniel Roth](https://github.com/danroth27)
 

--- a/aspnetcore/host-and-deploy/blazor/configure-linker.md
+++ b/aspnetcore/host-and-deploy/blazor/configure-linker.md
@@ -1,14 +1,14 @@
 ---
-title: Configure the Linker for Blazor
+title: Configure the Linker for ASP.NET Core Blazor
 author: guardrex
 description: Learn how to control the Intermediate Language (IL) Linker when building a Blazor app.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/24/2019
+ms.date: 06/14/2019
 uid: host-and-deploy/blazor/configure-linker
 ---
-# Configure the Linker for Blazor
+# Configure the Linker for ASP.NET Core Blazor
 
 By [Luke Latham](https://github.com/guardrex)
 

--- a/aspnetcore/host-and-deploy/blazor/index.md
+++ b/aspnetcore/host-and-deploy/blazor/index.md
@@ -1,14 +1,14 @@
 ---
-title: Host and deploy Blazor
+title: Host and deploy ASP.NET Core Blazor
 author: guardrex
 description: Discover how to host and deploy Blazor apps.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/23/2019
+ms.date: 06/14/2019
 uid: host-and-deploy/blazor/index
 ---
-# Host and deploy Blazor
+# Host and deploy ASP.NET Core Blazor
 
 By [Luke Latham](https://github.com/guardrex), [Rainer Stropek](https://www.timecockpit.com), and [Daniel Roth](https://github.com/danroth27)
 
@@ -49,4 +49,4 @@ For deployment guidance, see the following topics:
 
 Blazor client-side apps can be served from [Azure Storage](https://azure.microsoft.com/services/storage/) as static content directly from a storage container.
 
-For more information, see [Host and deploy Blazor client-side (Standalone deployment): Azure Storage](xref:host-and-deploy/blazor/client-side#azure-storage).
+For more information, see [Host and deploy ASP.NET Core Blazor client-side (Standalone deployment): Azure Storage](xref:host-and-deploy/blazor/client-side#azure-storage).


### PR DESCRIPTION
Fixes #12865 

* Existed without "ASP.NET Core" because it was experimental and couldn't attach to the naming at that time.
* Three topics will have their titles updated on their existing PRs. This PR gets the rest of them.