### PR TITLE
Display all the packages required for a gRPC client

### DIFF
--- a/aspnetcore/grpc/basics.md
+++ b/aspnetcore/grpc/basics.md
@@ -46,9 +46,9 @@ This package is required by both the server and client projects. The `Grpc.AspNe
 
 [!code-xml[](~/tutorials/grpc/grpc-start/sample/GrpcGreeter/GrpcGreeter.csproj?highlight=1&range=12)]
 
-Client projects should reference `Grpc.Tools` directly. The tooling package isn't required at runtime, so the dependency is marked with `PrivateAssets="All"`:
+Client projects should reference `Grpc.Tools` directly, alongside the other packages required to use the gRPC client. The tooling package isn't required at runtime, so the dependency is marked with `PrivateAssets="All"`:
 
-[!code-xml[](~/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/GrpcGreeterClient.csproj?highlight=1&range=11)]
+[!code-xml[](~/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/GrpcGreeterClient.csproj?highlight=3&range=9-11)]
 
 ## Generated C# assets
 

--- a/aspnetcore/grpc/basics.md
+++ b/aspnetcore/grpc/basics.md
@@ -46,7 +46,7 @@ This package is required by both the server and client projects. The `Grpc.AspNe
 
 [!code-xml[](~/tutorials/grpc/grpc-start/sample/GrpcGreeter/GrpcGreeter.csproj?highlight=1&range=12)]
 
-Client projects should reference `Grpc.Tools` directly, alongside the other packages required to use the gRPC client. The tooling package isn't required at runtime, so the dependency is marked with `PrivateAssets="All"`:
+Client projects should directly reference `Grpc.Tools` alongside the other packages required to use the gRPC client. The tooling package isn't required at runtime, so the dependency is marked with `PrivateAssets="All"`:
 
 [!code-xml[](~/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/GrpcGreeterClient.csproj?highlight=3&range=9-11)]
 


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore.Docs/issues/13681

@Rick-Anderson I think this is a simple change to include all the packages required for the code sample to work.

https://review.docs.microsoft.com/en-us/aspnet/core/grpc/basics?view=aspnetcore-3.0&branch=pr-en-us-13704