### PR TITLE
Improve the 1x to 2x migration guide about Windows Authentication

### DIFF
--- a/aspnetcore/migration/1x-to-2x/identity-2x.md
+++ b/aspnetcore/migration/1x-to-2x/identity-2x.md
@@ -3,7 +3,7 @@ title: Migrate authentication and Identity to ASP.NET Core 2.0
 author: scottaddie
 description: This article outlines the most common steps for migrating ASP.NET Core 1.x authentication and Identity to ASP.NET Core 2.0.
 ms.author: scaddie
-ms.date: 06/13/2019
+ms.date: 06/21/2019
 uid: migration/1x-to-2x/identity-2x
 ---
 # Migrate authentication and Identity to ASP.NET Core 2.0
@@ -298,29 +298,31 @@ In 2.0 projects, import the `Microsoft.AspNetCore.Authentication` namespace, and
 ## Windows Authentication (HTTP.sys / IISIntegration)
 
 There are two variations of Windows authentication:
-1. The host only allows authenticated users
-2. The host allows both anonymous and authenticated users
 
-The first variation described above is unaffected by the 2.0 changes.
+* The host only allows authenticated users. This variation isn't affected by the 2.0 changes.
+* The host allows both anonymous and authenticated users. This variation is affected by the 2.0 changes. For example, the app should allow anonymous users at the [IIS](xref:host-and-deploy/iis/index) or [HTTP.sys](xref:fundamentals/servers/httpsys) layer but authorize users at the controller level. In this scenario, set the default scheme in the `Startup.ConfigureServices` method.
 
-The second variation described above is affected by the 2.0 changes. For example, you may be allowing anonymous users into your app at the IIS or [HTTP.sys](xref:fundamentals/servers/httpsys) layer but authorizing users at the Controller level. In this scenario, set the default scheme to `HttpSysDefaults.AuthenticationScheme` or `IISDefaults.AuthenticationScheme` in the `Startup.ConfigureServices` method:
+  For [Microsoft.AspNetCore.Server.IISIntegration](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.IISIntegration/), set the default scheme to `IISDefaults.AuthenticationScheme`:
 
-For [Microsoft.AspNetCore.Server.HttpSys](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.HttpSys/)
-```csharp
-using Microsoft.AspNetCore.Server.HttpSys;
+  ```csharp
+  using Microsoft.AspNetCore.Server.IISIntegration;
 
-services.AddAuthentication(HttpSysDefaults.AuthenticationScheme);
-```
+  services.AddAuthentication(IISDefaults.AuthenticationScheme);
+  ```
 
-For [Microsoft.AspNetCore.Server.IISIntegration](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.IISIntegration/)
-```csharp
-using Microsoft.AspNetCore.Server.IISIntegration;
+  For [Microsoft.AspNetCore.Server.HttpSys](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.HttpSys/), set the default scheme to `HttpSysDefaults.AuthenticationScheme`:
 
-services.AddAuthentication(IISDefaults.AuthenticationScheme);
-```
+  ```csharp
+  using Microsoft.AspNetCore.Server.HttpSys;
 
-Failure to set the default scheme prevents the authorize request to challenge from working with the following exception:
-> `System.InvalidOperationException`: No authenticationScheme was specified, and there was no DefaultChallengeScheme found.
+  services.AddAuthentication(HttpSysDefaults.AuthenticationScheme);
+  ```
+
+  Failure to set the default scheme prevents the authorize (challenge) request from working with the following exception:
+
+  > `System.InvalidOperationException`: No authenticationScheme was specified, and there was no DefaultChallengeScheme found.
+
+For more information, see <xref:security/authentication/windowsauth>.
 
 <a name="identity-cookie-options"></a>
 

--- a/aspnetcore/migration/1x-to-2x/identity-2x.md
+++ b/aspnetcore/migration/1x-to-2x/identity-2x.md
@@ -303,13 +303,24 @@ There are two variations of Windows authentication:
 
 The first variation described above is unaffected by the 2.0 changes.
 
-The second variation described above is affected by the 2.0 changes. For example, you may be allowing anonymous users into your app at the IIS or [HTTP.sys](xref:fundamentals/servers/httpsys) layer but authorizing users at the Controller level. In this scenario, set the default scheme to `IISDefaults.AuthenticationScheme` in the `Startup.ConfigureServices` method:
+The second variation described above is affected by the 2.0 changes. For example, you may be allowing anonymous users into your app at the IIS or [HTTP.sys](xref:fundamentals/servers/httpsys) layer but authorizing users at the Controller level. In this scenario, set the default scheme to `HttpSysDefaults.AuthenticationScheme` or `IISDefaults.AuthenticationScheme` in the `Startup.ConfigureServices` method:
 
+For [Microsoft.AspNetCore.Server.HttpSys](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.HttpSys/)
 ```csharp
+using Microsoft.AspNetCore.Server.HttpSys;
+
+services.AddAuthentication(HttpSysDefaults.AuthenticationScheme);
+```
+
+For [Microsoft.AspNetCore.Server.IISIntegration](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.IISIntegration/)
+```csharp
+using Microsoft.AspNetCore.Server.IISIntegration;
+
 services.AddAuthentication(IISDefaults.AuthenticationScheme);
 ```
 
-Failure to set the default scheme prevents the authorize request to challenge from working.
+Failure to set the default scheme prevents the authorize request to challenge from working with the following exception:
+> `System.InvalidOperationException`: No authenticationScheme was specified, and there was no DefaultChallengeScheme found.
 
 <a name="identity-cookie-options"></a>
 


### PR DESCRIPTION
* Give precise instructions for both HTTP.sys and IISIntegration
    * Mention NuGet packages
    * Add `using` statements
* Spell out the full exception that would be thrown if authentication is not properly setup to improve searchability

It's clear from [ASP.NET Core 2.0 HttpSys Windows Authentication fails with Authorize attribute][1] answer on Stack Overflow that this part of documentation needed improvements:
> I initially thought that this wouldn't apply to HttpSys, given the full name of the constant (especially the IISIntegration threw me off).

[1]: https://stackoverflow.com/questions/45818095/asp-net-core-2-0-httpsys-windows-authentication-fails-with-authorize-attribute/45818096#45818096



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->