### PR TITLE
Add Redis Backplane as scaleout option for ASP.NET Core SignalR

### DIFF
--- a/aspnetcore/signalr/version-differences.md
+++ b/aspnetcore/signalr/version-differences.md
@@ -162,6 +162,7 @@ ASP.NET SignalR supports SQL Server and Redis. ASP.NET Core SignalR supports Azu
 ### ASP.NET Core
 
 * [Azure SignalR Service](/azure/azure-signalr/)
+* [Redis Backplane](xref:signalr/redis-backplane)
 
 ## Additional resources
 


### PR DESCRIPTION
Shouldn't Redis Backplane listed as one of the option for ASP.NET Core SignalR scaleout?



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->