### PR TITLE
Add some hints on how to use tag helpers and areas together

### DIFF
--- a/aspnetcore/mvc/controllers/areas.md
+++ b/aspnetcore/mvc/controllers/areas.md
@@ -3,7 +3,7 @@ title: Areas in ASP.NET Core
 author: rick-anderson
 description: Learn how Areas are an ASP.NET MVC feature used to organize related functionality into a group as a separate namespace (for routing) and folder structure (for views).
 ms.author: riande
-ms.date: 05/10/2019
+ms.date: 08/07/2019
 uid: mvc/controllers/areas
 ---
 # Areas in ASP.NET Core
@@ -116,7 +116,7 @@ To share a common layout for the entire app, move the *_ViewStart.cshtml* to the
 
 ### _ViewImports.cshtml
 
-In its standard location */Views/_ViewImports.cshtml* does not apply to areas. To use common [tag helpers](xref:mvc/views/tag-helpers/intro), `@using` or `@inject` in your area, ensure a proper *_ViewImports.cshtml* file [applies to your area views](xref:/mvc/views/layout#importing-shared-directives). If you want the same behavior in all your views, just move */Views/_ViewImports.cshtml* to application root.
+In its standard location, */Views/_ViewImports.cshtml* doesn't apply to areas. To use common [Tag Helpers](xref:mvc/views/tag-helpers/intro), `@using`, or `@inject` in your area, ensure a proper *_ViewImports.cshtml* file [applies to your area views](xref:/mvc/views/layout#importing-shared-directives). If you want the same behavior in all your views, move */Views/_ViewImports.cshtml* to the application root.
 
 <a name="rename"></a>
 

--- a/aspnetcore/mvc/controllers/areas.md
+++ b/aspnetcore/mvc/controllers/areas.md
@@ -114,6 +114,10 @@ For more information, see [Routing to controller actions](xref:mvc/controllers/r
 
 To share a common layout for the entire app, move the *_ViewStart.cshtml* to the application root folder.
 
+### _ViewImports.cshtml
+
+In its standard location */Views/_ViewImports.cshtml* does not apply to areas. To use common [tag helpers](xref:mvc/views/tag-helpers/intro), `@using` or `@inject` in your area, ensure a proper *_ViewImports.cshtml* file [applies to your area views](xref:/mvc/views/layout#importing-shared-directives). If you want the same behavior in all your views, just move */Views/_ViewImports.cshtml* to application root.
+
 <a name="rename"></a>
 
 ### Change default area folder where views are stored

--- a/aspnetcore/mvc/controllers/areas.md
+++ b/aspnetcore/mvc/controllers/areas.md
@@ -116,7 +116,7 @@ To share a common layout for the entire app, move the *_ViewStart.cshtml* to the
 
 ### _ViewImports.cshtml
 
-In its standard location, */Views/_ViewImports.cshtml* doesn't apply to areas. To use common [Tag Helpers](xref:mvc/views/tag-helpers/intro), `@using`, or `@inject` in your area, ensure a proper *_ViewImports.cshtml* file [applies to your area views](xref:/mvc/views/layout#importing-shared-directives). If you want the same behavior in all your views, move */Views/_ViewImports.cshtml* to the application root.
+In its standard location, */Views/_ViewImports.cshtml* doesn't apply to areas. To use common [Tag Helpers](xref:mvc/views/tag-helpers/intro), `@using`, or `@inject` in your area, ensure a proper *_ViewImports.cshtml* file [applies to your area views](xref:mvc/views/layout#importing-shared-directives). If you want the same behavior in all your views, move */Views/_ViewImports.cshtml* to the application root.
 
 <a name="rename"></a>
 


### PR DESCRIPTION
The standard `asp-*` tag-helpers did not work when used from a view inside an area.

Could probably be written better, but this would at least save me some time, because I'd probably move `_ViewImports.cshtml` togheter with `_ViewStart.cshtml` when I started using Areas.

For current users it is good that `ctrl-f` `area` on [tag heplpers](https://docs.microsoft.com/en-us/aspnet/core/mvc/views/tag-helpers/built-in/?view=aspnetcore-3.0) would point directly to hints on what to do.


<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->