### PR TITLE
Added missing link to Visual Studio IDE

### DIFF
--- a/aspnetcore/fundamentals/choose-aspnet-framework.md
+++ b/aspnetcore/fundamentals/choose-aspnet-framework.md
@@ -30,7 +30,7 @@ The following table compares ASP.NET Core to ASP.NET 4.x.
 |Build for Windows, macOS, or Linux|Build for Windows|
 |[Razor Pages](xref:razor-pages/index) is the recommended approach to create a Web UI as of ASP.NET Core 2.x. See also [MVC](xref:mvc/overview), [Web API](xref:tutorials/first-web-api), and [SignalR](xref:signalr/introduction).|Use [Web Forms](/aspnet/web-forms), [SignalR](/aspnet/signalr), [MVC](/aspnet/mvc), [Web API](/aspnet/web-api/), [WebHooks](/aspnet/webhooks/), or [Web Pages](/aspnet/web-pages)|
 |Multiple versions per machine|One version per machine|
-|Develop with Visual Studio, [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/), or [Visual Studio Code](https://code.visualstudio.com/) using C# or F#|Develop with Visual Studio using C#, VB, or F#|
+|Develop with [Visual Studio](https://visualstudio.microsoft.com/vs/), [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/), or [Visual Studio Code](https://code.visualstudio.com/) using C# or F#|Develop with [Visual Studio](https://visualstudio.microsoft.com/vs/) using C#, VB, or F#|
 |Higher performance than ASP.NET 4.x|Good performance|
 |[Choose .NET Framework or .NET Core runtime](/dotnet/standard/choosing-core-framework-server)|Use .NET Framework runtime|
 


### PR DESCRIPTION
Hyperlinks to Visual Studio Code and Visual Studio for Mac are present but there was no hyperlink to Visual Studio IDE. So added that hyperlink.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->