### PR TITLE
Pass Debug option to a Blazor app for debugging

### DIFF
--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -34,7 +34,7 @@ Development of further debugging scenarios is an on-going focus of the engineeri
 
 ## Prerequisites
 
-Either of the following browsers:
+Debugging requires either of the following browsers:
 
 * Google Chrome (version 70 or later)
 * Microsoft Edge preview ([Edge Dev Channel](https://www.microsoftedgeinsider.com))

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -37,7 +37,7 @@ Development of further debugging scenarios is an on-going focus of the engineeri
 To debug a Blazor client-side app in Chrome:
 
 1. Run a Blazor client-side app in `Debug` configuration. Pass the `--configuration Debug` option to the [dotnet run](/dotnet/core/tools/dotnet-run) command: `dotnet run --configuration Debug`.
-1. Access the app in Chrome (version 70 or later).
+1. Access the app in Chrome (version 70 or later) or with a Microsoft Edge preview ([Edge Dev Channel](https://www.microsoftedgeinsider.com)).
 1. With the keyboard focus on the app (not in the developer tools panel, which you should probably close for a less confusing debugging experience), select the following Blazor-specific keyboard shortcut:
    * `Shift+Alt+D` on Windows/Linux
    * `Shift+Cmd+D` on macOS

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -32,13 +32,19 @@ You *can't*:
 
 Development of further debugging scenarios is an on-going focus of the engineering team.
 
+## Prerequisites
+
+Either of the following browsers:
+
+* Google Chrome (version 70 or later)
+* Microsoft Edge preview ([Edge Dev Channel](https://www.microsoftedgeinsider.com))
+
 ## Procedure
 
-To debug a Blazor client-side app in Chrome or Edge:
-
 1. Run a Blazor client-side app in `Debug` configuration. Pass the `--configuration Debug` option to the [dotnet run](/dotnet/core/tools/dotnet-run) command: `dotnet run --configuration Debug`.
-1. Access the app in Chrome (version 70 or later) or with a Microsoft Edge preview ([Edge Dev Channel](https://www.microsoftedgeinsider.com)).
-1. With the keyboard focus on the app (not in the developer tools panel, which you should probably close for a less confusing debugging experience), select the following Blazor-specific keyboard shortcut:
+1. Access the app in the browser.
+1. Place the keyboard focus on the app, not the developer tools panel. The developer tools panel can be closed when debugging is initiated.
+1. Select the following Blazor-specific keyboard shortcut:
    * `Shift+Alt+D` on Windows/Linux
    * `Shift+Cmd+D` on macOS
 

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -5,7 +5,7 @@ description: Learn how to debug Blazor apps.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 06/14/2019
+ms.date: 07/31/2019
 uid: blazor/debug
 ---
 # Debug ASP.NET Core Blazor
@@ -36,11 +36,11 @@ Development of further debugging scenarios is an on-going focus of the engineeri
 
 To debug a Blazor client-side app in Chrome:
 
-* Build a Blazor app in `Debug` configuration (the default for unpublished apps).
-* Run the Blazor app in Chrome (version 70 or later).
-* With the keyboard focus on the app (not in the developer tools panel, which you should probably close for a less confusing debugging experience), select the following Blazor-specific keyboard shortcut:
-  * `Shift+Alt+D` on Windows/Linux
-  * `Shift+Cmd+D` on macOS
+1. Run a Blazor client-side app in `Debug` configuration. Pass the `--configuration Debug` option to the [dotnet run](/dotnet/core/tools/dotnet-run) command: `dotnet run --configuration Debug`.
+1. Access the app in Chrome (version 70 or later).
+1. With the keyboard focus on the app (not in the developer tools panel, which you should probably close for a less confusing debugging experience), select the following Blazor-specific keyboard shortcut:
+   * `Shift+Alt+D` on Windows/Linux
+   * `Shift+Cmd+D` on macOS
 
 ## Enable remote debugging
 

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -34,7 +34,7 @@ Development of further debugging scenarios is an on-going focus of the engineeri
 
 ## Procedure
 
-To debug a Blazor client-side app in Chrome:
+To debug a Blazor client-side app in Chrome or Edge:
 
 1. Run a Blazor client-side app in `Debug` configuration. Pass the `--configuration Debug` option to the [dotnet run](/dotnet/core/tools/dotnet-run) command: `dotnet run --configuration Debug`.
 1. Access the app in Chrome (version 70 or later) or with a Microsoft Edge preview ([Edge Dev Channel](https://www.microsoftedgeinsider.com)).


### PR DESCRIPTION
Fixes #13548 

We can revert this instruction pending the outcome of the engineering issue (https://github.com/aspnet/AspNetCore/issues/12779). I've opened https://github.com/aspnet/AspNetCore.Docs/issues/13596 to track the reversion, and that will be monitored on the Blazor.Docs project.