### PR TITLE
Blazor event argument coverage

### DIFF
--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -299,13 +299,24 @@ Event handlers can also be asynchronous and return a <xref:System.Threading.Task
 
 For some events, event-specific event argument types are permitted. If access to one of these event types isn't necessary, it isn't required in the method call.
 
-The list of supported event arguments is:
+Supported [UIEventArgs](https://github.com/aspnet/AspNetCore/blob/master/src/Components/Components/src/UIEventArgs.cs) are shown in the following table.
 
-* UIEventArgs
-* UIChangeEventArgs
-* UIKeyboardEventArgs
-* UIMouseEventArgs
+| Event Class | Description |
+| ----------- | ----------- |
+| `UIChangeEventArgs` | Supplies information about an `<input>` change event. |
+| `UIKeyboardEventArgs` | Supplies information about a keyboard event. |
+| `UIMouseEventArgs` | Supplies information about a mouse event. |
+| `UIPointerEventArgs` | Supplies information about a mouse pointer event. |
+| `UIWheelEventArgs` | Supplies information about a mouse wheel event. |
+| `UIProgressEventArgs` | Supplies information about a progress event. |
+| `UITouchEventArgs` | Supplies information about a touch event. `UITouchPoint` represents a single contact point on a touch-sensitive device. |
+| `UIClipboardEventArgs` | Supplies information about an clipboard event. |
+| `UIDragEventArgs` | Supplies information about an drag event. `DataTransfer` is used to hold the dragged data during a drag and drop operation and may hold one or more `UIDataTransferItem`. `UIDataTransferItem` represents one drag data item.  |
+| `UIErrorEventArgs` | Supplies information about an error event. |
+| `UIFocusEventArgs` | Supplies information about a focus event. Doesn't include support for `relatedTarget`. |
 
+For information on the properties of these events and event handling behavior, see [UIEventArgs](https://github.com/aspnet/AspNetCore/blob/master/src/Components/Components/src/UIEventArgs.cs) in the reference source.
+  
 Lambda expressions can also be used:
 
 ```cshtml

--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -315,7 +315,7 @@ Supported [UIEventArgs](https://github.com/aspnet/AspNetCore/blob/master/src/Com
 | Progress | `UIProgressEventArgs` |
 | Touch | `UITouchEventArgs` &ndash; `UITouchPoint` represents a single contact point on a touch-sensitive device. |
 
-For information on the properties of these events and event handling behavior, see [UIEventArgs](https://github.com/aspnet/AspNetCore/blob/master/src/Components/Components/src/UIEventArgs.cs) in the reference source.
+For information on the properties and event handling behavior of the events in the preceding table, see [UIEventArgs](https://github.com/aspnet/AspNetCore/blob/master/src/Components/Components/src/UIEventArgs.cs) in the reference source.
   
 Lambda expressions can also be used:
 

--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -301,19 +301,19 @@ For some events, event-specific event argument types are permitted. If access to
 
 Supported [UIEventArgs](https://github.com/aspnet/AspNetCore/blob/master/src/Components/Components/src/UIEventArgs.cs) are shown in the following table.
 
-| Event Class | Description |
-| ----------- | ----------- |
-| `UIChangeEventArgs` | Supplies information about an `<input>` change event. |
-| `UIKeyboardEventArgs` | Supplies information about a keyboard event. |
-| `UIMouseEventArgs` | Supplies information about a mouse event. |
-| `UIPointerEventArgs` | Supplies information about a mouse pointer event. |
-| `UIWheelEventArgs` | Supplies information about a mouse wheel event. |
-| `UIProgressEventArgs` | Supplies information about a progress event. |
-| `UITouchEventArgs` | Supplies information about a touch event. `UITouchPoint` represents a single contact point on a touch-sensitive device. |
-| `UIClipboardEventArgs` | Supplies information about an clipboard event. |
-| `UIDragEventArgs` | Supplies information about an drag event. `DataTransfer` is used to hold the dragged data during a drag and drop operation and may hold one or more `UIDataTransferItem`. `UIDataTransferItem` represents one drag data item.  |
-| `UIErrorEventArgs` | Supplies information about an error event. |
-| `UIFocusEventArgs` | Supplies information about a focus event. Doesn't include support for `relatedTarget`. |
+| Event | Class |
+| ----- | ----- |
+| Clipboard | `UIClipboardEventArgs` |
+| Drag  | `UIDragEventArgs` &ndash; `DataTransfer` is used to hold the dragged data during a drag and drop operation and may hold one or more `UIDataTransferItem`. `UIDataTransferItem` represents one drag data item. |
+| Error | `UIErrorEventArgs` |
+| Focus | `UIFocusEventArgs` &ndash; Doesn't include support for `relatedTarget`. |
+| `<input>` change | `UIChangeEventArgs` |
+| Keyboard | `UIKeyboardEventArgs` |
+| Mouse | `UIMouseEventArgs` |
+| Mouse pointer | `UIPointerEventArgs` |
+| Mouse wheel | `UIWheelEventArgs` |
+| Progress | `UIProgressEventArgs` |
+| Touch | `UITouchEventArgs` &ndash; `UITouchPoint` represents a single contact point on a touch-sensitive device. |
 
 For information on the properties of these events and event handling behavior, see [UIEventArgs](https://github.com/aspnet/AspNetCore/blob/master/src/Components/Components/src/UIEventArgs.cs) in the reference source.
   


### PR DESCRIPTION
Fixes #12548

Decided to flip my first-pass table so that the human-readable event names are the keys. The values are the classes. It's probably a bit more reader- and :eye:-friendly this way.