### PR TITLE
Security vulnerabilities in sample app

### DIFF
--- a/aspnetcore/security/cookie-sharing/sample/CookieAuthWithIdentity.NETFramework/CookieAuthWithIdentity.NETFramework/CookieAuthWithIdentity.NETFramework.csproj
+++ b/aspnetcore/security/cookie-sharing/sample/CookieAuthWithIdentity.NETFramework/CookieAuthWithIdentity.NETFramework/CookieAuthWithIdentity.NETFramework.csproj
@@ -114,8 +114,8 @@
     <Reference Include="System.Security.AccessControl, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.AccessControl.4.4.0\lib\net461\System.Security.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Cryptography.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.Xml.4.4.0\lib\net461\System.Security.Cryptography.Xml.dll</HintPath>
+    <Reference Include="System.Security.Cryptography.Xml, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Xml.4.4.2\lib\net461\System.Security.Cryptography.Xml.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Principal.Windows, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Principal.Windows.4.4.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>

--- a/aspnetcore/security/cookie-sharing/sample/CookieAuthWithIdentity.NETFramework/CookieAuthWithIdentity.NETFramework/Web.config
+++ b/aspnetcore/security/cookie-sharing/sample/CookieAuthWithIdentity.NETFramework/CookieAuthWithIdentity.NETFramework/Web.config
@@ -75,6 +75,10 @@
         <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.Xml" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.1" newVersion="4.0.0.1" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <entityFramework>

--- a/aspnetcore/security/cookie-sharing/sample/CookieAuthWithIdentity.NETFramework/CookieAuthWithIdentity.NETFramework/packages.config
+++ b/aspnetcore/security/cookie-sharing/sample/CookieAuthWithIdentity.NETFramework/CookieAuthWithIdentity.NETFramework/packages.config
@@ -56,7 +56,7 @@
   <package id="Respond" version="1.2.0" targetFramework="net461" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.4.0" targetFramework="net461" />
   <package id="System.Security.AccessControl" version="4.4.0" targetFramework="net461" />
-  <package id="System.Security.Cryptography.Xml" version="4.4.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Xml" version="4.4.2" targetFramework="net461" />
   <package id="System.Security.Principal.Windows" version="4.4.0" targetFramework="net461" />
   <package id="System.Text.Encodings.Web" version="4.4.0" targetFramework="net461" />
   <package id="WebGrease" version="1.5.2" targetFramework="net461" />


### PR DESCRIPTION
Fixes #12886

* System.Security.Cryptography.Xml taken to 4.4.2 per CVE-2018-0764 and CVE-2018-0765.
* Sample app confirmed running after this update.