### PR TITLE
Update health-checks.md

### DIFF
--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -263,16 +263,15 @@ private static Task WriteResponse(HttpContext httpContext,
 {
     httpContext.Response.ContentType = "application/json";
 
-    var json = new JObject(
-        new JProperty("status", result.Status.ToString()),
-        new JProperty("results", new JObject(result.Entries.Select(pair =>
-            new JProperty(pair.Key, new JObject(
-                new JProperty("status", pair.Value.Status.ToString()),
-                new JProperty("description", pair.Value.Description),
-                new JProperty("data", new JObject(pair.Value.Data.Select(
-                    p => new JProperty(p.Key, p.Value))))))))));
-    return httpContext.Response.WriteAsync(
-        json.ToString(Formatting.Indented));
+    var jsonString = JsonConvert.SerializeObject(result, Formatting.Indented,
+        new JsonSerializerSettings
+        {
+            Converters = new List<JsonConverter>
+            {
+                new Newtonsoft.Json.Converters.StringEnumConverter(),
+            }
+        });
+    return httpContext.Response.WriteAsync(jsonString);
 }
 ```
 

--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -5,7 +5,7 @@ description: Learn how to set up health checks for ASP.NET Core infrastructure, 
 monikerRange: '>= aspnetcore-2.2'
 ms.author: riande
 ms.custom: mvc
-ms.date: 07/11/2019
+ms.date: 07/27/2019
 uid: host-and-deploy/health-checks
 ---
 # Health checks in ASP.NET Core
@@ -246,6 +246,7 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 The <xref:Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions.ResponseWriter> option gets or sets a delegate used to write the response. The default delegate writes a minimal plaintext response with the string value of [HealthReport.Status](xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthReport.Status).
 
 ```csharp
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 


### PR DESCRIPTION
This proposal attempts to simplify the sample code in the `ResponseWriter` delegate to be a little easier to read and remove the numerous new JProperty and JObject invocations. The `StringEnumConverter` is passed into the serializer to ensure the `HealthStatus` enum's are rendered by their names and not their values (Healthy or Unhealthy vs. 2 or 0).
Thank you.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->