### PR TITLE
Components topic code example updates

### DIFF
--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/Components/HeadingComponent.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/Components/HeadingComponent.razor
@@ -21,7 +21,7 @@
             _italicsCheck field.
         *@
         <input type="checkbox" id="italicsCheck" 
-               @bind="@_italicsCheck" />
+               @bind="_italicsCheck" />
         <label class="form-check-label" 
             for="italicsCheck">Use italics</label>
     </div>

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/Pages/CascadingValuesParametersTabSet.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/Pages/CascadingValuesParametersTabSet.razor
@@ -8,7 +8,7 @@
         <h4>Greetings from the first tab!</h4>
 
         <label>
-            <input type="checkbox" @bind="@showThirdTab" />
+            <input type="checkbox" @bind="showThirdTab" />
             Toggle third tab
         </label>
     </Tab>
@@ -49,7 +49,7 @@ namespace BlazorSample.UIInterfaces
         &lt;h4&gt;Greetings from the first tab!&lt;/h4&gt;
 
         &lt;label&gt;
-            &lt;input type="checkbox" @@bind="@@showThirdTab" /&gt;
+            &lt;input type="checkbox" @@bind="showThirdTab" /&gt;
             Toggle third tab
         &lt;/label&gt;
     &lt;/Tab&gt;

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/Pages/Index.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/Pages/Index.razor
@@ -40,7 +40,7 @@
         @@*
             A check box sets the font style and is bound to the _italicsCheck field.
         *@@
-        &lt;input type="checkbox" id="italicsCheck" @@bind="@@_italicsCheck" /&gt;
+        &lt;input type="checkbox" id="italicsCheck" @@bind="_italicsCheck" /&gt;
         &lt;label class="form-check-label" for="italicsCheck"&gt;Use italics&lt;/label&gt;
     &lt;/div&gt;
 

--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -5,7 +5,7 @@ description: Learn how to create and use Razor components, including how to bind
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 06/12/2019
+ms.date: 06/16/2019
 uid: blazor/components
 ---
 # Create and use Razor components
@@ -123,14 +123,14 @@ Data binding to both components and DOM elements is accomplished with the `@bind
 
 ```cshtml
 <input type="checkbox" class="form-check-input" id="italicsCheck" 
-    @bind="_italicsCheck" />
+    @bind="@_italicsCheck" />
 ```
 
 When the check box is selected and cleared, the property's value is updated to `true` and `false`, respectively.
 
 The check box is updated in the UI only when the component is rendered, not in response to changing the property's value. Since components render themselves after event handler code executes, property updates are usually reflected in the UI immediately.
 
-Using `@bind` with a `CurrentValue` property (`<input @bind="CurrentValue" />`) is essentially equivalent to the following:
+Using `@bind` with a `CurrentValue` property (`<input @bind="@CurrentValue" />`) is essentially equivalent to the following:
 
 ```cshtml
 <input value="@CurrentValue" 
@@ -142,7 +142,7 @@ When the component is rendered, the `value` of the input element comes from the 
 In addition to `onchange`, the property can be bound using other events like `oninput` by adding a `@bind` attribute with an `event` parameter:
 
 ```cshtml
-<input type="text" @bind-value="@CurrentValue" @bind-value:event="oninput" />
+<input @bind-value="@CurrentValue" @bind-value:event="oninput" />
 ```
 
 Unlike `onchange`, `oninput` fires for every character that is input into the text box.

--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -145,7 +145,7 @@ In addition to handling `onchange` events with `@bind` syntax, a property or fie
 <input @bind-value="CurrentValue" @bind-value:event="oninput" />
 ```
 
-Unlike `onchange`, `oninput` fires for every character changed in the text box.
+Unlike `onchange`, which fires when the element loses focus, `oninput` fires when the value of the text box changes.
 
 **Format strings**
 

--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -123,14 +123,14 @@ Data binding to both components and DOM elements is accomplished with the `@bind
 
 ```cshtml
 <input type="checkbox" class="form-check-input" id="italicsCheck" 
-    @bind="@_italicsCheck" />
+    @bind="_italicsCheck" />
 ```
 
 When the check box is selected and cleared, the property's value is updated to `true` and `false`, respectively.
 
 The check box is updated in the UI only when the component is rendered, not in response to changing the property's value. Since components render themselves after event handler code executes, property updates are usually reflected in the UI immediately.
 
