### PR TITLE
Remove PreserveCompilationContext requirement

### DIFF
--- a/aspnetcore/mvc/views/view-compilation.md
+++ b/aspnetcore/mvc/views/view-compilation.md
@@ -127,10 +127,6 @@ Runtime compilation is enabled using the `Microsoft.AspNetCore.Mvc.Razor.Runtime
       .AddRazorRuntimeCompilation()
   ```
 
-For runtime compilation to work when deployed, apps must modify their project files to set the `PreserveCompilationReferences` to `true`:
-
-[!code-xml[](view-compilation/sample/RuntimeCompilation.csproj?highlight=4)]
-
 ::: moniker-end
 
 ## Additional resources

--- a/aspnetcore/mvc/views/view-compilation.md
+++ b/aspnetcore/mvc/views/view-compilation.md
@@ -119,11 +119,11 @@ For guidance and examples of setting the app's compatibility version, see <xref:
 Runtime compilation is enabled using the `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation` package. To enable runtime compilation, apps must:
 
 * Install the [Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation/) NuGet package.
-* Update the application's `ConfigureServices` to include a call to `AddMvcRazorRuntimeCompilation`:
+* Update the application's `ConfigureServices` to include a call to `AddRazorRuntimeCompilation`:
 
   ```csharp
   services
-      .AddMvc()
+      .AddControllersWithViews()
       .AddRazorRuntimeCompilation()
   ```
 

--- a/aspnetcore/mvc/views/view-compilation.md
+++ b/aspnetcore/mvc/views/view-compilation.md
@@ -5,7 +5,7 @@ description: Learn how compilation of Razor files occurs in an ASP.NET Core app.
 monikerRange: '>= aspnetcore-1.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/30/2019
+ms.date: 06/20/2019
 uid: mvc/views/view-compilation
 ---
 # Razor file compilation in ASP.NET Core
@@ -119,12 +119,12 @@ For guidance and examples of setting the app's compatibility version, see <xref:
 Runtime compilation is enabled using the `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation` package. To enable runtime compilation, apps must:
 
 * Install the [Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation/) NuGet package.
-* Update the application's `ConfigureServices` to include a call to `AddRazorRuntimeCompilation`:
+* Update the project's `Startup.ConfigureServices` method to include a call to `AddRazorRuntimeCompilation`:
 
   ```csharp
   services
       .AddControllersWithViews()
-      .AddRazorRuntimeCompilation()
+      .AddRazorRuntimeCompilation();
   ```
 
 ::: moniker-end


### PR DESCRIPTION
The RuntimeCompilation package does this on user's behalf. We had a bug in one of the earlier preview releases that required this, but it should be fixed now.