### PR TITLE
Add documentation for using gRPC on macOS

### DIFF
--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -106,7 +106,7 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
         });
 ```
 
-The gRPC client must set the `System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport` switch to true and use `http` in the server address:
+The gRPC client must set the `System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport` switch to `true` and use `http` in the server address:
 
 ```csharp
 // This switch must be set before creating the HttpClient.

--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -119,7 +119,7 @@ var client = GrpcClient.Create<Greeter.GreeterClient>(httpClient);
 ```
 
 > [!WARNING]
-> HTTP/2 without [Transport Layer Security (TLS)](https://tools.ietf.org/html/rfc5246) should only be used during app development. Production applications should always use transport security. For more information, see [Security considerations in gRPC for ASP.NET Core](xref:grpc/security#transport-security).
+> HTTP/2 without TLS should only be used during app development. Production applications should always use transport security. For more information, see [Security considerations in gRPC for ASP.NET Core](xref:grpc/security#transport-security).
 
 ## Additional resources
 

--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -84,7 +84,7 @@ The gRPC API provides access to some HTTP/2 message data, such as the method, ho
 
 ## gRPC and ASP.NET Core on macOS
 
-Kestrel doesn't support HTTP/2 with [Transport Layer Security (TLS)](https://tools.ietf.org/html/rfc5246) on macOS. The ASP.NET Core gRPC template and samples use TLS by default, and you will see this error message when you attempt to start the gRPC server:
+Kestrel doesn't support HTTP/2 with [Transport Layer Security (TLS)](https://tools.ietf.org/html/rfc5246) on macOS. The ASP.NET Core gRPC template and samples use TLS by default. You'll see the following error message when you attempt to start the gRPC server:
 
 > Unable to bind to https://localhost:5001 on the IPv4 loopback interface: 'HTTP/2 over TLS is not supported on OSX due to missing ALPN support.'.
 

--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -119,7 +119,7 @@ var client = GrpcClient.Create<Greeter.GreeterClient>(httpClient);
 ```
 
 > [!WARNING]
