### PR TITLE
Fix indentation in Kestrel HTTPS config example

### DIFF
--- a/aspnetcore/fundamentals/servers/kestrel.md
+++ b/aspnetcore/fundamentals/servers/kestrel.md
@@ -681,41 +681,41 @@ In the following *appsettings.json* example:
 
 ```json
 {
-"Kestrel": {
-  "Endpoints": {
-    "Http": {
-      "Url": "http://localhost:5000"
-    },
+  "Kestrel": {
+    "Endpoints": {
+      "Http": {
+        "Url": "http://localhost:5000"
+      },
 
-    "HttpsInlineCertFile": {
-      "Url": "https://localhost:5001",
-      "Certificate": {
-        "Path": "<path to .pfx file>",
-        "Password": "<certificate password>"
+      "HttpsInlineCertFile": {
+        "Url": "https://localhost:5001",
+        "Certificate": {
+          "Path": "<path to .pfx file>",
+          "Password": "<certificate password>"
+        }
+      },
+
+      "HttpsInlineCertStore": {
+        "Url": "https://localhost:5002",
+        "Certificate": {
+          "Subject": "<subject; required>",
+          "Store": "<certificate store; required>",
+          "Location": "<location; defaults to CurrentUser>",
+          "AllowInvalid": "<true or false; defaults to false>"
+        }
+      },
+
+      "HttpsDefaultCert": {
+        "Url": "https://localhost:5003"
+      },
+
+      "Https": {
+        "Url": "https://*:5004",
+        "Certificate": {
+          "Path": "<path to .pfx file>",
+          "Password": "<certificate password>"
+        }
       }
-    },
-
-    "HttpsInlineCertStore": {
-      "Url": "https://localhost:5002",
-      "Certificate": {
-        "Subject": "<subject; required>",
-        "Store": "<certificate store; required>",
-        "Location": "<location; defaults to CurrentUser>",
-        "AllowInvalid": "<true or false; defaults to false>"
-      }
-    },
-
-    "HttpsDefaultCert": {
-      "Url": "https://localhost:5003"
-    },
-
-    "Https": {
-      "Url": "https://*:5004",
-      "Certificate": {
-      "Path": "<path to .pfx file>",
-      "Password": "<certificate password>"
-      }
-    }
     },
     "Certificates": {
       "Default": {


### PR DESCRIPTION
This fixes the indentation in the Kestrel endpoint configuration example which was sometimes indented at the wrong level making it a bit difficult to read.