-Using `@bind` with a `CurrentValue` property (`<input @bind="@CurrentValue" />`) is essentially equivalent to the following:
+Using `@bind` with a `CurrentValue` property (`<input @bind="CurrentValue" />`) is essentially equivalent to the following:
 
 ```cshtml
 <input value="@CurrentValue" 

--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -139,13 +139,13 @@ Using `@bind` with a `CurrentValue` property (`<input @bind="CurrentValue" />`) 
 
 When the component is rendered, the `value` of the input element comes from the `CurrentValue` property. When the user types in the text box, the `onchange` event is fired and the `CurrentValue` property is set to the changed value. In reality, the code generation is a little more complex because `@bind` handles a few cases where type conversions are performed. In principle, `@bind` associates the current value of an expression with a `value` attribute and handles changes using the registered handler.
 
-In addition to `onchange`, the property can be bound using other events like `oninput` by adding a `@bind` attribute with an `event` parameter:
+In addition to handling `onchange` events with `@bind` syntax, a property or field can be bound using other events by specifying an `@bind-value` attribute with an `event` parameter. The following example binds the `CurrentValue` property for the `oninput` event:
 
 ```cshtml
 <input @bind-value="CurrentValue" @bind-value:event="oninput" />
 ```
 
-Unlike `onchange`, `oninput` fires for every character that is input into the text box.
+Unlike `onchange`, `oninput` fires for every character changed in the text box.
 
 **Format strings**
 

--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -142,7 +142,7 @@ When the component is rendered, the `value` of the input element comes from the 
 In addition to `onchange`, the property can be bound using other events like `oninput` by adding a `@bind` attribute with an `event` parameter:
 
 ```cshtml
-<input @bind-value="@CurrentValue" @bind-value:event="oninput" />
+<input @bind-value="CurrentValue" @bind-value:event="oninput" />
 ```
 
 Unlike `onchange`, `oninput` fires for every character that is input into the text box.


### PR DESCRIPTION
 Fixes #12892

**Skip these remarks and access the diff. My confusion was cleared in the discussion.**

**This PR has the final set of updates that we need.**

RE: [Update blazor docs to reflect directive attributes changes (aspnet/AspNetCore.Docs \#12756)](https://github.com/aspnet/AspNetCore.Docs/pull/12756)

1. WRT the temporary (Pre6) need to place an `@` on a field/property value of an `@bind` directive. I looked at [Implement directive attribute feature for components (aspnet/AspNetCore \#6364)](https://github.com/aspnet/AspNetCore/issues/6364), but none of the description discusses the scenario.

   For example in the [Format strings section](https://docs.microsoft.com/aspnet/core/blazor/components?view=aspnetcore-3.0#data-binding) of the Components topic, updates didn't add the `@` to the value for `StartDate` ...

   ```cshtml
   <input @bind="StartDate" @bind:format="yyyy-MM-dd" />
   ```

   Same thing in the `ParentYear` examples (`@bind-{property}` syntax) ...

   ```cshtml
   <ChildComponent @bind-Year="ParentYear" />
   ```

    ... and should devs apply the `@`-value temporary rule to `@bind-value:event`/`bind-{property}:event`? It was left on the updates as ...

   ```cshtml
   <ChildComponent @bind-Year="ParentYear" @bind-Year:event="YearChanged" />
   ```

1. What's the difference between the following, if any:

   ```cshtml
   <input @bind="@CurrentValue" />
   ```

   ```cshtml
   <input @bind-value="@CurrentValue" @bind-value:event="onchange" />
   ```

   Is the former just a shorthand way of setting up `onchange` binding? If they are the same, it isn't considered better to have *Just One Consistent Way*:tm: :smile: to do it (the latter approach, which comports with other `on{event}` binding)?