### PR TITLE
Update DI example

### DIFF
--- a/aspnetcore/fundamentals/dependency-injection.md
+++ b/aspnetcore/fundamentals/dependency-injection.md
@@ -5,7 +5,7 @@ description: Learn how ASP.NET Core implements dependency injection and how to u
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 07/09/2019
+ms.date: 07/24/2019
 uid: fundamentals/dependency-injection
 ---
 # Dependency injection in ASP.NET Core
@@ -470,9 +470,9 @@ The factory method of single service, such as the second argument to [AddSinglet
   ```csharp
   public void MyMethod()
   {
-      var options = 
+      var optionsMonitor = 
           _services.GetService<IOptionsMonitor<MyOptions>>();
-      var option = options.CurrentValue.Option;
+      var option = optionsMonitor.CurrentValue.Option;
 
       ...
   }
@@ -481,16 +481,16 @@ The factory method of single service, such as the second argument to [AddSinglet
   **Correct**:
 
   ```csharp
-  private readonly MyOptions _options;
+  private readonly IOptionsMonitor<MyOptions> _optionsMonitor;
 
-  public MyClass(IOptionsMonitor<MyOptions> options)
+  public MyClass(IOptionsMonitor<MyOptions> optionsMonitor)
   {
-      _options = options.CurrentValue;
+      _optionsMonitor = optionsMonitor;
   }
 
   public void MyMethod()
   {
-      var option = _options.Option;
+      var option = _optionsMonitor.CurrentValue.Option;
 
       ...
   }

--- a/aspnetcore/fundamentals/dependency-injection.md
+++ b/aspnetcore/fundamentals/dependency-injection.md
@@ -468,31 +468,37 @@ The factory method of single service, such as the second argument to [AddSinglet
   **Incorrect:**
 
   ```csharp
-  public void MyMethod()
+  public class MyClass()
   {
-      var optionsMonitor = 
-          _services.GetService<IOptionsMonitor<MyOptions>>();
-      var option = optionsMonitor.CurrentValue.Option;
+      public void MyMethod()
+      {
+          var optionsMonitor = 
+              _services.GetService<IOptionsMonitor<MyOptions>>();
+          var option = optionsMonitor.CurrentValue.Option;
 
-      ...
+          ...
+      }
   }
   ```
 
   **Correct**:
 
   ```csharp
-  private readonly IOptionsMonitor<MyOptions> _optionsMonitor;
-
-  public MyClass(IOptionsMonitor<MyOptions> optionsMonitor)
+  public class MyClass
   {
-      _optionsMonitor = optionsMonitor;
-  }
+      private readonly IOptionsMonitor<MyOptions> _optionsMonitor;
 
-  public void MyMethod()
-  {
-      var option = _optionsMonitor.CurrentValue.Option;
+      public MyClass(IOptionsMonitor<MyOptions> optionsMonitor)
+      {
+          _optionsMonitor = optionsMonitor;
+      }
 
-      ...
+      public void MyMethod()
+      {
+          var option = _optionsMonitor.CurrentValue.Option;
+
+          ...
+      }
   }
   ```
 


### PR DESCRIPTION
Fixes #13450

* In this example (instructing the reader to avoid the service locator pattern), `MyClass` isn't a registered service ... it's just a class example ... so it's fine in its present form. However, @moikot correctly calls out that *IF* the pattern shown in the example were to be adopted by a singleton service that it won't work and probably isn't the best example.
* Let's inject `IOptionsMonitor<MyOptions>`, then pull the `CurrentValue` in the `MyMethod`. That will always work if this pattern were to become part of a singleton.
* This whole topic is coming up for a 3.0 update in a few weeks. I'll comb thru it (and take a look at the Options topic when it comes up) to see if any other little *gotchas* like this might be lurking.

Thanks @moikot for calling this out. 🎸