### PR TITLE
Versioning patch

### DIFF
--- a/aspnetcore/host-and-deploy/aspnet-core-module.md
+++ b/aspnetcore/host-and-deploy/aspnet-core-module.md
@@ -103,6 +103,8 @@ For out-of-process, [CreateDefaultBuilder](xref:fundamentals/host/web-host#set-u
 * Configure the port and base path the server should listen on when running behind the ASP.NET Core Module.
 * Configure the host to capture startup errors.
 
+::: moniker-end
+
 ::: moniker range=">= aspnetcore-3.0"
 
 When hosting out-of-process, <xref:Microsoft.AspNetCore.Authentication.AuthenticationService.AuthenticateAsync*> isn't called internally to initialize a user. Therefore, an <xref:Microsoft.AspNetCore.Authentication.IClaimsTransformation> implementation used to transform claims after every authentication isn't activated by default. When transforming claims with an <xref:Microsoft.AspNetCore.Authentication.IClaimsTransformation> implementation, call <xref:Microsoft.Extensions.DependencyInjection.AuthenticationServiceCollectionExtensions.AddAuthentication*> to add authentication services:
@@ -121,6 +123,8 @@ public void Configure(IApplicationBuilder app)
 ```
 
 ::: moniker-end
+
+::: moniker range=">= aspnetcore-2.2"
 
 ### Hosting model changes
 


### PR DESCRIPTION
**_QUICK_** 🐇 versioning patch. Opening the diff further on https://github.com/aspnet/AspNetCore.Docs/pull/13074 from earlier today would've revealed that the added 3.0 content dropped right into the middle of previously versioned 2.2+ content. This should patch it up.