### PR TITLE
Surface troubleshooting overview in hosting topics

### DIFF
--- a/aspnetcore/host-and-deploy/azure-apps/index.md
+++ b/aspnetcore/host-and-deploy/azure-apps/index.md
@@ -5,7 +5,7 @@ description: This article contains links to Azure host and deploy resources.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 07/16/2019
+ms.date: 07/28/2019
 uid: host-and-deploy/azure-apps/index
 ---
 # Deploy ASP.NET Core apps to Azure App Service
@@ -35,6 +35,9 @@ Set up a CI build for an ASP.NET Core app, then create a continuous deployment r
 
 [Azure Web App sandbox](https://github.com/projectkudu/kudu/wiki/Azure-Web-App-sandbox)  
 Discover Azure App Service runtime execution limitations enforced by the Azure Apps platform.
+
+<xref:test/troubleshoot>  
+Understand and troubleshoot warnings and errors with ASP.NET Core projects.
 
 ## Application configuration
 

--- a/aspnetcore/host-and-deploy/iis/index.md
+++ b/aspnetcore/host-and-deploy/iis/index.md
@@ -5,7 +5,7 @@ description: Learn how to host ASP.NET Core apps on Windows Server Internet Info
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 07/16/2019
+ms.date: 07/28/2019
 uid: host-and-deploy/iis/index
 ---
 # Host ASP.NET Core on Windows with IIS
@@ -24,6 +24,8 @@ The following operating systems are supported:
 [HTTP.sys server](xref:fundamentals/servers/httpsys) (formerly called WebListener) doesn't work in a reverse proxy configuration with IIS. Use the [Kestrel server](xref:fundamentals/servers/kestrel).
 
 For information on hosting in Azure, see <xref:host-and-deploy/azure-apps/index>.
+
+For troubleshooting guidance, see <xref:test/troubleshoot>.
 
 ## Supported platforms
 


### PR DESCRIPTION
Fixes #13533 

An additional approach to surfacing the troubleshooting guidance is to place at link in or near the introductions of the IIS and Azure Apps topics. We already surface troubleshooting guidance in the *Additional Resources* sections, but this should aid readers when they're sent to these topics from a cross-link that we don't control (e.g., framework messages/links).

Close this PR if this doesn't look like it will be of any help. Just *spit-ball'in* here.