### PR TITLE
Update client-side template name for VS Preview

### DIFF
--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -5,7 +5,7 @@ description: Get started with Blazor by building a Blazor app with the tooling o
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 07/01/2019
+ms.date: 07/19/2019
 uid: blazor/get-started
 ---
 # Get started with ASP.NET Core Blazor
@@ -38,7 +38,7 @@ Get started with Blazor:
 
    6\. In the **Create a new ASP.NET Core Web Application** dialog, confirm that **.NET Core** and **ASP.NET Core 3.0** are selected.
 
-   7\. For a Blazor client-side experience, choose the **Blazor (client-side)** template. For a Blazor server-side experience, choose the **Blazor Server App** template. Select **Create**. For information on the two Blazor hosting models, server-side and client-side, see <xref:blazor/hosting-models>.
+   7\. For a Blazor client-side experience, choose the **Blazor WebAssembly App** template. For a Blazor server-side experience, choose the **Blazor Server App** template. Select **Create**. For information on the two Blazor hosting models, server-side and client-side, see <xref:blazor/hosting-models>.
 
    8\. Press **F5** to run the app.
 
@@ -80,7 +80,7 @@ Get started with Blazor:
 
    3\. In the sidebar, select **.NET Core** > **App**.
 
-   4\. For a Blazor server-side experience, select the **ASP.NET Core Blazor Server App** template. For a Blazor client-side experience, select the **ASP.NET Core Blazor (client-side)** template. Select **Next**. For information on the two Blazor hosting models, server-side and client-side, see <xref:blazor/hosting-models>.
+   4\. For a Blazor server-side experience, select the **ASP.NET Core Blazor Server App** template. For a Blazor client-side experience, select the **ASP.NET Core Blazor WebAssembly App** template. Select **Next**. For information on the two Blazor hosting models, server-side and client-side, see <xref:blazor/hosting-models>.
 
    5\. The **Target Framework** defaults to **.NET Core 3.0**. Select **Next**.
 


### PR DESCRIPTION
Fixes #13402

* From the community report, this change just rolled out a couple of days ago for 16.2 Pre4.
* I don't have VS Preview (no HD space left here). I might have Aquent send me a laptop tho to address this *little problem* 😩 going forward.
* WRT any other spots that call out the VS UI template name, I'll square them away on my upcoming *doc sweep*.