### PR TITLE
Conventional middleware class requirements.

### DIFF
--- a/aspnetcore/fundamentals/middleware/index/snapshot/Culture/StartupCulture.cs
+++ b/aspnetcore/fundamentals/middleware/index/snapshot/Culture/StartupCulture.cs
@@ -12,7 +12,7 @@ namespace Culture
     {
         public void Configure(IApplicationBuilder app)
         {
-            app.Use((context, next) =>
+            app.Use(async (context, next) =>
             {
                 var cultureQuery = context.Request.Query["culture"];
                 if (!string.IsNullOrWhiteSpace(cultureQuery))
@@ -24,7 +24,7 @@ namespace Culture
                 }
 
                 // Call the next delegate/middleware in the pipeline
-                return next();
+                await next();
             });
 
             app.Run(async (context) =>

--- a/aspnetcore/fundamentals/middleware/write.md
+++ b/aspnetcore/fundamentals/middleware/write.md
@@ -35,7 +35,7 @@ The middleware class must include:
   * Return a `Task`.
   * Accept a first parameter of type <xref:Microsoft.AspNetCore.Http.HttpContext>.
   
-Additional constructor and `Invoke`/`InvokeAsync` parameters are populated by [dependency injection (DI)](xref:fundamentals/dependency-injection).
+Additional parameters for the constructor and `Invoke`/`InvokeAsync` are populated by [dependency injection (DI)](xref:fundamentals/dependency-injection).
 
 ## Middleware dependencies
 

--- a/aspnetcore/fundamentals/middleware/write.md
+++ b/aspnetcore/fundamentals/middleware/write.md
@@ -21,33 +21,28 @@ Middleware is generally encapsulated in a class and exposed with an extension me
 
 The preceding sample code is used to demonstrate creating a middleware component. For ASP.NET Core's built-in localization support, see <xref:fundamentals/localization>.
 
-You can test the middleware by passing in the culture. For example, `http://localhost:7997/?culture=no`.
+You can test the middleware by passing in the culture. For example, `https://localhost:5001/?culture=no`.
 
 The following code moves the middleware delegate to a class:
 
 [!code-csharp[](index/snapshot/Culture/RequestCultureMiddleware.cs)]
 
-::: moniker range="< aspnetcore-2.0"
+The middleware class must include:
 
-The middleware `Task` method's name must be `Invoke`. In ASP.NET Core 2.0 or later, the name can be either `Invoke` or `InvokeAsync`.
+* A public constructor with a parameter of type <xref:Microsoft.AspNetCore.Http.RequestDelegate>.
+* A public method named `Invoke` or `InvokeAsync`. This method must:
+  * Return a `Task`.
+  * Accept a first parameter of type <xref:Microsoft.AspNetCore.Http.HttpContext>.
+  
+Any additional constructor and `Invoke`/`InvokeAsync` parameters will be populated by [dependency injection (DI)](xref:fundamentals/dependency-injection).
 
-::: moniker-end
-
-## Middleware extension method
-
-The following extension method exposes the middleware through <xref:Microsoft.AspNetCore.Builder.IApplicationBuilder>:
-
-[!code-csharp[](index/snapshot/Culture/RequestCultureMiddlewareExtensions.cs)]
-
-The following code calls the middleware from `Startup.Configure`:
-
-[!code-csharp[](index/snapshot/Culture/Startup.cs?name=snippet1&highlight=5)]
+## Middleware dependencies
 
 Middleware should follow the [Explicit Dependencies Principle](/dotnet/standard/modern-web-apps-azure-architecture/architectural-principles#explicit-dependencies) by exposing its dependencies in its constructor. Middleware is constructed once per *application lifetime*. See the [Per-request dependencies](#per-request-dependencies) section if you need to share services with middleware within a request.
 
 Middleware components can resolve their dependencies from [dependency injection (DI)](xref:fundamentals/dependency-injection) through constructor parameters. [UseMiddleware&lt;T&gt;](/dotnet/api/microsoft.aspnetcore.builder.usemiddlewareextensions.usemiddleware#Microsoft_AspNetCore_Builder_UseMiddlewareExtensions_UseMiddleware_Microsoft_AspNetCore_Builder_IApplicationBuilder_System_Type_System_Object___) can also accept additional parameters directly.
 
-## Per-request dependencies
+### Per-request dependencies
 
 Because middleware is constructed at app startup, not per-request, *scoped* lifetime services used by middleware constructors aren't shared with other dependency-injected types during each request. If you must share a *scoped* service between your middleware and other types, add these services to the `Invoke` method's signature. The `Invoke` method can accept additional parameters that are populated by DI:
 
@@ -69,6 +64,16 @@ public class CustomMiddleware
     }
 }
 ```
+
+## Middleware extension method
+
+The following extension method exposes the middleware through <xref:Microsoft.AspNetCore.Builder.IApplicationBuilder>:
+
+[!code-csharp[](index/snapshot/Culture/RequestCultureMiddlewareExtensions.cs)]
+
+The following code calls the middleware from `Startup.Configure`:
+
+[!code-csharp[](index/snapshot/Culture/Startup.cs?name=snippet1&highlight=5)]
 
 ## Additional resources
 

--- a/aspnetcore/fundamentals/middleware/write.md
+++ b/aspnetcore/fundamentals/middleware/write.md
@@ -2,9 +2,10 @@
 title: Write custom ASP.NET Core middleware
 author: rick-anderson
 description: Learn how to write custom ASP.NET Core middleware.
+monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 02/14/2019
+ms.date: 06/17/2019
 uid: fundamentals/middleware/write
 ---
 # Write custom ASP.NET Core middleware
@@ -21,7 +22,7 @@ Middleware is generally encapsulated in a class and exposed with an extension me
 
 The preceding sample code is used to demonstrate creating a middleware component. For ASP.NET Core's built-in localization support, see <xref:fundamentals/localization>.
 
-You can test the middleware by passing in the culture. For example, `https://localhost:5001/?culture=no`.
+Test the middleware by passing in the culture. For example, request `https://localhost:5001/?culture=no`.
 
 The following code moves the middleware delegate to a class:
 
@@ -34,15 +35,15 @@ The middleware class must include:
   * Return a `Task`.
   * Accept a first parameter of type <xref:Microsoft.AspNetCore.Http.HttpContext>.
   
-Any additional constructor and `Invoke`/`InvokeAsync` parameters will be populated by [dependency injection (DI)](xref:fundamentals/dependency-injection).
+Additional constructor and `Invoke`/`InvokeAsync` parameters are populated by [dependency injection (DI)](xref:fundamentals/dependency-injection).
 
 ## Middleware dependencies
 
-Middleware should follow the [Explicit Dependencies Principle](/dotnet/standard/modern-web-apps-azure-architecture/architectural-principles#explicit-dependencies) by exposing its dependencies in its constructor. Middleware is constructed once per *application lifetime*. See the [Per-request dependencies](#per-request-dependencies) section if you need to share services with middleware within a request.
+Middleware should follow the [Explicit Dependencies Principle](/dotnet/standard/modern-web-apps-azure-architecture/architectural-principles#explicit-dependencies) by exposing its dependencies in its constructor. Middleware is constructed once per *application lifetime*. See the [Per-request middleware dependencies](#per-request-middleware-dependencies) section if you need to share services with middleware within a request.
 
 Middleware components can resolve their dependencies from [dependency injection (DI)](xref:fundamentals/dependency-injection) through constructor parameters. [UseMiddleware&lt;T&gt;](/dotnet/api/microsoft.aspnetcore.builder.usemiddlewareextensions.usemiddleware#Microsoft_AspNetCore_Builder_UseMiddlewareExtensions_UseMiddleware_Microsoft_AspNetCore_Builder_IApplicationBuilder_System_Type_System_Object___) can also accept additional parameters directly.
 
-### Per-request dependencies
+## Per-request middleware dependencies
 
 Because middleware is constructed at app startup, not per-request, *scoped* lifetime services used by middleware constructors aren't shared with other dependency-injected types during each request. If you must share a *scoped* service between your middleware and other types, add these services to the `Invoke` method's signature. The `Invoke` method can accept additional parameters that are populated by DI:
 


### PR DESCRIPTION
Fixes #11443.

I made a few changes here:

* Changed the delegate example to use `async`/`await` to match the approach used in the middleware class.
* Switched the example URL to use https and the template-generated default 5001 port for that.
* Added an explanation of the requirements for a middleware class. All of these requirements are enforced by the hosting startup process, where exceptions are thrown if the requirements aren't met.
* Moved the dependencies section up to below the requirements explanation I added. I think this follows on naturally.
* Made the per-request dependencies section a child of the higher-level dependencies section.

**TODO**:

I don't know how to test the moniker ranges locally, so I couldn't update the note about `InvokeAsync` being available in ASP.NET Core 2.0+. Ideally, I'd like to know how to test this locally but alternatively, please make the relevant change. I imagine this being a different version of the relevant bullet for < 2.0, e.g.:

> A public method named `Invoke`. In ASP.NET Core 2.0 or later, the name can also be `InvokeAsync`. This method must:

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->