### PR TITLE
Fix indentation in http-repl.md

### DIFF
--- a/aspnetcore/web-api/http-repl.md
+++ b/aspnetcore/web-api/http-repl.md
@@ -526,12 +526,12 @@ To issue an HTTP POST request:
 
 1. Modify the JSON template to satisfy model validation requirements:
 
-  ```json
-  {
-    "id": 0,
-    "name": "Scott Addie"
-  }
-  ```
+    ```json
+    {
+      "id": 0,
+      "name": "Scott Addie"
+    }
+    ```
 
 1. Save the *.tmp* file, and close the text editor. The following output appears in the command shell:
 


### PR DESCRIPTION
Without this change, the list of instructions for making POST requests is ordered 1, 2, 1 instead of 1, 2, 3
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->