### PR TITLE
Fix: Wrong property naming on Movie

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/start-mvc/sample/MvcMovie22/Models/MovieDateRatingDA.cs
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc/sample/MvcMovie22/Models/MovieDateRatingDA.cs
@@ -9,7 +9,7 @@ namespace MvcMovie.Models
     #region snippet1
     public class Movie
     {
-        public int ID { get; set; }
+        public int Id { get; set; }
 
         [StringLength(60, MinimumLength = 3)]
         [Required]


### PR DESCRIPTION
There is an compiler error because the property "ID" on model "Movie" was written different than the references.