### PR TITLE
No instructions to disable ssl verification on mac

### DIFF
--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -723,6 +723,7 @@ The return type of the `GetTodoItems` and `GetTodoItem` methods is [ActionResult
 * If no item matches the requested ID, the method returns a 404 [NotFound](/dotnet/api/microsoft.aspnetcore.mvc.controllerbase.notfound) error code.
 * Otherwise, the method returns 200 with a JSON response body. Returning `item` results in an HTTP 200 response.
 
+
 ## Test the GetTodoItems method
 
 This tutorial uses Postman to test the web API.
@@ -732,8 +733,15 @@ This tutorial uses Postman to test the web API.
 * Start Postman.
 * Disable **SSL certificate verification**
   
+# [Visual Studio](#tab/visual-studio)
   * From  **File > Settings** (**General* tab), disable **SSL certificate verification**.
-    > [!WARNING]
+  
+# [Visual Studio for Mac](#tab/visual-studio-mac)
+  * From **Postman > Preferences > (**General* tab), disable **SSL certificate verification** OR click on the wrench and select Settings then disable the SSL certificate verification.
+  
+  ---
+  
+> [!WARNING]
     > Re-enable SSL certificate verification after testing the controller.
 
 * Create a new request.

--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -737,7 +737,7 @@ This tutorial uses Postman to test the web API.
   * From  **File > Settings** (**General* tab), disable **SSL certificate verification**.
   
 # [Visual Studio for Mac](#tab/visual-studio-mac)
-  * From **Postman > Preferences > (**General* tab), disable **SSL certificate verification** OR click on the wrench and select Settings then disable the SSL certificate verification.
+  * From **Postman > Preferences > (**General* tab), disable **SSL certificate verification**. Alternatively, select the wrench and select **Settings**, then disable the SSL certificate verification.
   
   ---
   


### PR DESCRIPTION
created new tab for mac and windows, updating the instructions to include mac.
fixes #13666
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->