### PR TITLE
Turn off md024, 25, 36

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -7,7 +7,7 @@
     "fenced-code-language": true,
     "first-header-h1": false,
     "first-line-h1": false,
-    "header-increment": true,
+    "header-increment": false,
     "header-start-left": true,
     "header-style": {
         "style": "atx"
@@ -21,7 +21,7 @@
     "no-alt-text": true,
     "no-bare-urls": true,
     "no-blanks-blockquote": true,
-    "no-duplicate-header": true,
+    "no-duplicate-header": false,
     "no-empty-links": true,
     "no-hard-tabs": true,
     "no-inline-html": {
@@ -60,6 +60,6 @@
         ]
     },
     "required-headers": false,
-    "single-h1": true,
+    "single-h1": false,
     "ul-start-left": false
 }


### PR DESCRIPTION
These markdownlint rules cause too many false positives when tabs are used.  Tabs get flagged as duplicate headings and multiple h1s, and subsequent h3s get flagged as a jump in heading level even if there was an h2 before the tab.