### PR TITLE
Update EventArgs ref source links

### DIFF
--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -5,7 +5,7 @@ description: Learn how to create and use Razor components, including how to bind
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 07/25/2019
+ms.date: 08/02/2019
 uid: blazor/components
 ---
 # Create and use ASP.NET Core Razor components
@@ -368,7 +368,7 @@ In the following example, `UpdateHeading` is called asynchronously when the butt
 
 For some events, event-specific event argument types are permitted. If access to one of these event types isn't necessary, it isn't required in the method call.
 
-Supported [UIEventArgs](https://github.com/aspnet/AspNetCore/blob/master/src/Components/Components/src/UIEventArgs.cs) are shown in the following table.
+Supported [UIEventArgs](https://github.com/aspnet/AspNetCore/blob/release/3.0-preview8/src/Components/Components/src/UIEventArgs.cs) are shown in the following table.
 
 | Event | Class |
 | ----- | ----- |
@@ -384,7 +384,7 @@ Supported [UIEventArgs](https://github.com/aspnet/AspNetCore/blob/master/src/Com
 | Progress | `UIProgressEventArgs` |
 | Touch | `UITouchEventArgs` &ndash; `UITouchPoint` represents a single contact point on a touch-sensitive device. |
 
-For information on the properties and event handling behavior of the events in the preceding table, see [UIEventArgs](https://github.com/aspnet/AspNetCore/blob/master/src/Components/Components/src/UIEventArgs.cs) in the reference source.
+For information on the properties and event handling behavior of the events in the preceding table, see [EventArgs classes in the reference source](https://github.com/aspnet/AspNetCore/tree/release/3.0-preview8/src/Components/Web/src).
   
 Lambda expressions can also be used:
 


### PR DESCRIPTION
Fixes #13613

* Updating links to Pre8 ref source branch.
* Will open a Pre9 issue to react to https://github.com/aspnet/AspNetCore/pull/12660.

Thanks @Lurs! 🏍