### PR TITLE
aspnet/Identity on github has moved

### DIFF
--- a/aspnetcore/security/data-protection/consumer-apis/password-hashing.md
+++ b/aspnetcore/security/data-protection/consumer-apis/password-hashing.md
@@ -21,4 +21,4 @@ The package currently offers a method `KeyDerivation.Pbkdf2` which allows hashin
 
 [!code-csharp[](password-hashing/samples/passwordhasher.cs)]
 
-See the [source code](https://github.com/aspnet/Identity/blob/master/src/Core/PasswordHasher.cs) for ASP.NET Core Identity's `PasswordHasher` type for a real-world use case.
+See the [source code](https://github.com/aspnet/AspNetCore/blob/master/src/Identity/Extensions.Core/src/PasswordHasher.cs) for ASP.NET Core Identity's `PasswordHasher` type for a real-world use case.


### PR DESCRIPTION
The new location seems to be at [aspnet/AspNetCore/Identity/Extensions.Core](https://github.com/aspnet/AspNetCore/blob/master/src/Identity/Extensions.Core/src/PasswordHasher.cs)



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->