### PR TITLE
Add note about single-file deployments for in-proc

### DIFF
--- a/aspnetcore/host-and-deploy/iis/index.md
+++ b/aspnetcore/host-and-deploy/iis/index.md
@@ -64,6 +64,13 @@ In-process hosting is opt-in for existing apps, but [dotnet new](/dotnet/core/to
 
 `CreateDefaultBuilder` adds an <xref:Microsoft.AspNetCore.Hosting.Server.IServer> instance by calling the <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderIISExtensions.UseIIS*> method to boot the [CoreCLR](/dotnet/standard/glossary#coreclr) and host the app inside of the IIS worker process (*w3wp.exe* or *iisexpress.exe*). Performance tests indicate that hosting a .NET Core app in-process delivers significantly higher request throughput compared to hosting the app out-of-process and proxying requests to [Kestrel](xref:fundamentals/servers/kestrel) server.
 
+::: moniker range=">= aspnetcore-3.0"
+
+> [!NOTE]
+> Apps published as a single file executable can't be loaded by the in-process hosting model.
+
+::: moniker-end
+
 ### Out-of-process hosting model
 
 Because ASP.NET Core apps run in a process separate from the IIS worker process, the module handles process management. The module starts the process for the ASP.NET Core app when the first request arrives and restarts the app if it shuts down or crashes. This is essentially the same behavior as seen with apps that run in-process that are managed by the [Windows Process Activation Service (WAS)](/iis/manage/provisioning-and-managing-iis/features-of-the-windows-process-activation-service-was).

--- a/aspnetcore/host-and-deploy/iis/index.md
+++ b/aspnetcore/host-and-deploy/iis/index.md
@@ -64,12 +64,16 @@ In-process hosting is opt-in for existing apps, but [dotnet new](/dotnet/core/to
 
 `CreateDefaultBuilder` adds an <xref:Microsoft.AspNetCore.Hosting.Server.IServer> instance by calling the <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderIISExtensions.UseIIS*> method to boot the [CoreCLR](/dotnet/standard/glossary#coreclr) and host the app inside of the IIS worker process (*w3wp.exe* or *iisexpress.exe*). Performance tests indicate that hosting a .NET Core app in-process delivers significantly higher request throughput compared to hosting the app out-of-process and proxying requests to [Kestrel](xref:fundamentals/servers/kestrel) server.
 
+::: moniker-end
+
 ::: moniker range=">= aspnetcore-3.0"
 
 > [!NOTE]
 > Apps published as a single file executable can't be loaded by the in-process hosting model.
 
 ::: moniker-end
+
+::: moniker range=">= aspnetcore-2.2"
 
 ### Out-of-process hosting model
 


### PR DESCRIPTION
We don't support loading single-file deployments in-proc. We have a nice error but we should doc that too :).

I think this has a nested moniker, so I hope that works. I'll find out in the doc build! :)

[Internal Review Version](https://review.docs.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/index?view=aspnetcore-3.0&branch=pr-en-us-12956)