### PR TITLE
Adds Missing "using" statements

### DIFF
--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -110,6 +110,9 @@ If using directories with IIS or a reverse proxy, set the Swagger endpoint to a 
 
 Swagger provides options for documenting the object model and customizing the UI to match your theme.
 
+In the Startup class, add the following namespaces:
+[!code-csharp[](../tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup2.cs?name=snippet_PreReqNamespaces)]
+
 ### API info and description
 
 The configuration action passed to the `AddSwaggerGen` method adds information such as the author, license, and description:

--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -111,7 +111,7 @@ If using directories with IIS or a reverse proxy, set the Swagger endpoint to a 
 Swagger provides options for documenting the object model and customizing the UI to match your theme.
 
 In the Startup class, add the following namespaces:
-[!code-csharp[](../tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup2.cs?name=snippet_PreReqNamespaces)]
+[!code-csharp[](~/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup2.cs?name=snippet_PreReqNamespaces)]
 
 ### API info and description
 

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup2.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup2.cs
@@ -5,7 +5,11 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 #endregion
 using TodoApi.Models;
-
+#region snippet_PreReqNamespaces
+using System;
+using System.Reflection;
+using System.IO;
+#endregion
 namespace TodoApi
 {
     public class Startup2


### PR DESCRIPTION
Fixes #13701
References same file as the InfoClassNamespace. I PR'd that file as well. /tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/Startup2.cs



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->