### PR TITLE
Bump NSwag and Swashbuckle package versions

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-2.2.md
+++ b/aspnetcore/release-notes/aspnetcore-2.2.md
@@ -13,7 +13,7 @@ This article highlights the most significant changes in ASP.NET Core 2.2, with l
 
 ## OpenAPI Analyzers & Conventions
 
-OpenAPI (formerly known as Swagger) is a language-agnostic specification for describing REST APIs. The OpenAPI ecosystem has tools that allow for discovering, testing, and producing client code using the specification. Support for generating and visualizing OpenAPI documents in ASP.NET Core MVC is provided via community driven projects such as [NSwag](https://github.com/RicoSuter/NSwag), and [Swashbuckle.AspNetCore](https://github.com/domaindrivendev/Swashbuckle.AspNetCore). ASP.NET Core 2.2 provides improved tooling and runtime experiences for creating OpenAPI documents.
+OpenAPI (formerly known as Swagger) is a language-agnostic specification for describing REST APIs. The OpenAPI ecosystem has tools that allow for discovering, testing, and producing client code using the specification. Support for generating and visualizing OpenAPI documents in ASP.NET Core MVC is provided via community driven projects such as [NSwag](https://github.com/RicoSuter/NSwag) and [Swashbuckle.AspNetCore](https://github.com/domaindrivendev/Swashbuckle.AspNetCore). ASP.NET Core 2.2 provides improved tooling and runtime experiences for creating OpenAPI documents.
 
 For more information, see the following resources:
 

--- a/aspnetcore/release-notes/aspnetcore-2.2.md
+++ b/aspnetcore/release-notes/aspnetcore-2.2.md
@@ -13,7 +13,7 @@ This article highlights the most significant changes in ASP.NET Core 2.2, with l
 
 ## OpenAPI Analyzers & Conventions
 
-OpenAPI (formerly known as Swagger) is a language-agnostic specification for describing REST APIs. The OpenAPI ecosystem has tools that allow for discovering, testing, and producing client code using the specification. Support for generating and visualizing OpenAPI documents in ASP.NET Core MVC is provided via community driven projects such as [NSwag](https://github.com/RSuter/NSwag), and [Swashbuckle.AspNetCore](https://github.com/domaindrivendev/Swashbuckle.AspNetCore). ASP.NET Core 2.2 provides improved tooling and runtime experiences for creating OpenAPI documents.
+OpenAPI (formerly known as Swagger) is a language-agnostic specification for describing REST APIs. The OpenAPI ecosystem has tools that allow for discovering, testing, and producing client code using the specification. Support for generating and visualizing OpenAPI documents in ASP.NET Core MVC is provided via community driven projects such as [NSwag](https://github.com/RicoSuter/NSwag), and [Swashbuckle.AspNetCore](https://github.com/domaindrivendev/Swashbuckle.AspNetCore). ASP.NET Core 2.2 provides improved tooling and runtime experiences for creating OpenAPI documents.
 
 For more information, see the following resources:
 
@@ -47,7 +47,7 @@ For more information, see [Health checks in ASP.NET Core](xref:host-and-deploy/h
 
 ## HTTP/2 in Kestrel
 
-ASP.NET Core 2.2 adds support for HTTP/2. 
+ASP.NET Core 2.2 adds support for HTTP/2.
 
 HTTP/2 is a major revision of the HTTP protocol. Some of the notable features of HTTP/2 are support for header compression and fully multiplexed streams over a single connection. While HTTP/2 preserves HTTP’s semantics (HTTP headers, methods, etc) it's a breaking change from HTTP/1.x on how this data is framed and sent over the wire.
 

--- a/aspnetcore/tutorials/getting-started-with-NSwag.md
+++ b/aspnetcore/tutorials/getting-started-with-NSwag.md
@@ -85,11 +85,7 @@ dotnet add TodoApi.csproj package NSwag.AspNetCore
 
 ## Add and configure Swagger middleware
 
- Add and configure Swagger in your ASP.NET Core app by performing the following steps in the `Startup` class:
-
-* Import the following namespaces:
-
-[!code-csharp[](../tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup.cs?name=snippet_StartupConfigureImports)]
+Add and configure Swagger in your ASP.NET Core app by performing the following steps in the `Startup` class:
 
 * In the `ConfigureServices` method, register the required Swagger services:
 

--- a/aspnetcore/tutorials/getting-started-with-NSwag.md
+++ b/aspnetcore/tutorials/getting-started-with-NSwag.md
@@ -37,7 +37,7 @@ Register the NSwag middleware to:
 * Generate the Swagger specification for the implemented web API.
 * Serve the Swagger UI to browse and test the web API.
 
-To use the [NSwag](https://github.com/RSuter/NSwag) ASP.NET Core middleware, install the [NSwag.AspNetCore](https://www.nuget.org/packages/NSwag.AspNetCore/) NuGet package. This package contains the middleware to generate and serve the Swagger specification, Swagger UI (v2 and v3), and [ReDoc UI](https://github.com/Rebilly/ReDoc).
+To use the [NSwag](https://github.com/RicoSuter/NSwag) ASP.NET Core middleware, install the [NSwag.AspNetCore](https://www.nuget.org/packages/NSwag.AspNetCore/) NuGet package. This package contains the middleware to generate and serve the Swagger specification, Swagger UI (v2 and v3), and [ReDoc UI](https://github.com/Rebilly/ReDoc).
 
 Use one of the following approaches to install the NSwag NuGet package:
 
@@ -107,15 +107,15 @@ dotnet add TodoApi.csproj package NSwag.AspNetCore
 
 You can take advantage of NSwag's code generation capabilities by choosing one of the following options:
 
-* [NSwagStudio](https://github.com/NSwag/NSwag/wiki/NSwagStudio) &ndash; a Windows desktop app for generating API client code in C# or TypeScript.
+* [NSwagStudio](https://github.com/RicoSuter/NSwag/wiki/NSwagStudio) &ndash; a Windows desktop app for generating API client code in C# or TypeScript.
 * The [NSwag.CodeGeneration.CSharp](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) or [NSwag.CodeGeneration.TypeScript](https://www.nuget.org/packages/NSwag.CodeGeneration.TypeScript/) NuGet packages for code generation inside your project.
-* NSwag from the [command line](https://github.com/NSwag/NSwag/wiki/CommandLine).
-* The [NSwag.MSBuild](https://github.com/NSwag/NSwag/wiki/MSBuild) NuGet package.
+* NSwag from the [command line](https://github.com/RicoSuter/NSwag/wiki/CommandLine).
+* The [NSwag.MSBuild](https://github.com/RicoSuter/NSwag/wiki/MSBuild) NuGet package.
 * The [Unchase OpenAPI (Swagger) Connected Service](https://marketplace.visualstudio.com/items?itemName=Unchase.unchaseopenapiconnectedservice) &ndash; a Visual Studio Connected Service for generating API client code in C# or TypeScript. Also generates C# controllers for OpenAPI services with NSwag.
 
 ### Generate code with NSwagStudio
 
-* Install NSwagStudio by following the instructions at the [NSwagStudio GitHub repository](https://github.com/RSuter/NSwag/wiki/NSwagStudio).
+* Install NSwagStudio by following the instructions at the [NSwagStudio GitHub repository](https://github.com/RicoSuter/NSwag/wiki/NSwagStudio).
 * Launch NSwagStudio and enter the *swagger.json* file URL in the **Swagger Specification URL** text box. For example, *http://localhost:44354/swagger/v1/swagger.json*.
 * Click the **Create local Copy** button to generate a JSON representation of your Swagger specification.
 
@@ -271,7 +271,7 @@ The preceding action returns `IActionResult`, but inside the action it's returni
 
 ::: moniker range=">= aspnetcore-2.1"
 
- Because NSwag uses [Reflection](/dotnet/csharp/programming-guide/concepts/reflection), and the recommended return type for web API actions is [ActionResult\<T>](xref:Microsoft.AspNetCore.Mvc.ActionResult%601), it can only infer the return type defined by `T`. You can't automatically infer other possible return types. 
+ Because NSwag uses [Reflection](/dotnet/csharp/programming-guide/concepts/reflection), and the recommended return type for web API actions is [ActionResult\<T>](xref:Microsoft.AspNetCore.Mvc.ActionResult%601), it can only infer the return type defined by `T`. You can't automatically infer other possible return types.
 
 Consider the following example:
 

--- a/aspnetcore/tutorials/getting-started-with-NSwag.md
+++ b/aspnetcore/tutorials/getting-started-with-NSwag.md
@@ -4,7 +4,7 @@ author: zuckerthoben
 description: Learn how to use NSwag to generate documentation and help pages for an ASP.NET Core web API.
 ms.author: scaddie
 ms.custom: mvc
-ms.date: 12/30/2018
+ms.date: 06/21/2019
 uid: tutorials/get-started-with-nswag
 ---
 # Get started with NSwag and ASP.NET Core
@@ -85,13 +85,13 @@ dotnet add TodoApi.csproj package NSwag.AspNetCore
 
 ## Add and configure Swagger middleware
 
-Add and configure Swagger in your ASP.NET Core app by performing the following steps in the `Startup` class:
+Add and configure Swagger in your ASP.NET Core app by performing the following steps:
 
-* In the `ConfigureServices` method, register the required Swagger services:
+* In the `Startup.ConfigureServices` method, register the required Swagger services:
 
 [!code-csharp[](../tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup.cs?name=snippet_ConfigureServices&highlight=8)]
 
-* In the `Configure` method, enable the middleware for serving the generated Swagger specification and the Swagger UI:
+* In the `Startup.Configure` method, enable the middleware for serving the generated Swagger specification and the Swagger UI:
 
 [!code-csharp[](../tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup.cs?name=snippet_Configure&highlight=6-7)]
 

--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -69,7 +69,7 @@ dotnet add TodoApi.csproj package Swashbuckle.AspNetCore
 
 ## Add and configure Swagger middleware
 
-Import the following namespace to use the `Info` class:
+Import the following namespace to use the `OpenApiInfo` class:
 
 [!code-csharp[](../tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup2.cs?name=snippet_InfoClassNamespace)]
 

--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -4,7 +4,7 @@ author: zuckerthoben
 description: Learn how to add Swashbuckle to your ASP.NET Core web API project to integrate the Swagger UI.
 ms.author: scaddie
 ms.custom: mvc
-ms.date: 04/04/2019
+ms.date: 06/21/2019
 uid: tutorials/get-started-with-swashbuckle
 ---
 # Get started with Swashbuckle and ASP.NET Core
@@ -33,7 +33,7 @@ Swashbuckle can be added with the following approaches:
   * Execute the following command:
 
     ```powershell
-    Install-Package Swashbuckle.AspNetCore
+    Install-Package Swashbuckle.AspNetCore -Version 5.0.0-rc2
     ```
 
 * From the **Manage NuGet Packages** dialog:
@@ -54,7 +54,7 @@ Swashbuckle can be added with the following approaches:
 Run the following command from the **Integrated Terminal**:
 
 ```console
-dotnet add TodoApi.csproj package Swashbuckle.AspNetCore
+dotnet add TodoApi.csproj package Swashbuckle.AspNetCore -v 5.0.0-rc2
 ```
 
 ### [.NET Core CLI](#tab/netcore-cli)
@@ -62,14 +62,14 @@ dotnet add TodoApi.csproj package Swashbuckle.AspNetCore
 Run the following command:
 
 ```console
-dotnet add TodoApi.csproj package Swashbuckle.AspNetCore
+dotnet add TodoApi.csproj package Swashbuckle.AspNetCore -v 5.0.0-rc2
 ```
 
 ---
 
 ## Add and configure Swagger middleware
 
-Import the following namespace to use the `OpenApiInfo` class:
+In the `Startup` class, import the following namespace to use the `OpenApiInfo` class:
 
 [!code-csharp[](../tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup2.cs?name=snippet_InfoClassNamespace)]
 

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger.md
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger.md
@@ -13,7 +13,7 @@ By [Christoph Nienaber](https://twitter.com/zuckerthoben) and [Rico Suter](http:
 
 When consuming a Web API, understanding its various methods can be challenging for a developer. [Swagger](https://swagger.io/), also known as [OpenAPI](https://www.openapis.org/), solves the problem of generating useful documentation and help pages for Web APIs. It provides benefits such as interactive documentation, client SDK generation, and API discoverability.
 
-In this article, the [Swashbuckle.AspNetCore](https://github.com/domaindrivendev/Swashbuckle.AspNetCore) and [NSwag](https://github.com/RSuter/NSwag) .NET Swagger implementations are showcased:
+In this article, the [Swashbuckle.AspNetCore](https://github.com/domaindrivendev/Swashbuckle.AspNetCore) and [NSwag](https://github.com/RicoSuter/NSwag) .NET Swagger implementations are showcased:
 
 * **Swashbuckle.AspNetCore** is an open source project for generating Swagger documents for ASP.NET Core Web APIs.
 

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples.sln
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples.sln
@@ -1,0 +1,89 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29009.5
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "2.0", "2.0", "{2725557C-26F6-4862-884A-DEE669A46327}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TodoApi", "samples\2.0\TodoApi.NSwag\TodoApi.csproj", "{938A4A36-3F69-4D06-BA11-23333181E48B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TodoApi", "samples\2.0\TodoApi.Swashbuckle\TodoApi.csproj", "{4BC95ABB-D3BF-4E47-9D71-28EF8325FD8C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "2.1", "2.1", "{AEFA2811-67ED-4605-8C93-1645479F764A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TodoApi", "samples\2.1\TodoApi.NSwag\TodoApi.csproj", "{10DDA2BF-14D2-41A7-9BC4-F0179A272574}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TodoApi", "samples\2.1\TodoApi.Swashbuckle\TodoApi.csproj", "{DF75D4B8-44B5-4603-9617-26BD11EDE76B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{938A4A36-3F69-4D06-BA11-23333181E48B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{938A4A36-3F69-4D06-BA11-23333181E48B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{938A4A36-3F69-4D06-BA11-23333181E48B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{938A4A36-3F69-4D06-BA11-23333181E48B}.Debug|x64.Build.0 = Debug|Any CPU
+		{938A4A36-3F69-4D06-BA11-23333181E48B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{938A4A36-3F69-4D06-BA11-23333181E48B}.Debug|x86.Build.0 = Debug|Any CPU
+		{938A4A36-3F69-4D06-BA11-23333181E48B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{938A4A36-3F69-4D06-BA11-23333181E48B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{938A4A36-3F69-4D06-BA11-23333181E48B}.Release|x64.ActiveCfg = Release|Any CPU
+		{938A4A36-3F69-4D06-BA11-23333181E48B}.Release|x64.Build.0 = Release|Any CPU
+		{938A4A36-3F69-4D06-BA11-23333181E48B}.Release|x86.ActiveCfg = Release|Any CPU
+		{938A4A36-3F69-4D06-BA11-23333181E48B}.Release|x86.Build.0 = Release|Any CPU
+		{4BC95ABB-D3BF-4E47-9D71-28EF8325FD8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4BC95ABB-D3BF-4E47-9D71-28EF8325FD8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4BC95ABB-D3BF-4E47-9D71-28EF8325FD8C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4BC95ABB-D3BF-4E47-9D71-28EF8325FD8C}.Debug|x64.Build.0 = Debug|Any CPU
+		{4BC95ABB-D3BF-4E47-9D71-28EF8325FD8C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4BC95ABB-D3BF-4E47-9D71-28EF8325FD8C}.Debug|x86.Build.0 = Debug|Any CPU
+		{4BC95ABB-D3BF-4E47-9D71-28EF8325FD8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4BC95ABB-D3BF-4E47-9D71-28EF8325FD8C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4BC95ABB-D3BF-4E47-9D71-28EF8325FD8C}.Release|x64.ActiveCfg = Release|Any CPU
+		{4BC95ABB-D3BF-4E47-9D71-28EF8325FD8C}.Release|x64.Build.0 = Release|Any CPU
+		{4BC95ABB-D3BF-4E47-9D71-28EF8325FD8C}.Release|x86.ActiveCfg = Release|Any CPU
+		{4BC95ABB-D3BF-4E47-9D71-28EF8325FD8C}.Release|x86.Build.0 = Release|Any CPU
+		{10DDA2BF-14D2-41A7-9BC4-F0179A272574}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{10DDA2BF-14D2-41A7-9BC4-F0179A272574}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{10DDA2BF-14D2-41A7-9BC4-F0179A272574}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{10DDA2BF-14D2-41A7-9BC4-F0179A272574}.Debug|x64.Build.0 = Debug|Any CPU
+		{10DDA2BF-14D2-41A7-9BC4-F0179A272574}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{10DDA2BF-14D2-41A7-9BC4-F0179A272574}.Debug|x86.Build.0 = Debug|Any CPU
+		{10DDA2BF-14D2-41A7-9BC4-F0179A272574}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{10DDA2BF-14D2-41A7-9BC4-F0179A272574}.Release|Any CPU.Build.0 = Release|Any CPU
+		{10DDA2BF-14D2-41A7-9BC4-F0179A272574}.Release|x64.ActiveCfg = Release|Any CPU
+		{10DDA2BF-14D2-41A7-9BC4-F0179A272574}.Release|x64.Build.0 = Release|Any CPU
+		{10DDA2BF-14D2-41A7-9BC4-F0179A272574}.Release|x86.ActiveCfg = Release|Any CPU
+		{10DDA2BF-14D2-41A7-9BC4-F0179A272574}.Release|x86.Build.0 = Release|Any CPU
+		{DF75D4B8-44B5-4603-9617-26BD11EDE76B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DF75D4B8-44B5-4603-9617-26BD11EDE76B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DF75D4B8-44B5-4603-9617-26BD11EDE76B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DF75D4B8-44B5-4603-9617-26BD11EDE76B}.Debug|x64.Build.0 = Debug|Any CPU
+		{DF75D4B8-44B5-4603-9617-26BD11EDE76B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DF75D4B8-44B5-4603-9617-26BD11EDE76B}.Debug|x86.Build.0 = Debug|Any CPU
+		{DF75D4B8-44B5-4603-9617-26BD11EDE76B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DF75D4B8-44B5-4603-9617-26BD11EDE76B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DF75D4B8-44B5-4603-9617-26BD11EDE76B}.Release|x64.ActiveCfg = Release|Any CPU
+		{DF75D4B8-44B5-4603-9617-26BD11EDE76B}.Release|x64.Build.0 = Release|Any CPU
+		{DF75D4B8-44B5-4603-9617-26BD11EDE76B}.Release|x86.ActiveCfg = Release|Any CPU
+		{DF75D4B8-44B5-4603-9617-26BD11EDE76B}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{938A4A36-3F69-4D06-BA11-23333181E48B} = {2725557C-26F6-4862-884A-DEE669A46327}
+		{4BC95ABB-D3BF-4E47-9D71-28EF8325FD8C} = {2725557C-26F6-4862-884A-DEE669A46327}
+		{10DDA2BF-14D2-41A7-9BC4-F0179A272574} = {AEFA2811-67ED-4605-8C93-1645479F764A}
+		{DF75D4B8-44B5-4603-9617-26BD11EDE76B} = {AEFA2811-67ED-4605-8C93-1645479F764A}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {CBAC5A92-5105-4D43-BD3F-054454B681E3}
+	EndGlobalSection
+EndGlobal

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup.cs
@@ -1,10 +1,6 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-#region snippet_StartupConfigureImports
-using NJsonSchema;
-using NSwag.AspNetCore;
-#endregion
 using TodoApi.Models;
 
 namespace TodoApi
@@ -14,7 +10,7 @@ namespace TodoApi
         #region snippet_ConfigureServices
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddDbContext<TodoContext>(opt => 
+            services.AddDbContext<TodoContext>(opt =>
                 opt.UseInMemoryDatabase("TodoList"));
             services.AddMvc();
 

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup.cs
@@ -29,7 +29,7 @@ namespace TodoApi
             app.UseStaticFiles();
 
             // Register the Swagger generator and the Swagger UI middlewares
-            app.UseSwagger();
+            app.UseOpenApi();
             app.UseSwaggerUi3();
 
             app.UseMvc();

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup2.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup2.cs
@@ -27,13 +27,13 @@ namespace TodoApi
                     document.Info.Title = "ToDo API";
                     document.Info.Description = "A simple ASP.NET Core web API";
                     document.Info.TermsOfService = "None";
-                    document.Info.Contact = new NSwag.SwaggerContact
+                    document.Info.Contact = new NSwag.OpenApiContact
                     {
                         Name = "Shayne Boyer",
                         Email = string.Empty,
                         Url = "https://twitter.com/spboyer"
                     };
-                    document.Info.License = new NSwag.SwaggerLicense
+                    document.Info.License = new NSwag.OpenApiLicense
                     {
                         Name = "Use under LICX",
                         Url = "https://example.com/license"
@@ -49,7 +49,7 @@ namespace TodoApi
         {
             app.UseStaticFiles();
 
-            app.UseSwagger();
+            app.UseOpenApi();
             app.UseSwaggerUi3();
 
             app.UseMvc();

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup2.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup2.cs
@@ -1,10 +1,6 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-#region snippet_StartupConfigureImports
-using NJsonSchema;
-using NSwag.AspNetCore;
-#endregion
 using TodoApi.Models;
 
 namespace TodoApi

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/TodoApi.csproj
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/TodoApi.csproj
@@ -5,6 +5,12 @@
     <ProjectUISubcaption>NSwag - ASP.NET Core 2.0</ProjectUISubcaption>
   </PropertyGroup>
 
+  <!-- <snippet_NoDocumentGeneration> -->
+  <PropertyGroup>
+    <OpenApiGenerateDocuments>false</OpenApiGenerateDocuments>
+  </PropertyGroup>
+  <!-- </snippet_NoDocumentGeneration> -->
+
   <!-- <snippet_DocumentationFileElement> -->
   <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
@@ -14,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
-    <PackageReference Include="NSwag.AspNetCore" Version="11.19.2" />
+    <PackageReference Include="NSwag.AspNetCore" Version="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup.cs
@@ -1,11 +1,10 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using System;
+using System.IO;
+using System.Reflection;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
-using Swashbuckle.AspNetCore.Swagger;
-using System;
-using System.IO;
-using System.Reflection;
 using TodoApi.Models;
 
 namespace TodoApi
@@ -15,7 +14,7 @@ namespace TodoApi
         #region snippet_ConfigureServices
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddDbContext<TodoContext>(opt => 
+            services.AddDbContext<TodoContext>(opt =>
                 opt.UseInMemoryDatabase("TodoList"));
             services.AddMvc();
 
@@ -57,7 +56,7 @@ namespace TodoApi
             // Enable middleware to serve generated Swagger as a JSON endpoint.
             app.UseSwagger();
 
-            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.), 
+            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.),
             // specifying the Swagger JSON endpoint.
             app.UseSwaggerUI(c =>
             {

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Swagger;
 using System;
 using System.IO;
@@ -21,22 +22,22 @@ namespace TodoApi
             // Register the Swagger generator, defining 1 or more Swagger documents
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("v1", new Info
+                c.SwaggerDoc("v1", new OpenApiInfo
                 {
                     Version = "v1",
                     Title = "ToDo API",
                     Description = "A simple example ASP.NET Core Web API",
-                    TermsOfService = "None",
-                    Contact = new Contact
+                    TermsOfService = new Uri("https://example.com/terms"),
+                    Contact = new OpenApiContact
                     {
                         Name = "Shayne Boyer",
                         Email = string.Empty,
-                        Url = "https://twitter.com/spboyer"
+                        Url = new Uri("https://twitter.com/spboyer"),
                     },
-                    License = new License
+                    License = new OpenApiLicense
                     {
                         Name = "Use under LICX",
-                        Url = "https://example.com/license"
+                        Url = new Uri("https://example.com/license"),
                     }
                 });
 

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup1x.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup1x.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Swagger;
 using System;
 using System.IO;
@@ -22,22 +23,22 @@ namespace TodoApi
             // Register the Swagger generator, defining 1 or more Swagger documents
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("v1", new Info
+                c.SwaggerDoc("v1", new OpenApiInfo
                 {
                     Version = "v1",
                     Title = "ToDo API",
                     Description = "A simple example ASP.NET Core Web API",
-                    TermsOfService = "None",
-                    Contact = new Contact
+                    TermsOfService = new Uri("https://example.com/terms"),
+                    Contact = new OpenApiContact
                     {
                         Name = "Shayne Boyer",
                         Email = string.Empty,
-                        Url = "https://twitter.com/spboyer"
+                        Url = new Uri("https://twitter.com/spboyer"),
                     },
-                    License = new License
+                    License = new OpenApiLicense
                     {
                         Name = "Use under LICX",
-                        Url = "https://example.com/license"
+                        Url = new Uri("https://example.com/license"),
                     }
                 });
 
@@ -57,7 +58,7 @@ namespace TodoApi
             // Enable middleware to serve generated Swagger as a JSON endpoint.
             app.UseSwagger();
 
-            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.), 
+            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.),
             // specifying the Swagger JSON endpoint.
             app.UseSwaggerUI(c =>
             {

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup1x.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup1x.cs
@@ -1,12 +1,11 @@
 ﻿// This is the Startup.cs file for an ASP.NET Core 1.x app.
+using System;
+using System.IO;
+using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
-using Swashbuckle.AspNetCore.Swagger;
-using System;
-using System.IO;
-using System.Reflection;
 using TodoApi.Models;
 
 namespace TodoApi

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup2.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup2.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 #region snippet_InfoClassNamespace
-using Swashbuckle.AspNetCore.Swagger;
+using Microsoft.OpenApi.Models;
 #endregion
 using TodoApi.Models;
 
@@ -13,14 +13,14 @@ namespace TodoApi
         #region snippet_ConfigureServices
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddDbContext<TodoContext>(opt => 
+            services.AddDbContext<TodoContext>(opt =>
                 opt.UseInMemoryDatabase("TodoList"));
             services.AddMvc();
 
             // Register the Swagger generator, defining 1 or more Swagger documents
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("v1", new Info { Title = "My API", Version = "v1" });
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
             });
         }
         #endregion
@@ -31,7 +31,7 @@ namespace TodoApi
             // Enable middleware to serve generated Swagger as a JSON endpoint.
             app.UseSwagger();
 
-            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.), 
+            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.),
             // specifying the Swagger JSON endpoint.
             app.UseSwaggerUI(c =>
             {

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup3.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup3.cs
@@ -2,7 +2,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
-using Swashbuckle.AspNetCore.Swagger;
 using TodoApi.Models;
 
 namespace TodoApi
@@ -12,7 +11,7 @@ namespace TodoApi
         #region snippet_ConfigureServices
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddDbContext<TodoContext>(opt => 
+            services.AddDbContext<TodoContext>(opt =>
                 opt.UseInMemoryDatabase("TodoList"));
             services.AddMvc();
 
@@ -29,7 +28,7 @@ namespace TodoApi
             // Enable middleware to serve generated Swagger as a JSON endpoint.
             app.UseSwagger();
 
-            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.), 
+            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.),
             // specifying the Swagger JSON endpoint.
             #region snippet_UseSwaggerUI
             app.UseSwaggerUI(c =>

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup3.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup3.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Swagger;
 using TodoApi.Models;
 
@@ -18,7 +19,7 @@ namespace TodoApi
             // Register the Swagger generator, defining 1 or more Swagger documents
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("v1", new Info { Title = "My API", Version = "v1" });
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
             });
         }
         #endregion

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup4.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup4.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using System;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Swagger;
 using TodoApi.Models;
 
@@ -19,22 +21,22 @@ namespace TodoApi
             // Register the Swagger generator, defining 1 or more Swagger documents
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("v1", new Info
+                c.SwaggerDoc("v1", new OpenApiInfo
                 {
                     Version = "v1",
                     Title = "ToDo API",
                     Description = "A simple example ASP.NET Core Web API",
-                    TermsOfService = "None",
-                    Contact = new Contact
+                    TermsOfService = new Uri("https://example.com/terms"),
+                    Contact = new OpenApiContact
                     {
                         Name = "Shayne Boyer",
                         Email = string.Empty,
-                        Url = "https://twitter.com/spboyer"
+                        Url = new Uri("https://twitter.com/spboyer"),
                     },
-                    License = new License
+                    License = new OpenApiLicense
                     {
                         Name = "Use under LICX",
-                        Url = "https://example.com/license"
+                        Url = new Uri("https://example.com/license"),
                     }
                 });
             });

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup4.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup4.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
-using Swashbuckle.AspNetCore.Swagger;
 using TodoApi.Models;
 
 namespace TodoApi
@@ -52,7 +51,7 @@ namespace TodoApi
             // Enable middleware to serve generated Swagger as a JSON endpoint.
             app.UseSwagger();
 
-            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.), 
+            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.),
             // specifying the Swagger JSON endpoint.
             app.UseSwaggerUI(c =>
             {

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/TodoApi.csproj
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/TodoApi.csproj
@@ -5,6 +5,12 @@
     <ProjectUISubcaption>Swashbuckle - ASP.NET Core 2.0</ProjectUISubcaption>
   </PropertyGroup>
 
+  <!-- <snippet_NoDocumentGeneration> -->
+  <PropertyGroup>
+    <OpenApiGenerateDocuments>false</OpenApiGenerateDocuments>
+  </PropertyGroup>
+  <!-- </snippet_NoDocumentGeneration> -->
+
   <!-- <snippet_SuppressWarnings> -->
   <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/TodoApi.csproj
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/TodoApi.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="2.3.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc2" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.NSwag/Startup.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.NSwag/Startup.cs
@@ -2,10 +2,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-#region snippet_StartupConfigureImports
-using NJsonSchema;
-using NSwag.AspNetCore;
-#endregion
 using TodoApi.Models;
 
 namespace TodoApi

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.NSwag/Startup.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.NSwag/Startup.cs
@@ -15,7 +15,7 @@ namespace TodoApi
         #region snippet_ConfigureServices
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddDbContext<TodoContext>(opt => 
+            services.AddDbContext<TodoContext>(opt =>
                 opt.UseInMemoryDatabase("TodoList"));
             services.AddMvc()
                     .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
@@ -31,7 +31,7 @@ namespace TodoApi
             app.UseStaticFiles();
 
             // Register the Swagger generator and the Swagger UI middlewares
-            app.UseSwagger();
+            app.UseOpenApi();
             app.UseSwaggerUi3();
 
             app.UseMvc();

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.NSwag/TodoApi.csproj
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.NSwag/TodoApi.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="NSwag.AspNetCore" Version="12.0.15" />
+    <PackageReference Include="NSwag.AspNetCore" Version="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.Swashbuckle/Startup.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.Swashbuckle/Startup.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Swagger;
 using System;
 using System.IO;
@@ -15,7 +16,7 @@ namespace TodoApi
         #region snippet_ConfigureServices
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddDbContext<TodoContext>(opt => 
+            services.AddDbContext<TodoContext>(opt =>
                 opt.UseInMemoryDatabase("TodoList"));
             services.AddMvc()
                 .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
@@ -23,22 +24,22 @@ namespace TodoApi
             // Register the Swagger generator, defining 1 or more Swagger documents
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("v1", new Info
+                c.SwaggerDoc("v1", new OpenApiInfo
                 {
                     Version = "v1",
                     Title = "ToDo API",
                     Description = "A simple example ASP.NET Core Web API",
-                    TermsOfService = "None",
-                    Contact = new Contact
+                    TermsOfService = new Uri("https://example.com/terms"),
+                    Contact = new OpenApiContact
                     {
                         Name = "Shayne Boyer",
                         Email = string.Empty,
-                        Url = "https://twitter.com/spboyer"
+                        Url = new Uri("https://twitter.com/spboyer"),
                     },
-                    License = new License
+                    License = new OpenApiLicense
                     {
                         Name = "Use under LICX",
-                        Url = "https://example.com/license"
+                        Url = new Uri("https://example.com/license"),
                     }
                 });
 
@@ -58,7 +59,7 @@ namespace TodoApi
             // Enable middleware to serve generated Swagger as a JSON endpoint.
             app.UseSwagger();
 
-            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.), 
+            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.),
             // specifying the Swagger JSON endpoint.
             app.UseSwaggerUI(c =>
             {

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.Swashbuckle/Startup.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.Swashbuckle/Startup.cs
@@ -1,12 +1,11 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using System;
+using System.IO;
+using System.Reflection;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
-using Swashbuckle.AspNetCore.Swagger;
-using System;
-using System.IO;
-using System.Reflection;
 using TodoApi.Models;
 
 namespace TodoApi

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.Swashbuckle/Startup2.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.Swashbuckle/Startup2.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Swagger;
 using TodoApi.Models;
 
@@ -20,7 +21,7 @@ namespace TodoApi
             // Register the Swagger generator, defining 1 or more Swagger documents
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("v1", new Info { Title = "My API", Version = "v1" });
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
             });
         }
         #endregion

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.Swashbuckle/Startup2.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.Swashbuckle/Startup2.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
-using Swashbuckle.AspNetCore.Swagger;
 using TodoApi.Models;
 
 namespace TodoApi
@@ -32,7 +31,7 @@ namespace TodoApi
             // Enable middleware to serve generated Swagger as a JSON endpoint.
             app.UseSwagger();
 
-            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.), 
+            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.),
             // specifying the Swagger JSON endpoint.
             app.UseSwaggerUI(c =>
             {

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.Swashbuckle/TodoApi.csproj
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.Swashbuckle/TodoApi.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc2" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/web-api/action-return-types/samples/WebApiSample.Api.21/WebApiSample.Api.21.csproj
+++ b/aspnetcore/web-api/action-return-types/samples/WebApiSample.Api.21/WebApiSample.Api.21.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/aspnetcore/web-api/action-return-types/samples/WebApiSample.Api.Pre21/WebApiSample.Api.Pre21.csproj
+++ b/aspnetcore/web-api/action-return-types/samples/WebApiSample.Api.Pre21/WebApiSample.Api.Pre21.csproj
@@ -8,11 +8,11 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>bin\Debug\$(TargetFramework)\$(MSBuildProjectName).xml</DocumentationFile>
     <NoWarn>1701;1702;1705;1591</NoWarn>
-  </PropertyGroup>  
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="2.3.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- part of #8462
- react to changes in these new packages

nits:
- update NSwag URLs to current GitHub location
- add solution for web-api-help-pages-using-swagger projects
- remove unused namespaces