### PR TITLE
Minor tweaks to "IP Safelist".

### DIFF
--- a/aspnetcore/security/ip-safelist.md
+++ b/aspnetcore/security/ip-safelist.md
@@ -17,7 +17,7 @@ This article shows three ways to implement an IP safelist (also known as a white
 * Action filters to check the remote IP address of requests for specific controllers or action methods.
 * Razor Pages filters to check the remote IP address of requests for Razor pages.
 
-The sample app illustrates all approaches. In each case, a string containing approved client IP addresses is stored in an app setting. The middleware or filter parses the string into a list and checks if the remote IP is in the list. If not, an HTTP 403 Forbidden status code is returned.
+In each case, a string containing approved client IP addresses is stored in an app setting. The middleware or filter parses the string into a list and checks if the remote IP is in the list. If not, an HTTP 403 Forbidden status code is returned.
 
 [View or download sample code](https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/security/ip-safelist/samples/2.x/ClientIpAspNetCore) ([how to download](xref:index#how-to-download-a-sample))
 

--- a/aspnetcore/security/ip-safelist.md
+++ b/aspnetcore/security/ip-safelist.md
@@ -17,7 +17,7 @@ This article shows three ways to implement an IP safelist (also known as a white
 * Action filters to check the remote IP address of requests for specific controllers or action methods.
 * Razor Pages filters to check the remote IP address of requests for Razor pages.
 
-The sample app illustrates both approaches. In each case, a string containing approved client IP addresses is stored in an app setting. The middleware or filter parses the string into a list and  checks if the remote IP is in the list. If not, an HTTP 403 Forbidden status code is returned.
+The sample app illustrates all approaches. In each case, a string containing approved client IP addresses is stored in an app setting. The middleware or filter parses the string into a list and checks if the remote IP is in the list. If not, an HTTP 403 Forbidden status code is returned.
 
 [View or download sample code](https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/security/ip-safelist/samples/2.x/ClientIpAspNetCore) ([how to download](xref:index#how-to-download-a-sample))
 
@@ -31,7 +31,7 @@ The list is configured in the *appsettings.json* file. It's a semicolon-delimite
 
 The `Configure` method adds the middleware and passes the safelist string to it in a constructor parameter.
 
-[!code-csharp[](ip-safelist/samples/2.x/ClientIpAspNetCore/Startup.cs?name=snippet_Configure&highlight=7)]
+[!code-csharp[](ip-safelist/samples/2.x/ClientIpAspNetCore/Startup.cs?name=snippet_Configure&highlight=10)]
 
 The middleware parses the string into an array and looks for the remote IP address in the array. If the remote IP address is not found, the middleware returns HTTP 401 Forbidden. This validation process is bypassed for HTTP Get requests.
 

--- a/aspnetcore/security/ip-safelist/samples/2.x/ClientIpAspNetCore/AdminSafeListMiddleware.cs
+++ b/aspnetcore/security/ip-safelist/samples/2.x/ClientIpAspNetCore/AdminSafeListMiddleware.cs
@@ -49,13 +49,12 @@ namespace ClientIpAspNetCore
                 {
                     _logger.LogInformation(
                         $"Forbidden Request from Remote IP address: {remoteIp}");
-                    context.Response.StatusCode = (int)HttpStatusCode.Forbidden;
+                    context.Response.StatusCode = 401;
                     return;
                 }
             }
 
             await _next.Invoke(context);
-
         }
     }
     #endregion

--- a/aspnetcore/security/ip-safelist/samples/2.x/ClientIpAspNetCore/Startup.cs
+++ b/aspnetcore/security/ip-safelist/samples/2.x/ClientIpAspNetCore/Startup.cs
@@ -55,8 +55,7 @@ namespace ClientIpAspNetCore
 
             app.UseStaticFiles();
 
-            app.UseMiddleware<AdminSafeListMiddleware>(
-                Configuration["AdminSafeList"]);
+            app.UseMiddleware<AdminSafeListMiddleware>(Configuration["AdminSafeList"]);
             app.UseMvc();
         }
         #endregion


### PR DESCRIPTION
I was reading through [Client IP safelist for ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/security/ip-safelist?view=aspnetcore-2.2) (uid: security/ip-safelist) and I noticed some minor errors:

* 3 approaches are listed and then the text explains how *both* approaches are in the sample.
* A line highlight for the second snippet is off.
* One of the code examples uses an enum for a 403, whereas the others use 401 and they use it directly.

You'll see that I collapsed the code that needed to be highlighted onto 1 line, as this works out to be exactly 80 characters, which I've read is the max for docs pages.

---

I think the page could do with some more work, which I'm happy to raise as an issue if this isn't already on the radar. Of course, I'd also be happy to PR something for that too, once I've had a look at a couple of other PRs I've volunteered for. :sweat_smile:

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->