### PR TITLE
Update RCL static asset path

### DIFF
--- a/aspnetcore/razor-pages/ui-class.md
+++ b/aspnetcore/razor-pages/ui-class.md
@@ -234,7 +234,7 @@ When packing an RCL, all companion assets in the *wwwroot* folder are included i
 
 ### Consume content from a referenced RCL
 
-The files included in the *wwwroot* folder of the RCL are exposed to the consuming app under the prefix `_content/{LIBRARY NAME}/`. `{LIBRARY NAME}` is the library project name converted to lowercase with periods (`.`) removed. For example, a library named *Razor.Class.Lib* results in a path to static content at `_content/razorclasslib/`.
+The files included in the *wwwroot* folder of the RCL are exposed to the consuming app under the prefix `_content/{LIBRARY NAME}/`. For example, a library named *Razor.Class.Lib* results in a path to static content at `_content/Razor.Class.Lib/`.
 
 The consuming app references static assets provided by the library with `<script>`, `<style>`, `<img>`, and other HTML tags. The consuming app must have [static file support](xref:fundamentals/static-files) enabled.
 


### PR DESCRIPTION
Path cleansing for RCL was reverted for preview 7.
This is creating confusion at 
Fixes https://github.com/aspnet/AspNetCore/issues/12561
Commit reference
https://github.com/aspnet/AspNetCore-Tooling/commit/98b168c8947d8c7f7b3f2beb3a0561fb89cadfb5



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->