### PR TITLE
Remove curly braces from proto rpcs

### DIFF
--- a/aspnetcore/grpc/authn-and-authz/sample/Ticketer/Protos/ticket.proto
+++ b/aspnetcore/grpc/authn-and-authz/sample/Ticketer/Protos/ticket.proto
@@ -5,9 +5,9 @@ package Ticket;
 
 service Ticketer {
   // Get available ticket count
-  rpc GetAvailableTickets (google.protobuf.Empty) returns (AvailableTicketsResponse) {};
+  rpc GetAvailableTickets (google.protobuf.Empty) returns (AvailableTicketsResponse);
   // Buy tickets
-  rpc BuyTickets (BuyTicketsRequest) returns (BuyTicketsResponse) {};
+  rpc BuyTickets (BuyTicketsRequest) returns (BuyTicketsResponse);
 }
 
 // The response message containing the available ticket count

--- a/aspnetcore/grpc/authn-and-authz/sample/TicketerClient/Protos/ticket.proto
+++ b/aspnetcore/grpc/authn-and-authz/sample/TicketerClient/Protos/ticket.proto
@@ -5,9 +5,9 @@ package Ticket;
 
 service Ticketer {
   // Get available ticket count
-  rpc GetAvailableTickets (google.protobuf.Empty) returns (AvailableTicketsResponse) {};
+  rpc GetAvailableTickets (google.protobuf.Empty) returns (AvailableTicketsResponse);
   // Buy tickets
-  rpc BuyTickets (BuyTicketsRequest) returns (BuyTicketsResponse) {};
+  rpc BuyTickets (BuyTicketsRequest) returns (BuyTicketsResponse);
 }
 
 // The response message containing the available ticket count

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeter/Protos/greet.proto
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeter/Protos/greet.proto
@@ -5,7 +5,7 @@ package Greet;
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {};
+  rpc SayHello (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/Protos/greet.proto
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/Protos/greet.proto
@@ -5,7 +5,7 @@ package Greet;
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply);
 }
 
 // The request message containing the user's name.


### PR DESCRIPTION
This is the most common syntax for declaring proto rpcs