### PR TITLE
Add warning to prevent es2015 minification errors

### DIFF
--- a/aspnetcore/client-side/bundling-and-minification.md
+++ b/aspnetcore/client-side/bundling-and-minification.md
@@ -4,7 +4,7 @@ author: scottaddie
 description: Learn how to optimize static resources in an ASP.NET Core web application by applying bundling and minification techniques.
 ms.author: scaddie
 ms.custom: mvc
-ms.date: 05/10/2019
+ms.date: 06/17/2019
 uid: client-side/bundling-and-minification
 ---
 # Bundle and minify static assets in ASP.NET Core
@@ -280,8 +280,9 @@ The *gulpfile.js* file reads the *bundleconfig.json* file for the inputs, output
 If Visual Studio and/or the Bundler & Minifier extension aren't available, convert manually.
 
 Add a *package.json* file, with the following `devDependencies`, to the project root:
+
 > [!WARNING]
-> Gulp-uglify does not support ES2015 and after. Use [gulp-terser](https://www.npmjs.com/package/gulp-terser) instead of  gulp-uglify if you need javascript ES2015 and after.
+> The `gulp-uglify` module doesn't support ECMAScript (ES) 2015 / ES6 and later. Install [gulp-terser](https://www.npmjs.com/package/gulp-terser) instead of `gulp-uglify` to use ES2015 / ES6 or later.
 
 [!code-json[](../client-side/bundling-and-minification/samples/BuildBundlerMinifierApp/package.json?range=5-13)]
 

--- a/aspnetcore/client-side/bundling-and-minification.md
+++ b/aspnetcore/client-side/bundling-and-minification.md
@@ -280,6 +280,8 @@ The *gulpfile.js* file reads the *bundleconfig.json* file for the inputs, output
 If Visual Studio and/or the Bundler & Minifier extension aren't available, convert manually.
 
 Add a *package.json* file, with the following `devDependencies`, to the project root:
+> [!WARNING]
+> Gulp-uglify does not support ES2015 and after. Use [gulp-terser](https://www.npmjs.com/package/gulp-terser) instead of  gulp-uglify if you need javascript ES2015 and after.
 
 [!code-json[](../client-side/bundling-and-minification/samples/BuildBundlerMinifierApp/package.json?range=5-13)]
 


### PR DESCRIPTION
Fixes #12861 
Adding warning message to understanding gulp-uglify errors with es2015 syntax and newer.
<!--
# Instructions
Fixes #12861 
NOTE: This is a comment; please type your descriptions above or below it.
-->