### PR TITLE
Revise remark in AKV config provider topic

### DIFF
--- a/aspnetcore/security/key-vault-configuration.md
+++ b/aspnetcore/security/key-vault-configuration.md
@@ -5,7 +5,7 @@ description: Learn how to use the Azure Key Vault Configuration Provider to conf
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/13/2019
+ms.date: 08/01/2019
 uid: security/key-vault-configuration
 ---
 # Azure Key Vault Configuration Provider in ASP.NET Core
@@ -300,7 +300,7 @@ Configuration.Reload();
 
 ## Disabled and expired secrets
 
-Disabled and expired secrets throw a `KeyVaultClientException`. To prevent your app from throwing, replace your app or update the disabled/expired secret.
+Disabled and expired secrets throw a `KeyVaultClientException` at runtime. To prevent the app from throwing, provide the configuration using a different configuration provider or update the disabled or expired secret.
 
 ## Troubleshoot
 


### PR DESCRIPTION
Fixes #13608 

The original remark was ...

> Disabled and expired secrets throw a `KeyVaultClientException` at runtime. Therefore, it's important that you update your application or replace or update a disabled or expried secret in the key vault before the provider attempts to load or reload a disabled or expired secret.

It was clearly mangled a bit on an ancient update back in 2017.

New remark on this PR ...

> Disabled and expired secrets throw a `KeyVaultClientException` at runtime. To prevent the app from throwing, provide the configuration using a different configuration provider or update the disabled or expired secret.

Thanks @ps-tb! :rocket: