### PR TITLE
Document public [Parameter] expectation in 3.0.0-preview8.

### DIFF
--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/Components/ChildComponent.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/Components/ChildComponent.razor
@@ -9,12 +9,12 @@
 
 @code {
     [Parameter]
-    private string Title { get; set; }
+    public string Title { get; set; }
 
     [Parameter]
-    private RenderFragment ChildContent { get; set; }
+    public RenderFragment ChildContent { get; set; }
 
     [Parameter]
-    private EventCallback<UIMouseEventArgs> OnClick { get; set; }
+    public EventCallback<UIMouseEventArgs> OnClick { get; set; }
 }
 

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/Components/ListViewTemplate.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/Components/ListViewTemplate.razor
@@ -9,8 +9,8 @@
 
 @code {
     [Parameter]
-    private RenderFragment<TItem> ItemTemplate { get; set; }
+    public RenderFragment<TItem> ItemTemplate { get; set; }
 
     [Parameter]
-    private IReadOnlyList<TItem> Items { get; set; }
+    public IReadOnlyList<TItem> Items { get; set; }
 }

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/Components/Tab.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/Components/Tab.razor
@@ -10,13 +10,13 @@
 
 @code {
     [CascadingParameter]
-    private TabSet ContainerTabSet { get; set; }
+    public TabSet ContainerTabSet { get; set; }
 
     [Parameter]
-    private string Title { get; set; }
+    public string Title { get; set; }
 
     [Parameter]
-    public RenderFragment ChildContent { get; private set; }
+    public RenderFragment ChildContent { get; set; }
 
     private string TitleCssClass => ContainerTabSet.ActiveTab == this ? "active" : null;
 

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/Components/TabSet.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/Components/TabSet.razor
@@ -14,7 +14,7 @@
 
 @code {
     [Parameter]
-    private RenderFragment ChildContent { get; set; }
+    public RenderFragment ChildContent { get; set; }
 
     public ITab ActiveTab { get; private set; }
 

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/Components/TableTemplate.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/Components/TableTemplate.razor
@@ -17,14 +17,14 @@
 
 @code {
     [Parameter]
-    private RenderFragment TableHeader { get; set; }
+    public RenderFragment TableHeader { get; set; }
 
     [Parameter]
-    private RenderFragment<TItem> RowTemplate { get; set; }
+    public RenderFragment<TItem> RowTemplate { get; set; }
 
     [Parameter]
-    private RenderFragment TableFooter { get; set; }
+    public RenderFragment TableFooter { get; set; }
 
     [Parameter]
-    private IReadOnlyList<TItem> Items { get; set; }
+    public IReadOnlyList<TItem> Items { get; set; }
 }

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/Pages/CascadingValuesParametersTabSet.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/Pages/CascadingValuesParametersTabSet.razor
@@ -91,7 +91,7 @@ namespace BlazorSample.UIInterfaces
 
 @@code {
     [Parameter]
-    private RenderFragment ChildContent { get; set; }
+    public RenderFragment ChildContent { get; set; }
 
     public ITab ActiveTab { get; private set; }
 
@@ -140,10 +140,10 @@ namespace BlazorSample.UIInterfaces
     private TabSet ContainerTabSet { get; set; }
 
     [Parameter]
-    private string Title { get; set; }
+    public string Title { get; set; }
 
     [Parameter]
-    public RenderFragment ChildContent { get; private set; }
+    public RenderFragment ChildContent { get; set; }
 
     private string TitleCssClass => ContainerTabSet.ActiveTab == this ? "active" : null;
 

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/Pages/ParentComponent.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/Pages/ParentComponent.razor
@@ -61,11 +61,11 @@
 
 @@code {
     [Parameter]
-    private string Title { get; set; }
+    public string Title { get; set; }
 
     [Parameter]
-    private RenderFragment ChildContent { get; set; }
+    public RenderFragment ChildContent { get; set; }
 
     [Parameter]
-    private EventCallback&lt;UIMouseEventArgs&gt; OnClick { get; set; }
+    public EventCallback&lt;UIMouseEventArgs&gt; OnClick { get; set; }
 }</code></pre>

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample/Pages/RouteParameter.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample/Pages/RouteParameter.razor
@@ -26,7 +26,7 @@
 
 @@code {
     [Parameter]
-    private string Text { get; set; } = "fantastic";
+    public string Text { get; set; } = "fantastic";
 }</code></pre>
 <p>
     Example:

--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -5,7 +5,7 @@ description: Learn how to create and use Razor components, including how to bind
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 07/24/2019
+ms.date: 07/26/2019
 uid: blazor/components
 ---
 # Create and use ASP.NET Core Razor components
@@ -85,7 +85,7 @@ The following markup in *Index.razor* renders a `HeadingComponent` instance:
 
 ## Component parameters
 
-Components can have *component parameters*, which are defined using properties (usually *non-public*) on the component class with the `[Parameter]` attribute. Use attributes to specify arguments for a component in markup.
+Components can have *component parameters*, which are defined using public properties on the component class with the `[Parameter]` attribute. Use attributes to specify arguments for a component in markup.
 
 *Components/ChildComponent.razor*:
 
@@ -134,19 +134,19 @@ In the following example, the first `<input>` element (`id="useIndividualParams"
 
 @code {
     [Parameter]
-    private string Maxlength { get; set; } = "10";
+    public string Maxlength { get; set; } = "10";
 
     [Parameter]
-    private string Placeholder { get; set; } = "Input placeholder text";
+    public string Placeholder { get; set; } = "Input placeholder text";
 
     [Parameter]
-    private string Required { get; set; } = "required";
+    public string Required { get; set; } = "required";
 
     [Parameter]
-    private string Size { get; set; } = "50";
+    public string Size { get; set; } = "50";
 
     [Parameter]
-    private Dictionary<string, object> InputAttributes { get; set; } =
+    public Dictionary<string, object> InputAttributes { get; set; } =
         new Dictionary<string, object>()
         {
             { "maxlength", "10" }, 
@@ -180,7 +180,7 @@ To accept arbitrary attributes, define a component parameter using the `[Paramet
 ```cshtml
 @code {
     [Parameter(CaptureUnmatchedAttributes = true)]
-    private Dictionary<string, object> InputAttributes { get; set; }
+    public Dictionary<string, object> InputAttributes { get; set; }
 }
 ```
 
@@ -225,7 +225,7 @@ Data binding works with <xref:System.DateTime> format strings. Other format expr
 
 @code {
     [Parameter]
-    private DateTime StartDate { get; set; } = new DateTime(2020, 1, 1);
+    public DateTime StartDate { get; set; } = new DateTime(2020, 1, 1);
 }
 ```
 
@@ -244,10 +244,10 @@ The following child component (`ChildComponent`) has a `Year` component paramete
 
 @code {
     [Parameter]
-    private int Year { get; set; }
+    public int Year { get; set; }
 
     [Parameter]
-    private EventCallback<int> YearChanged { get; set; }
+    public EventCallback<int> YearChanged { get; set; }
 }
 ```
 
@@ -270,7 +270,7 @@ The following parent component uses `ChildComponent` and binds the `ParentYear` 
 
 @code {
     [Parameter]
-    private int ParentYear { get; set; } = 1978;
+    public int ParentYear { get; set; } = 1978;
 
     private void ChangeTheYear()
     {
@@ -504,7 +504,7 @@ Consider the following example:
 
 @code {
     [Parameter]
-    private IEnumerable<Person> People { get; set; }
+    public IEnumerable<Person> People { get; set; }
 }
 ```
 
@@ -520,7 +520,7 @@ The mapping process can be controlled with the `@key` directive attribute. `@key
 
 @code {
     [Parameter]
-    private IEnumerable<Person> People { get; set; }
+    public IEnumerable<Person> People { get; set; }
 }
 ```
 
@@ -772,7 +772,7 @@ In the following example, `IsCompleted` determines if `checked` is rendered in t
 
 @code {
     [Parameter]
-    private bool IsCompleted { get; set; }
+    public bool IsCompleted { get; set; }
 }
 ```
 
@@ -1072,7 +1072,7 @@ Consider the following `PetDetails` component, which can be manually built into 
 @code
 {
     [Parameter]
-    private string PetDetailsQuote { get; set; }
+    public string PetDetailsQuote { get; set; }
 }
 ```
 

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -5,7 +5,7 @@ description: Get started with Blazor by building a Blazor app with the tooling o
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 07/23/2019
+ms.date: 07/26/2019
 uid: blazor/get-started
 ---
 # Get started with ASP.NET Core Blazor
@@ -146,7 +146,7 @@ Run the app. The homepage has its own counter provided by the `Counter` componen
 
 Component parameters are specified using attributes or [child content](xref:blazor/components#child-content), which allow you to set properties on the child component. To add a parameter to the `Counter` component, update the component's `@code` block:
 
-* Add a property for `IncrementAmount` with a `[Parameter]` attribute.
+* Add a public property for `IncrementAmount` with a `[Parameter]` attribute.
 * Change the `IncrementCount` method to use the `IncrementAmount` when increasing the value of `currentCount`.
 
 *Pages/Counter.razor*:

--- a/aspnetcore/blazor/get-started/samples_snapshot/3.x/Counter2.razor
+++ b/aspnetcore/blazor/get-started/samples_snapshot/3.x/Counter2.razor
@@ -10,7 +10,7 @@
     private int currentCount = 0;
 
     [Parameter]
-    private int IncrementAmount { get; set; } = 1;
+    public int IncrementAmount { get; set; } = 1;
 
     private void IncrementCount()
     {

--- a/aspnetcore/blazor/index.md
+++ b/aspnetcore/blazor/index.md
@@ -5,7 +5,7 @@ description: Explore ASP.NET Core Blazor, a way to build interactive client-side
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: "mvc, seoapril2019"
-ms.date: 07/01/2019
+ms.date: 07/26/2019
 uid: blazor/index
 ---
 # Introduction to Blazor
@@ -55,10 +55,10 @@ The following Razor markup demonstrates a component (*Dialog.razor*), which can 
 
 @code {
     [Parameter]
-    private string Title { get; set; }
+    public string Title { get; set; }
 
     [Parameter]
-    private RenderFragment ChildContent { get; set; }
+    public RenderFragment ChildContent { get; set; }
 
     private void OnYes()
     {

--- a/aspnetcore/blazor/routing/samples_snapshot/3.x/Constraint.razor
+++ b/aspnetcore/blazor/routing/samples_snapshot/3.x/Constraint.razor
@@ -4,5 +4,5 @@
 
 @code {
     [Parameter]
-    private int Id { get; set; }
+    public int Id { get; set; }
 }

--- a/aspnetcore/tutorials/build-your-first-blazor-app.md
+++ b/aspnetcore/tutorials/build-your-first-blazor-app.md
@@ -5,7 +5,7 @@ description: Build a Blazor app step-by-step.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 07/01/2019
+ms.date: 07/26/2019
 uid: tutorials/first-blazor-app
 ---
 # Build your first Blazor app
@@ -61,7 +61,7 @@ Include a component in another component using an HTML syntax.
 
 ## Component parameters
 
-Components can also have parameters. Component parameters are defined using non-public properties on the component class decorated with `[Parameter]`. Use attributes to specify arguments for a component in markup.
+Components can also have parameters. Component parameters are defined using public properties on the component class decorated with `[Parameter]`. Use attributes to specify arguments for a component in markup.
 
 1. Update the component's `@code` C# code:
 

--- a/aspnetcore/tutorials/build-your-first-blazor-app/samples_snapshot/3.x/Counter.razor
+++ b/aspnetcore/tutorials/build-your-first-blazor-app/samples_snapshot/3.x/Counter.razor
@@ -10,7 +10,7 @@
     private int currentCount = 0;
 
     [Parameter]
-    private int IncrementAmount { get; set; } = 1;
+    public int IncrementAmount { get; set; } = 1;
 
     private void IncrementCount()
     {


### PR DESCRIPTION
- A lot of the parameter documentation was already present (such as not setting parameters outside of their declaring class).
- Updated all `[Parameter]` locations to utilize `public` properties with `public` setters.
- Updated all the locations I could find where we were suggesting users to utilize non-public parameters.

Fixes #13453