-> HTTP/2 without [Transport Layer Security (TLS)](https://tools.ietf.org/html/rfc5246) should only be used during app development. Production applications should always use transport security. Visit [Security considerations in gRPC for ASP.NET Core](xref:grpc/security#transport-security) for more information.
+> HTTP/2 without [Transport Layer Security (TLS)](https://tools.ietf.org/html/rfc5246) should only be used during app development. Production applications should always use transport security. For more information, see [Security considerations in gRPC for ASP.NET Core](xref:grpc/security#transport-security).
 
 ## Additional resources
 

--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -99,7 +99,7 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
         {
             webBuilder.ConfigureKestrel(options =>
             {
-                // Setup a HTTP/2 endpoint without TLS
+                // Setup a HTTP/2 endpoint without TLS.
                 options.ListenLocalhost(5001, o => o.Protocols = HttpProtocols.Http2);
             });
             webBuilder.UseStartup<Startup>();

--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -4,7 +4,7 @@ author: juntaoluo
 description: Learn the basic concepts when writing gRPC services with ASP.NET Core.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: johluo
-ms.date: 07/03/2019
+ms.date: 08/07/2019
 uid: grpc/aspnetcore
 ---
 # gRPC services with ASP.NET Core

--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -90,7 +90,7 @@ Kestrel doesn't support HTTP/2 with [Transport Layer Security (TLS)](https://too
 
 To workaround this issue you must configure Kestrel and the gRPC client to use HTTP/2 **without** TLS. You should only do this during development. Not using TLS will result in gRPC messages being sent without encryption.
 
-Kestrel must configure a HTTP/2 endpoint that does use TLS in `Program.cs`:
+Kestrel must configure a HTTP/2 endpoint without TLS in `Program.cs`:
 
 ```cs
 public static IHostBuilder CreateHostBuilder(string[] args) =>

--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -92,7 +92,7 @@ To workaround this issue you must configure Kestrel and the gRPC client to use H
 
 Kestrel must configure a HTTP/2 endpoint without TLS in `Program.cs`:
 
-```cs
+```csharp
 public static IHostBuilder CreateHostBuilder(string[] args) =>
     Host.CreateDefaultBuilder(args)
         .ConfigureWebHostDefaults(webBuilder =>

--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -90,7 +90,7 @@ Kestrel doesn't support HTTP/2 with [Transport Layer Security (TLS)](https://too
 
 To workaround this issue you must configure Kestrel and the gRPC client to use HTTP/2 **without** TLS. You should only do this during development. Not using TLS will result in gRPC messages being sent without encryption.
 
-The gRPC server must configure a HTTP/2 endpoint that does use TLS in `Program.cs`:
+Kestrel must configure a HTTP/2 endpoint that does use TLS in `Program.cs`:
 
 ```cs
 public static IHostBuilder CreateHostBuilder(string[] args) =>
@@ -100,7 +100,7 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
             webBuilder.ConfigureKestrel(options =>
             {
                 // Setup a HTTP/2 endpoint without TLS.
-                options.ListenLocalhost(5001, o => o.Protocols = HttpProtocols.Http2);
+                options.ListenLocalhost(5000, o => o.Protocols = HttpProtocols.Http2);
             });
             webBuilder.UseStartup<Startup>();
         });
@@ -113,8 +113,8 @@ The gRPC client must set the `System.Net.Http.SocketsHttpHandler.Http2Unencrypte
 AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
 
 var httpClient = new HttpClient();
-// The port number(5001) must match the port of the gRPC server.
-httpClient.BaseAddress = new Uri("http://localhost:5001");
+// The port number(5000) must match the port of the gRPC server.
+httpClient.BaseAddress = new Uri("http://localhost:5000");
 var client = GrpcClient.Create<Greeter.GreeterClient>(httpClient);
 ```
 

--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -88,7 +88,7 @@ Kestrel doesn't support HTTP/2 with [Transport Layer Security (TLS)](https://too
 
 > Unable to bind to https://localhost:5001 on the IPv4 loopback interface: 'HTTP/2 over TLS is not supported on OSX due to missing ALPN support.'.
 
-To workaround this issue you must configure Kestrel and the gRPC client to use HTTP/2 **without** TLS. You should only do this during development. Not using TLS will result in gRPC messages being sent without encryption.
+To work around this issue, configure Kestrel and the gRPC client to use HTTP/2 **without** TLS. You should only do this during development. Not using TLS will result in gRPC messages being sent without encryption.
 
 Kestrel must configure a HTTP/2 endpoint without TLS in `Program.cs`:
 

--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -86,7 +86,7 @@ The gRPC API provides access to some HTTP/2 message data, such as the method, ho
 
 Kestrel doesn't support HTTP/2 with [Transport Layer Security (TLS)](https://tools.ietf.org/html/rfc5246) on macOS. The ASP.NET Core gRPC template and samples use TLS by default. You'll see the following error message when you attempt to start the gRPC server:
 
-> Unable to bind to https://localhost:5001 on the IPv4 loopback interface: 'HTTP/2 over TLS is not supported on OSX due to missing ALPN support.'.
+> Unable to bind to https://localhost:5001 on the IPv4 loopback interface: 'HTTP/2 over TLS is not supported on macOS due to missing ALPN support.'.
 
 To work around this issue, configure Kestrel and the gRPC client to use HTTP/2 **without** TLS. You should only do this during development. Not using TLS will result in gRPC messages being sent without encryption.
 

--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -84,13 +84,13 @@ The gRPC API provides access to some HTTP/2 message data, such as the method, ho
 
 ## gRPC and ASP.NET Core on macOS
 
-Kestrel on macOS doesn't support HTTP/2 with [Transport Layer Security (TLS)](https://tools.ietf.org/html/rfc5246). The ASP.NET Core gRPC template and samples use TLS by default, and you will see this error message when you attempt to start the gRPC server:
+Kestrel doesn't support HTTP/2 with [Transport Layer Security (TLS)](https://tools.ietf.org/html/rfc5246) on macOS. The ASP.NET Core gRPC template and samples use TLS by default, and you will see this error message when you attempt to start the gRPC server:
 
-> Unable to bind to https://localhost:5001 on the IPv4 loopback interface: 'HTTP/2 over TLS is not supported on OSX due to missing ALPN support.'.
+> `Unable to bind to https://localhost:5001 on the IPv4 loopback interface: 'HTTP/2 over TLS is not supported on OSX due to missing ALPN support.'.`
 
 To workaround this issue you must configure Kestrel and the gRPC client to use HTTP/2 **without** TLS. You should only do this during development. Not using TLS will result in gRPC messages being sent without encryption.
 
-Update `Program.cs` on the server setup a Kestrel HTTP/2 endpoint without TLS:
+Update the server to configure a HTTP/2 endpoint with TLS in `Program.cs`:
 
 ```cs
 public static IHostBuilder CreateHostBuilder(string[] args) =>

--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -86,11 +86,11 @@ The gRPC API provides access to some HTTP/2 message data, such as the method, ho
 
 Kestrel doesn't support HTTP/2 with [Transport Layer Security (TLS)](https://tools.ietf.org/html/rfc5246) on macOS. The ASP.NET Core gRPC template and samples use TLS by default, and you will see this error message when you attempt to start the gRPC server:
 
-> `Unable to bind to https://localhost:5001 on the IPv4 loopback interface: 'HTTP/2 over TLS is not supported on OSX due to missing ALPN support.'.`
+> Unable to bind to https://localhost:5001 on the IPv4 loopback interface: 'HTTP/2 over TLS is not supported on OSX due to missing ALPN support.'.
 
 To workaround this issue you must configure Kestrel and the gRPC client to use HTTP/2 **without** TLS. You should only do this during development. Not using TLS will result in gRPC messages being sent without encryption.
 
-Update the server to configure a HTTP/2 endpoint with TLS in `Program.cs`:
+The gRPC server must configure a HTTP/2 endpoint that does use TLS in `Program.cs`:
 
 ```cs
 public static IHostBuilder CreateHostBuilder(string[] args) =>
@@ -106,7 +106,7 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
         });
 ```
 
-The gRPC caller must set the `System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport` switch to true and use `http` in the server address:
+The gRPC client must set the `System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport` switch to true and use `http` in the server address:
 
 ```csharp
 // This switch must be set before creating the HttpClient.

--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -119,7 +119,7 @@ info: Microsoft.Hosting.Lifetime[0]
 ```
 
 > [!NOTE]
-> Additional configuration is required to successfully run gRPC services with ASP.NET Core on macOS. Visit [gRPC and ASP.NET Core on macOS](xref:grpc/aspnetcore#grpc-and-aspnet-core-on-macos) for more information.
+> Additional configuration is required to successfully run gRPC services with ASP.NET Core on macOS. For more information, see [gRPC and ASP.NET Core on macOS](xref:grpc/aspnetcore#grpc-and-aspnet-core-on-macos).
 
 ### Examine the project files
 

--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -118,6 +118,9 @@ info: Microsoft.Hosting.Lifetime[0]
 info: Microsoft.Hosting.Lifetime[0]
 ```
 
+> [!NOTE]
+> Additional configuration is required to successfully run gRPC services with ASP.NET Core on macOS. Visit [gRPC and ASP.NET Core on macOS](xref:grpc/aspnetcore#grpc-and-asp-net-core-on-macos) for more information.
+
 ### Examine the project files
 
 *GrpcGreeter* project files:

--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -119,7 +119,7 @@ info: Microsoft.Hosting.Lifetime[0]
 ```
 
 > [!NOTE]
-> Additional configuration is required to successfully run gRPC services with ASP.NET Core on macOS. Visit [gRPC and ASP.NET Core on macOS](xref:grpc/aspnetcore#grpc-and-asp-net-core-on-macos) for more information.
+> Additional configuration is required to successfully run gRPC services with ASP.NET Core on macOS. Visit [gRPC and ASP.NET Core on macOS](xref:grpc/aspnetcore#grpc-and-aspnet-core-on-macos) for more information.
 
 ### Examine the project files
 

--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -119,7 +119,9 @@ info: Microsoft.Hosting.Lifetime[0]
 ```
 
 > [!NOTE]
-> Additional configuration is required to successfully run gRPC services with ASP.NET Core on macOS. For more information, see [gRPC and ASP.NET Core on macOS](xref:grpc/aspnetcore#grpc-and-aspnet-core-on-macos).
+> The gRPC template is configured to use [Transport Layer Security (TLS)](https://tools.ietf.org/html/rfc5246). gRPC clients need to use HTTPS to call the server.
+>
+> macOS does not support ASP.NET Core gRPC with TLS. Additional configuration is required to successfully run gRPC services on macOS. For more information, see [gRPC and ASP.NET Core on macOS](xref:grpc/aspnetcore#grpc-and-aspnet-core-on-macos).
 
 ### Examine the project files
 

--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -4,7 +4,7 @@ author: juntaoluo
 description: This tutorial shows how to create a gRPC Service and gRPC client on ASP.NET Core. Learn how to create a gRPC Service project, edit a proto file, and add a duplex streaming call.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: johluo
-ms.date: 06/12/2019
+ms.date: 08/07/2019
 uid: tutorials/grpc/grpc-start
 ---
 # Tutorial: Create a gRPC client and server in ASP.NET Core
@@ -121,7 +121,7 @@ info: Microsoft.Hosting.Lifetime[0]
 > [!NOTE]
 > The gRPC template is configured to use [Transport Layer Security (TLS)](https://tools.ietf.org/html/rfc5246). gRPC clients need to use HTTPS to call the server.
 >
-> macOS does not support ASP.NET Core gRPC with TLS. Additional configuration is required to successfully run gRPC services on macOS. For more information, see [gRPC and ASP.NET Core on macOS](xref:grpc/aspnetcore#grpc-and-aspnet-core-on-macos).
+> macOS doesn't support ASP.NET Core gRPC with TLS. Additional configuration is required to successfully run gRPC services on macOS. For more information, see [gRPC and ASP.NET Core on macOS](xref:grpc/aspnetcore#grpc-and-aspnet-core-on-macos).
 
 ### Examine the project files
 


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore.Docs/issues/13544

Internal review URLs:
* https://review.docs.microsoft.com/en-us/aspnet/core/grpc/aspnetcore?view=aspnetcore-3.0&branch=pr-en-us-13568&tabs=visual-studio#grpc-and-aspnet-core-on-macos
* https://review.docs.microsoft.com/en-us/aspnet/core/tutorials/grpc/grpc-start?view=aspnetcore-3.0&branch=pr-en-us-13568&tabs=visual-studio#run-the-service