### PR TITLE
Update Blazor common sample to Pre7

### DIFF
--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/BlazorSample.csproj
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/BlazorSample.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.0.0-preview6.19307.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.0.0-preview6.19307.2" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.DevServer" Version="3.0.0-preview6.19307.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.0.0-preview7.19365.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.0.0-preview7.19365.7" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.DevServer" Version="3.0.0-preview7.19365.7" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/Pages/JSInterop.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/Pages/JSInterop.razor
@@ -48,7 +48,7 @@
 
 <!-- <snippet_JSInterop2> -->
 <button type="button" class="btn btn-primary"
-        @onclick="exampleJsFunctions.returnArrayAsyncJs()">
+        onclick="exampleJsFunctions.returnArrayAsyncJs()">
     Trigger .NET static method ReturnArrayAsync
 </button>
 


### PR DESCRIPTION
Fixes #13454

@danroth27 One thing threw me off for a sec. We were using the Razor syntax for the `onclick` (as `@onclick`) with the JS interop example to call the FNs, like this ...

```cshtml
<button type="button" class="btn btn-primary"
        @onclick="exampleJsFunctions.returnArrayAsyncJs()">
    Trigger .NET static method ReturnArrayAsync
</button>
```

Now, that yields a big 'ole :boom: ...

> Pages\JSInterop.razor(51,19,51,37): error CS0103: The name 'exampleJsFunctions' does not exist in the current context

I resolved it by going with an old skool `onclick` ...

```cshtml
<button type="button" class="btn btn-primary"
        onclick="exampleJsFunctions.returnArrayAsyncJs()">
    Trigger .NET static method ReturnArrayAsync
</button>
```

Idk if that's by-design or a regression. I'm going to go ahead and merge this and get it out there. Let me know if I need to do something else. :ear:

@scottaddie I'll take master to live after I merge this.