### PR TITLE
Kestrel topic+sample 3.0 update

### DIFF
--- a/aspnetcore/fundamentals/servers/index.md
+++ b/aspnetcore/fundamentals/servers/index.md
@@ -1,11 +1,11 @@
 ---
 title: Web server implementations in ASP.NET Core
-author: guardrex
+author: tdykstra
 description: Discover the web servers Kestrel and HTTP.sys for ASP.NET Core. Learn how to choose a server and when to use a reverse proxy server.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 06/01/2019
+ms.date: 08/10/2019
 uid: fundamentals/servers/index
 ---
 # Web server implementations in ASP.NET Core
@@ -28,7 +28,7 @@ Use Kestrel:
 
   ![Kestrel communicates indirectly with the Internet through a reverse proxy server, such as IIS, Nginx, or Apache](kestrel/_static/kestrel-to-internet.png)
 
-Either hosting configuration&mdash;with or without a reverse proxy server&mdash;is supported for ASP.NET Core 2.1 or later apps.
+Either hosting configuration&mdash;with or without a reverse proxy server&mdash;is supported.
 
 For Kestrel configuration guidance and information on when to use Kestrel in a reverse proxy configuration, see <xref:fundamentals/servers/kestrel>.
 

--- a/aspnetcore/fundamentals/servers/kestrel.md
+++ b/aspnetcore/fundamentals/servers/kestrel.md
@@ -93,8 +93,6 @@ A reverse proxy:
 
 ::: moniker range=">= aspnetcore-3.0"
 
-The Kestrel server is provided by the [Microsoft.AspNetCore.Server.Kestrel](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.Kestrel/) package, which is included implicitly in ASP.NET Core apps.
-
 ASP.NET Core project templates use Kestrel by default. In *Program.cs*, the template code calls <xref:Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder*>, which calls <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderKestrelExtensions.UseKestrel*> behind the scenes.
 
 [!code-csharp[](kestrel/samples/3.x/KestrelSample/Program.cs?name=snippet_DefaultBuilder&highlight=7)]
@@ -1577,14 +1575,9 @@ Protocols specified in code override values set by configuration.
 
 ## Transport configuration
 
-With the release of ASP.NET Core 2.1, Kestrel's default transport is no longer based on Libuv but instead based on managed sockets. This is a breaking change for ASP.NET Core 2.0 apps upgrading to 2.1 that call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderLibuvExtensions.UseLibuv*> and depend on either of the following packages:
-
-* [Microsoft.AspNetCore.Server.Kestrel](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.Kestrel/) (direct package reference)
-* [Microsoft.AspNetCore.App](https://www.nuget.org/packages/Microsoft.AspNetCore.App/)
-
 ::: moniker range=">= aspnetcore-3.0"
 
-For projects that require the use of Libuv:
+For projects that require the use of Libuv (<xref:Microsoft.AspNetCore.Hosting.WebHostBuilderLibuvExtensions.UseLibuv*>):
 
 * Add a dependency for the [Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/) package to the app's project file:
 
@@ -1593,7 +1586,7 @@ For projects that require the use of Libuv:
                      Version="{VERSION}" />
    ```
 
-* Call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderLibuvExtensions.UseLibuv*>:
+* Call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderLibuvExtensions.UseLibuv*> on the `IWebHostBuilder`:
 
    ```csharp
    public class Program
@@ -1605,9 +1598,9 @@ For projects that require the use of Libuv:
 
        public static IHostBuilder CreateHostBuilder(string[] args) =>
            Host.CreateDefaultBuilder(args)
-               .UseLibuv()
                .ConfigureWebHostDefaults(webBuilder =>
                {
+                   webBuilder.UseLibuv();
                    webBuilder.UseStartup<Startup>();
                });
    }
@@ -1617,7 +1610,12 @@ For projects that require the use of Libuv:
 
 ::: moniker range="< aspnetcore-3.0"
 
-For projects that use the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app) and require the use of Libuv:
+With the release of ASP.NET Core 2.1, Kestrel's default transport is no longer based on Libuv but instead based on managed sockets. This is a breaking change for ASP.NET Core 2.0 apps upgrading to 2.1 that call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderLibuvExtensions.UseLibuv*> and depend on either of the following packages:
+
+* [Microsoft.AspNetCore.Server.Kestrel](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.Kestrel/) (direct package reference)
+* [Microsoft.AspNetCore.App](https://www.nuget.org/packages/Microsoft.AspNetCore.App/)
+
+For projects that require the use of Libuv:
 
 * Add a dependency for the [Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/) package to the app's project file:
 

--- a/aspnetcore/fundamentals/servers/kestrel.md
+++ b/aspnetcore/fundamentals/servers/kestrel.md
@@ -5,18 +5,18 @@ description: Learn about Kestrel, the cross-platform web server for ASP.NET Core
 monikerRange: '>= aspnetcore-2.1'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 09/10/2019
+ms.date: 09/13/2019
 uid: fundamentals/servers/kestrel
 ---
 # Kestrel web server implementation in ASP.NET Core
 
 By [Tom Dykstra](https://github.com/tdykstra), [Chris Ross](https://github.com/Tratcher), and [Stephen Halter](https://twitter.com/halter73)
 
+::: moniker range=">= aspnetcore-3.0"
+
 Kestrel is a cross-platform [web server for ASP.NET Core](xref:fundamentals/servers/index). Kestrel is the web server that's included by default in ASP.NET Core project templates.
 
 Kestrel supports the following scenarios:
-
-::: moniker range=">= aspnetcore-2.2"
 
 * HTTPS
 * Opaque upgrade used to enable [WebSockets](https://github.com/aspnet/websockets)
@@ -25,21 +25,9 @@ Kestrel supports the following scenarios:
 
 &dagger;HTTP/2 will be supported on macOS in a future release.
 
-::: moniker-end
-
-::: moniker range="< aspnetcore-2.2"
-
-* HTTPS
-* Opaque upgrade used to enable [WebSockets](https://github.com/aspnet/websockets)
-* Unix sockets for high performance behind Nginx
-
-::: moniker-end
-
 Kestrel is supported on all platforms and versions that .NET Core supports.
 
 [View or download sample code](https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/fundamentals/servers/kestrel/samples) ([how to download](xref:index#how-to-download-a-sample))
-
-::: moniker range=">= aspnetcore-2.2"
 
 ## HTTP/2 support
 
@@ -58,8 +46,6 @@ Kestrel is supported on all platforms and versions that .NET Core supports.
 If an HTTP/2 connection is established, [HttpRequest.Protocol](xref:Microsoft.AspNetCore.Http.HttpRequest.Protocol*) reports `HTTP/2`.
 
 HTTP/2 is disabled by default. For more information on configuration, see the [Kestrel options](#kestrel-options) and [ListenOptions.Protocols](#listenoptionsprotocols) sections.
-
-::: moniker-end
 
 ## When to use Kestrel with a reverse proxy
 
@@ -90,8 +76,6 @@ A reverse proxy:
 > Hosting in a reverse proxy configuration requires [host filtering](#host-filtering).
 
 ## How to use Kestrel in ASP.NET Core apps
-
-::: moniker range=">= aspnetcore-3.0"
 
 ASP.NET Core project templates use Kestrel by default. In *Program.cs*, the template code calls <xref:Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder*>, which calls <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderKestrelExtensions.UseKestrel*> behind the scenes.
 
@@ -134,70 +118,6 @@ public static void Main(string[] args)
 }
 ```
 
-::: moniker-end
-
-::: moniker range="= aspnetcore-2.2"
-
-The [Microsoft.AspNetCore.Server.Kestrel](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.Kestrel/) package is included in the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app).
-
-ASP.NET Core project templates use Kestrel by default. In *Program.cs*, the template code calls <xref:Microsoft.AspNetCore.WebHost.CreateDefaultBuilder*>, which calls <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderKestrelExtensions.UseKestrel*> behind the scenes.
-
-[!code-csharp[](kestrel/samples/2.x/KestrelSample/Program.cs?name=snippet_DefaultBuilder&highlight=7)]
-
-To provide additional configuration after calling `CreateDefaultBuilder`, use `ConfigureKestrel`:
-
-```csharp
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .ConfigureKestrel((context, serverOptions) =>
-        {
-            // Set properties and call methods on serverOptions
-        });
-```
-
-If the app doesn't call `CreateDefaultBuilder` to set up the host, call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderKestrelExtensions.UseKestrel*> **before** calling `ConfigureKestrel`:
-
-```csharp
-public static void Main(string[] args)
-{
-    var host = new WebHostBuilder()
-        .UseContentRoot(Directory.GetCurrentDirectory())
-        .UseKestrel()
-        .UseIISIntegration()
-        .UseStartup<Startup>()
-        .ConfigureKestrel((context, serverOptions) =>
-        {
-            // Set properties and call methods on serverOptions
-        })
-        .Build();
-
-    host.Run();
-}
-```
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-2.2"
-
-The [Microsoft.AspNetCore.Server.Kestrel](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.Kestrel/) package is included in the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app).
-
-ASP.NET Core project templates use Kestrel by default. In *Program.cs*, the template code calls <xref:Microsoft.AspNetCore.WebHost.CreateDefaultBuilder*>, which calls <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderKestrelExtensions.UseKestrel*> behind the scenes.
-
-To provide additional configuration after calling `CreateDefaultBuilder`, call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderKestrelExtensions.UseKestrel*>:
-
-```csharp
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .UseKestrel(serverOptions =>
-        {
-            // Set properties and call methods on serverOptions
-        });
-```
-
-::: moniker-end
-
 ## Kestrel options
 
 The Kestrel web server has constraint configuration options that are especially useful in Internet-facing deployments.
@@ -216,31 +136,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 
 Gets or sets the [keep-alive timeout](https://tools.ietf.org/html/rfc7230#section-6.5). Defaults to 2 minutes.
 
-::: moniker range=">= aspnetcore-3.0"
-
 [!code-csharp[](kestrel/samples/3.x/KestrelSample/Program.cs?name=snippet_Limits&highlight=19-20)]
-
-::: moniker-end
-
-::: moniker range="= aspnetcore-2.2"
-
-[!code-csharp[](kestrel/samples/2.x/KestrelSample/Program.cs?name=snippet_Limits&highlight=15)]
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-2.2"
-
-```csharp
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .UseKestrel(serverOptions =>
-        {
-            serverOptions.Limits.KeepAliveTimeout = TimeSpan.FromMinutes(2);
-        });
-```
-
-::: moniker-end
 
 ### Maximum client connections
 
@@ -249,59 +145,11 @@ public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
 
 The maximum number of concurrent open TCP connections can be set for the entire app with the following code:
 
-::: moniker range=">= aspnetcore-3.0"
-
 [!code-csharp[](kestrel/samples/3.x/KestrelSample/Program.cs?name=snippet_Limits&highlight=3)]
-
-::: moniker-end
-
-::: moniker range="= aspnetcore-2.2"
-
-[!code-csharp[](kestrel/samples/2.x/KestrelSample/Program.cs?name=snippet_Limits&highlight=3)]
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-2.2"
-
-```csharp
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .UseKestrel(serverOptions =>
-        {
-            serverOptions.Limits.MaxConcurrentConnections = 100;
-        });
-```
-
-::: moniker-end
 
 There's a separate limit for connections that have been upgraded from HTTP or HTTPS to another protocol (for example, on a WebSockets request). After a connection is upgraded, it isn't counted against the `MaxConcurrentConnections` limit.
 
-::: moniker range=">= aspnetcore-3.0"
-
 [!code-csharp[](kestrel/samples/3.x/KestrelSample/Program.cs?name=snippet_Limits&highlight=4)]
-
-::: moniker-end
-
-::: moniker range="= aspnetcore-2.2"
-
-[!code-csharp[](kestrel/samples/2.x/KestrelSample/Program.cs?name=snippet_Limits&highlight=4)]
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-2.2"
-
-```csharp
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .UseKestrel(serverOptions =>
-        {
-            serverOptions.Limits.MaxConcurrentUpgradedConnections = 100;
-        });
-```
-
-::: moniker-end
 
 The maximum number of connections is unlimited (null) by default.
 
@@ -320,43 +168,11 @@ public IActionResult MyActionMethod()
 
 Here's an example that shows how to configure the constraint for the app on every request:
 
-::: moniker range=">= aspnetcore-3.0"
-
 [!code-csharp[](kestrel/samples/3.x/KestrelSample/Program.cs?name=snippet_Limits&highlight=5)]
 
 Override the setting on a specific request in middleware:
 
 [!code-csharp[](kestrel/samples/3.x/KestrelSample/Startup.cs?name=snippet_Limits&highlight=3-4)]
-
-::: moniker-end
-
-::: moniker range="= aspnetcore-2.2"
-
-[!code-csharp[](kestrel/samples/2.x/KestrelSample/Program.cs?name=snippet_Limits&highlight=5)]
-
-Override the setting on a specific request in middleware:
-
-[!code-csharp[](kestrel/samples/2.x/KestrelSample/Startup.cs?name=snippet_Limits&highlight=3-4)]
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-2.2"
-
-```csharp
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .UseKestrel(serverOptions =>
-        {
-            serverOptions.Limits.MaxRequestBodySize = 10 * 1024;
-        });
-```
-
-Override the setting on a specific request in middleware:
-
-[!code-csharp[](kestrel/samples/2.x/KestrelSample/Startup.cs?name=snippet_Limits&highlight=3-4)]
-
-::: moniker-end
 
 An exception is thrown if the app configures the limit on a request after the app has started to read the request. There's an `IsReadOnly` property that indicates if the `MaxRequestBodySize` property is in read-only state, meaning it's too late to configure the limit.
 
@@ -375,36 +191,7 @@ A minimum rate also applies to the response. The code to set the request limit a
 
 Here's an example that shows how to configure the minimum data rates in *Program.cs*:
 
-::: moniker range=">= aspnetcore-3.0"
-
 [!code-csharp[](kestrel/samples/3.x/KestrelSample/Program.cs?name=snippet_Limits&highlight=6-11)]
-
-::: moniker-end
-
-::: moniker range="= aspnetcore-2.2"
-
-[!code-csharp[](kestrel/samples/2.x/KestrelSample/Program.cs?name=snippet_Limits&highlight=6-9)]
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-2.2"
-
-```csharp
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .UseKestrel(serverOptions =>
-        {
-            serverOptions.Limits.MinRequestBodyDataRate =
-                new MinDataRate(bytesPerSecond: 100, gracePeriod: TimeSpan.FromSeconds(10));
-            serverOptions.Limits.MinResponseDataRate =
-                new MinDataRate(bytesPerSecond: 100, gracePeriod: TimeSpan.FromSeconds(10));
-        });
-```
-
-::: moniker-end
-
-::: moniker range=">= aspnetcore-3.0"
 
 Override the minimum rate limits per request in middleware:
 
@@ -414,52 +201,13 @@ The <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IHttpMinResponseData
 
 Server-wide rate limits configured via `KestrelServerOptions.Limits` still apply to both HTTP/1.x and HTTP/2 connections.
 
-::: moniker-end
-
-::: moniker range="= aspnetcore-2.2"
-
-Override the minimum rate limits per request in middleware:
-
-[!code-csharp[](kestrel/samples/2.x/KestrelSample/Startup.cs?name=snippet_Limits&highlight=6-21)]
-
-Neither rate feature referenced in the prior sample are present in `HttpContext.Features` for HTTP/2 requests because modifying rate limits on a per-request basis isn't supported for HTTP/2 due to the protocol's support for request multiplexing. Server-wide rate limits configured via `KestrelServerOptions.Limits` still apply to both HTTP/1.x and HTTP/2 connections.
-
-::: moniker-end
-
 ### Request headers timeout
 
 <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.RequestHeadersTimeout>
 
 Gets or sets the maximum amount of time the server spends receiving request headers. Defaults to 30 seconds.
 
-::: moniker range=">= aspnetcore-3.0"
-
 [!code-csharp[](kestrel/samples/3.x/KestrelSample/Program.cs?name=snippet_Limits&highlight=21-22)]
-
-::: moniker-end
-
-::: moniker range="= aspnetcore-2.2"
-
-[!code-csharp[](kestrel/samples/2.x/KestrelSample/Program.cs?name=snippet_Limits&highlight=16)]
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-2.2"
-
-```csharp
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .UseKestrel(serverOptions =>
-        {
-            serverOptions.Limits.RequestHeadersTimeout = TimeSpan.FromMinutes(1);
-        });
-```
-
-::: moniker-end
-
-
-::: moniker range=">= aspnetcore-3.0"
 
 ### Maximum streams per connection
 
@@ -539,156 +287,16 @@ The default value is 128 KB (131,072).
 
 The default value is 96 KB (98,304).
 
-::: moniker-end
-
-::: moniker range="= aspnetcore-2.2"
-
-### Maximum streams per connection
-
-`Http2.MaxStreamsPerConnection` limits the number of concurrent request streams per HTTP/2 connection. Excess streams are refused.
-
-```csharp
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .ConfigureKestrel((context, serverOptions) =>
-        {
-            serverOptions.Limits.Http2.MaxStreamsPerConnection = 100;
-        });
-```
-
-The default value is 100.
-
-### Header table size
-
-The HPACK decoder decompresses HTTP headers for HTTP/2 connections. `Http2.HeaderTableSize` limits the size of the header compression table that the HPACK decoder uses. The value is provided in octets and must be greater than zero (0).
-
-```csharp
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .ConfigureKestrel((context, serverOptions) =>
-        {
-            serverOptions.Limits.Http2.HeaderTableSize = 4096;
-        });
-```
-
-The default value is 4096.
-
-### Maximum frame size
-
-`Http2.MaxFrameSize` indicates the maximum size of the HTTP/2 connection frame payload to receive. The value is provided in octets and must be between 2^14 (16,384) and 2^24-1 (16,777,215).
-
-```csharp
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .ConfigureKestrel((context, serverOptions) =>
-        {
-            serverOptions.Limits.Http2.MaxFrameSize = 16384;
-        });
-```
-
-The default value is 2^14 (16,384).
-
-### Maximum request header size
-
-`Http2.MaxRequestHeaderFieldSize` indicates the maximum allowed size in octets of request header values. This limit applies to both name and value together in their compressed and uncompressed representations. The value must be greater than zero (0).
-
-```csharp
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .ConfigureKestrel((context, serverOptions) =>
-        {
-            serverOptions.Limits.Http2.MaxRequestHeaderFieldSize = 8192;
-        });
-```
-
-The default value is 8,192.
-
-### Initial connection window size
-
-`Http2.InitialConnectionWindowSize` indicates the maximum request body data in bytes the server buffers at one time aggregated across all requests (streams) per connection. Requests are also limited by `Http2.InitialStreamWindowSize`. The value must be greater than or equal to 65,535 and less than 2^31 (2,147,483,648).
-
-```csharp
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .ConfigureKestrel((context, serverOptions) =>
-        {
-            serverOptions.Limits.Http2.InitialConnectionWindowSize = 131072;
-        });
-```
-
-The default value is 128 KB (131,072).
-
-### Initial stream window size
-
-`Http2.InitialStreamWindowSize` indicates the maximum request body data in bytes the server buffers at one time per request (stream). Requests are also limited by `Http2.InitialStreamWindowSize`. The value must be greater than or equal to 65,535 and less than 2^31 (2,147,483,648).
-
-```csharp
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .ConfigureKestrel((context, serverOptions) =>
-        {
-            serverOptions.Limits.Http2.InitialStreamWindowSize = 98304;
-        });
-```
-
-The default value is 96 KB (98,304).
-
-::: moniker-end
-
 ### Synchronous IO
 
-::: moniker range=">= aspnetcore-3.0"
-
 <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.AllowSynchronousIO> controls whether synchronous IO is allowed for the request and response. The default value is `false`.
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-3.0"
-
-<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.AllowSynchronousIO> controls whether synchronous IO is allowed for the request and response. The  default value is `true`.
-
-::: moniker-end
 
 > [!WARNING]
 > A large number of blocking synchronous IO operations can lead to thread pool starvation, which makes the app unresponsive. Only enable `AllowSynchronousIO` when using a library that doesn't support asynchronous IO.
 
-::: moniker range=">= aspnetcore-3.0"
-
 The following example enables synchronous IO:
 
 [!code-csharp[](kestrel/samples/3.x/KestrelSample/Program.cs?name=snippet_SyncIO)]
-
-::: moniker-end
-
-::: moniker range="= aspnetcore-2.2"
-
-The following example enables synchronous IO:
-
-[!code-csharp[](kestrel/samples/2.x/KestrelSample/Program.cs?name=snippet_SyncIO)]
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-2.2"
-
-The following example disables synchronous IO:
-
-```csharp
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .UseKestrel(serverOptions =>
-        {
-            serverOptions.AllowSynchronousIO = false;
-        });
-```
-
-::: moniker-end
 
 For information about other Kestrel options and limits, see:
 
@@ -721,19 +329,17 @@ A development certificate is created:
 
 Some browsers require granting explicit permission to trust the local development certificate.
 
-ASP.NET Core 2.1 and later project templates configure apps to run on HTTPS by default and include [HTTPS redirection and HSTS support](xref:security/enforcing-ssl).
+Project templates configure apps to run on HTTPS by default and include [HTTPS redirection and HSTS support](xref:security/enforcing-ssl).
 
 Call <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.Listen*> or <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenUnixSocket*> methods on <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions> to configure URL prefixes and ports for Kestrel.
 
 `UseUrls`, the `--urls` command-line argument, `urls` host configuration key, and the `ASPNETCORE_URLS` environment variable also work but have the limitations noted later in this section (a default certificate must be available for HTTPS endpoint configuration).
 
-ASP.NET Core 2.1 or later `KestrelServerOptions` configuration:
+`KestrelServerOptions` configuration:
 
 ### ConfigureEndpointDefaults(Action\<ListenOptions>)
 
 Specifies a configuration `Action` to run for each specified endpoint. Calling `ConfigureEndpointDefaults` multiple times replaces prior `Action`s with the last `Action` specified.
-
-::: moniker range=">= aspnetcore-3.0"
 
 ```csharp
 public static IHostBuilder CreateHostBuilder(string[] args) =>
@@ -752,30 +358,9 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
 }
 ```
 
-::: moniker-end
-
-::: moniker range="< aspnetcore-3.0"
-
-```csharp
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .ConfigureKestrel((context, serverOptions) =>
-        {
-            serverOptions.ConfigureEndpointDefaults(listenOptions =>
-            {
-                // Configure endpoint defaults
-            });
-        });
-```
-
-::: moniker-end
-
 ### ConfigureHttpsDefaults(Action\<HttpsConnectionAdapterOptions>)
 
 Specifies a configuration `Action` to run for each HTTPS endpoint. Calling `ConfigureHttpsDefaults` multiple times replaces prior `Action`s with the last `Action` specified.
-
-::: moniker range=">= aspnetcore-3.0"
 
 ```csharp
 public static IHostBuilder CreateHostBuilder(string[] args) =>
@@ -794,26 +379,6 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
         });
 }
 ```
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-3.0"
-
-```csharp
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .ConfigureKestrel((context, serverOptions) =>
-        {
-            serverOptions.ConfigureHttpsDefaults(listenOptions =>
-            {
-                // certificate is an X509Certificate2
-                listenOptions.ServerCertificate = certificate;
-            });
-        });
-```
-
-::: moniker-end
 
 ### Configure(IConfiguration)
 
@@ -940,8 +505,6 @@ Schema notes:
 * Any number of endpoints may be defined in this way so long as they don't cause port conflicts.
 * `options.Configure(context.Configuration.GetSection("{SECTION}"))` returns a `KestrelConfigurationLoader` with an `.Endpoint(string name, listenOptions => { })` method that can be used to supplement a configured endpoint's settings:
 
-::: moniker range=">= aspnetcore-3.0"
-
 ```csharp
 public static IHostBuilder CreateHostBuilder(string[] args) =>
     Host.CreateDefaultBuilder(args)
@@ -958,26 +521,6 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
         });
 ```
 
-::: moniker-end
-
-::: moniker range="< aspnetcore-3.0"
-
-```csharp
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .UseKestrel((context, serverOptions) =>
-        {
-            serverOptions.Configure(context.Configuration.GetSection("Kestrel"))
-                .Endpoint("HTTPS", listenOptions =>
-                {
-                    listenOptions.HttpsOptions.SslProtocols = SslProtocols.Tls12;
-                });
-        });
-```
-
-::: moniker-end
-
 `KestrelServerOptions.ConfigurationLoader` can be directly accessed to continue iterating on the existing loader, such as the one provided by <xref:Microsoft.AspNetCore.WebHost.CreateDefaultBuilder*>.
 
 * The configuration section for each endpoint is a available on the options in the `Endpoint` method so that custom settings may be read.
@@ -987,8 +530,6 @@ public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
 *Change the defaults in code*
 
 `ConfigureEndpointDefaults` and `ConfigureHttpsDefaults` can be used to change default settings for `ListenOptions` and `HttpsConnectionAdapterOptions`, including overriding the default certificate specified in the prior scenario. `ConfigureEndpointDefaults` and `ConfigureHttpsDefaults` should be called before any endpoints are configured.
-
-::: moniker range=">= aspnetcore-3.0"
 
 ```csharp
 public static IHostBuilder CreateHostBuilder(string[] args) =>
@@ -1010,30 +551,6 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
         });
 ```
 
-::: moniker-end
-
-::: moniker range="< aspnetcore-3.0"
-
-```csharp
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .UseKestrel((context, serverOptions) =>
-        {
-            serverOptions.ConfigureEndpointDefaults(listenOptions =>
-            {
-                // Configure endpoint defaults
-            });
-            
-            serverOptions.ConfigureHttpsDefaults(listenOptions =>
-            {
-                listenOptions.SslProtocols = SslProtocols.Tls12;
-            });
-        });
-```
-
-::: moniker-end
-
 *Kestrel support for SNI*
 
 [Server Name Indication (SNI)](https://tools.ietf.org/html/rfc6066#section-3) can be used to host multiple domains on the same IP address and port. For SNI to function, the client sends the host name for the secure session to the server during the TLS handshake so that the server can provide the correct certificate. The client uses the furnished certificate for encrypted communication with the server during the secure session that follows the TLS handshake.
@@ -1042,10 +559,8 @@ Kestrel supports SNI via the `ServerCertificateSelector` callback. The callback 
 
 SNI support requires:
 
-* Running on target framework `netcoreapp2.1`. On `netcoreapp2.0` and `net461`, the callback is invoked but the `name` is always `null`. The `name` is also `null` if the client doesn't provide the host name parameter in the TLS handshake.
+* Running on target framework `netcoreapp2.1` or later. On `net461` or later, the callback is invoked but the `name` is always `null`. The `name` is also `null` if the client doesn't provide the host name parameter in the TLS handshake.
 * All websites run on the same Kestrel instance. Kestrel doesn't support sharing an IP address and port across multiple instances without a reverse proxy.
-
-::: moniker range=">= aspnetcore-3.0"
 
 ```csharp
 public static IHostBuilder CreateHostBuilder(string[] args) =>
@@ -1089,152 +604,11 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
         });
 ```
 
-::: moniker-end
-
-::: moniker range="= aspnetcore-2.2"
-
-```csharp
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .ConfigureKestrel((context, serverOptions) =>
-        {
-            serverOptions.ListenAnyIP(5005, listenOptions =>
-            {
-                listenOptions.UseHttps(httpsOptions =>
-                {
-                    var localhostCert = CertificateLoader.LoadFromStoreCert(
-                        "localhost", "My", StoreLocation.CurrentUser,
-                        allowInvalid: true);
-                    var exampleCert = CertificateLoader.LoadFromStoreCert(
-                        "example.com", "My", StoreLocation.CurrentUser,
-                        allowInvalid: true);
-                    var subExampleCert = CertificateLoader.LoadFromStoreCert(
-                        "sub.example.com", "My", StoreLocation.CurrentUser,
-                        allowInvalid: true);
-                    var certs = new Dictionary<string, X509Certificate2>(
-                        StringComparer.OrdinalIgnoreCase);
-                    certs["localhost"] = localhostCert;
-                    certs["example.com"] = exampleCert;
-                    certs["sub.example.com"] = subExampleCert;
-
-                    httpsOptions.ServerCertificateSelector = (connectionContext, name) =>
-                    {
-                        if (name != null && certs.TryGetValue(name, out var cert))
-                        {
-                            return cert;
-                        }
-
-                        return exampleCert;
-                    };
-                });
-            });
-        });
-```
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-2.2"
-
-```csharp
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .UseKestrel((context, serverOptions) =>
-        {
-            serverOptions.ListenAnyIP(5005, listenOptions =>
-            {
-                listenOptions.UseHttps(httpsOptions =>
-                {
-                    var localhostCert = CertificateLoader.LoadFromStoreCert(
-                        "localhost", "My", StoreLocation.CurrentUser,
-                        allowInvalid: true);
-                    var exampleCert = CertificateLoader.LoadFromStoreCert(
-                        "example.com", "My", StoreLocation.CurrentUser,
-                        allowInvalid: true);
-                    var subExampleCert = CertificateLoader.LoadFromStoreCert(
-                        "sub.example.com", "My", StoreLocation.CurrentUser,
-                        allowInvalid: true);
-                    var certs = new Dictionary<string, X509Certificate2>(
-                        StringComparer.OrdinalIgnoreCase);
-                    certs["localhost"] = localhostCert;
-                    certs["example.com"] = exampleCert;
-                    certs["sub.example.com"] = subExampleCert;
-
-                    httpsOptions.ServerCertificateSelector = (connectionContext, name) =>
-                    {
-                        if (name != null && certs.TryGetValue(name, out var cert))
-                        {
-                            return cert;
-                        }
-
-                        return exampleCert;
-                    };
-                });
-            });
-        })
-        .Build();
-```
-
-::: moniker-end
-
 ### Bind to a TCP socket
 
 The <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.Listen*> method binds to a TCP socket, and an options lambda permits X.509 certificate configuration:
 
-::: moniker range=">= aspnetcore-3.0"
-
 [!code-csharp[](kestrel/samples/3.x/KestrelSample/Program.cs?name=snippet_TCPSocket&highlight=9-16)]
-
-::: moniker-end
-
-::: moniker range="= aspnetcore-2.2"
-
-[!code-csharp[](kestrel/samples/2.x/KestrelSample/Program.cs?name=snippet_TCPSocket&highlight=9-16)]
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-2.2"
-
-```csharp
-public static void Main(string[] args)
-{
-    CreateWebHostBuilder(args).Build().Run();
-}
-
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .UseKestrel(serverOptions =>
-        {
-            serverOptions.Listen(IPAddress.Loopback, 5000);
-            serverOptions.Listen(IPAddress.Loopback, 5001, listenOptions =>
-            {
-                listenOptions.UseHttps("testCert.pfx", "testPassword");
-            });
-        });
-```
-
-```csharp
-public static void Main(string[] args)
-{
-    CreateWebHostBuilder(args).Build().Run();
-}
-
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .UseKestrel(serverOptions =>
-        {
-            serverOptions.Listen(IPAddress.Loopback, 5000);
-            serverOptions.Listen(IPAddress.Loopback, 5001, listenOptions =>
-            {
-                listenOptions.UseHttps("testCert.pfx", "testPassword");
-            });
-        });
-```
-
-::: moniker-end
 
 The example configures HTTPS for an endpoint with <xref:Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions>. Use the same API to configure other Kestrel settings for specific endpoints.
 
@@ -1244,51 +618,13 @@ The example configures HTTPS for an endpoint with <xref:Microsoft.AspNetCore.Ser
 
 Listen on a Unix socket with <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenUnixSocket*> for improved performance with Nginx, as shown in this example:
 
-::: moniker range=">= aspnetcore-3.0"
-
 [!code-csharp[](kestrel/samples/3.x/KestrelSample/Program.cs?name=snippet_UnixSocket)]
-
-::: moniker-end
-
-::: moniker range="= aspnetcore-2.2"
-
-[!code-csharp[](kestrel/samples/2.x/KestrelSample/Program.cs?name=snippet_UnixSocket)]
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-2.2"
-
-```csharp
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
-        .UseKestrel(serverOptions =>
-        {
-            serverOptions.ListenUnixSocket("/tmp/kestrel-test.sock");
-            serverOptions.ListenUnixSocket("/tmp/kestrel-test.sock", listenOptions =>
-            {
-                listenOptions.UseHttps("testCert.pfx", "testpassword");
-            });
-        });
-```
-
-::: moniker-end
 
 ### Port 0
 
 When the port number `0` is specified, Kestrel dynamically binds to an available port. The following example shows how to determine which port Kestrel actually bound at runtime:
 
-::: moniker range=">= aspnetcore-3.0"
-
 [!code-csharp[](kestrel/samples/3.x/KestrelSample/Startup.cs?name=snippet_Configure&highlight=3-4,15-21)]
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-3.0"
-
-[!code-csharp[](kestrel/samples/2.x/KestrelSample/Startup.cs?name=snippet_Configure&highlight=3-4,15-21)]
-
-::: moniker-end
 
 When the app is run, the console window output indicates the dynamic port where the app can be reached:
 
@@ -1313,8 +649,6 @@ These methods are useful for making code work with servers other than Kestrel. H
 ### IIS endpoint configuration
 
 When using IIS, the URL bindings for IIS override bindings are set by either `Listen` or `UseUrls`. For more information, see the [ASP.NET Core Module](xref:host-and-deploy/aspnet-core-module) topic.
-
-::: moniker range=">= aspnetcore-3.0"
 
 ### ListenOptions.Protocols
 
@@ -1448,9 +782,741 @@ The following *appsettings.json* example establishes the HTTP/1.1 connection pro
 
 Protocols specified in code override values set by configuration.
 
+## Transport configuration
+
+For projects that require the use of Libuv (<xref:Microsoft.AspNetCore.Hosting.WebHostBuilderLibuvExtensions.UseLibuv*>):
+
+* Add a dependency for the [Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/) package to the app's project file:
+
+   ```xml
+   <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv"
+                     Version="{VERSION}" />
+   ```
+
+* Call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderLibuvExtensions.UseLibuv*> on the `IWebHostBuilder`:
+
+   ```csharp
+   public class Program
+   {
+       public static void Main(string[] args)
+       {
+           CreateHostBuilder(args).Build().Run();
+       }
+
+       public static IHostBuilder CreateHostBuilder(string[] args) =>
+           Host.CreateDefaultBuilder(args)
+               .ConfigureWebHostDefaults(webBuilder =>
+               {
+                   webBuilder.UseLibuv();
+                   webBuilder.UseStartup<Startup>();
+               });
+   }
+   ```
+
+### URL prefixes
+
+When using `UseUrls`, `--urls` command-line argument, `urls` host configuration key, or `ASPNETCORE_URLS` environment variable, the URL prefixes can be in any of the following formats.
+
+Only HTTP URL prefixes are valid. Kestrel doesn't support HTTPS when configuring URL bindings using `UseUrls`.
+
+* IPv4 address with port number
+
+  ```
+  http://65.55.39.10:80/
+  ```
+
+  `0.0.0.0` is a special case that binds to all IPv4 addresses.
+
+* IPv6 address with port number
+
+  ```
+  http://[0:0:0:0:0:ffff:4137:270a]:80/
+  ```
+
+  `[::]` is the IPv6 equivalent of IPv4 `0.0.0.0`.
+
+* Host name with port number
+
+  ```
+  http://contoso.com:80/
+  http://*:80/
+  ```
+
+  Host names, `*`, and `+`, aren't special. Anything not recognized as a valid IP address or `localhost` binds to all IPv4 and IPv6 IPs. To bind different host names to different ASP.NET Core apps on the same port, use [HTTP.sys](xref:fundamentals/servers/httpsys) or a reverse proxy server, such as IIS, Nginx, or Apache.
+
+  > [!WARNING]
+  > Hosting in a reverse proxy configuration requires [host filtering](#host-filtering).
+
+* Host `localhost` name with port number or loopback IP with port number
+
+  ```
+  http://localhost:5000/
+  http://127.0.0.1:5000/
+  http://[::1]:5000/
+  ```
+
+  When `localhost` is specified, Kestrel attempts to bind to both IPv4 and IPv6 loopback interfaces. If the requested port is in use by another service on either loopback interface, Kestrel fails to start. If either loopback interface is unavailable for any other reason (most commonly because IPv6 isn't supported), Kestrel logs a warning.
+
+## Host filtering
+
+While Kestrel supports configuration based on prefixes such as `http://example.com:5000`, Kestrel largely ignores the host name. Host `localhost` is a special case used for binding to loopback addresses. Any host other than an explicit IP address binds to all public IP addresses. `Host` headers aren't validated.
+
+As a workaround, use Host Filtering Middleware. Host Filtering Middleware is provided by the [Microsoft.AspNetCore.HostFiltering](https://www.nuget.org/packages/Microsoft.AspNetCore.HostFiltering) package, which is implicitly provided for ASP.NET Core apps. The middleware is added by <xref:Microsoft.AspNetCore.WebHost.CreateDefaultBuilder*>, which calls <xref:Microsoft.AspNetCore.Builder.HostFilteringServicesExtensions.AddHostFiltering*>:
+
+[!code-csharp[](kestrel/samples-snapshot/2.x/KestrelSample/Program.cs?name=snippet_Program&highlight=9)]
+
+Host Filtering Middleware is disabled by default. To enable the middleware, define an `AllowedHosts` key in *appsettings.json*/*appsettings.\<EnvironmentName>.json*. The value is a semicolon-delimited list of host names without port numbers:
+
+*appsettings.json*:
+
+```json
+{
+  "AllowedHosts": "example.com;localhost"
+}
+```
+
+> [!NOTE]
+> [Forwarded Headers Middleware](xref:host-and-deploy/proxy-load-balancer) also has an <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.AllowedHosts> option. Forwarded Headers Middleware and Host Filtering Middleware have similar functionality for different scenarios. Setting `AllowedHosts` with Forwarded Headers Middleware is appropriate when the `Host` header isn't preserved while forwarding requests with a reverse proxy server or load balancer. Setting `AllowedHosts` with Host Filtering Middleware is appropriate when Kestrel is used as a public-facing edge server or when the `Host` header is directly forwarded.
+>
+> For more information on Forwarded Headers Middleware, see <xref:host-and-deploy/proxy-load-balancer>.
+
 ::: moniker-end
 
 ::: moniker range="= aspnetcore-2.2"
+
+Kestrel is a cross-platform [web server for ASP.NET Core](xref:fundamentals/servers/index). Kestrel is the web server that's included by default in ASP.NET Core project templates.
+
+Kestrel supports the following scenarios:
+
+* HTTPS
+* Opaque upgrade used to enable [WebSockets](https://github.com/aspnet/websockets)
+* Unix sockets for high performance behind Nginx
+* HTTP/2 (except on macOS&dagger;)
+
+&dagger;HTTP/2 will be supported on macOS in a future release.
+
+Kestrel is supported on all platforms and versions that .NET Core supports.
+
+[View or download sample code](https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/fundamentals/servers/kestrel/samples) ([how to download](xref:index#how-to-download-a-sample))
+
+## HTTP/2 support
+
+[HTTP/2](https://httpwg.org/specs/rfc7540.html) is available for ASP.NET Core apps if the following base requirements are met:
+
+* Operating system&dagger;
+  * Windows Server 2016/Windows 10 or later&Dagger;
+  * Linux with OpenSSL 1.0.2 or later (for example, Ubuntu 16.04 or later)
+* Target framework: .NET Core 2.2 or later
+* [Application-Layer Protocol Negotiation (ALPN)](https://tools.ietf.org/html/rfc7301#section-3) connection
+* TLS 1.2 or later connection
+
+&dagger;HTTP/2 will be supported on macOS in a future release.
+&Dagger;Kestrel has limited support for HTTP/2 on Windows Server 2012 R2 and Windows 8.1. Support is limited because the list of supported TLS cipher suites available on these operating systems is limited. A certificate generated using an Elliptic Curve Digital Signature Algorithm (ECDSA) may be required to secure TLS connections.
+
+If an HTTP/2 connection is established, [HttpRequest.Protocol](xref:Microsoft.AspNetCore.Http.HttpRequest.Protocol*) reports `HTTP/2`.
+
+HTTP/2 is disabled by default. For more information on configuration, see the [Kestrel options](#kestrel-options) and [ListenOptions.Protocols](#listenoptionsprotocols) sections.
+
+## When to use Kestrel with a reverse proxy
+
+Kestrel can be used by itself or with a *reverse proxy server*, such as [Internet Information Services (IIS)](https://www.iis.net/), [Nginx](https://nginx.org), or [Apache](https://httpd.apache.org/). A reverse proxy server receives HTTP requests from the network and forwards them to Kestrel.
+
+Kestrel used as an edge (Internet-facing) web server:
+
+![Kestrel communicates directly with the Internet without a reverse proxy server](kestrel/_static/kestrel-to-internet2.png)
+
+Kestrel used in a reverse proxy configuration:
+
+![Kestrel communicates indirectly with the Internet through a reverse proxy server, such as IIS, Nginx, or Apache](kestrel/_static/kestrel-to-internet.png)
+
+Either configuration, with or without a reverse proxy server, is a supported hosting configuration.
+
+Kestrel used as an edge server without a reverse proxy server doesn't support sharing the same IP and port among multiple processes. When Kestrel is configured to listen on a port, Kestrel handles all of the traffic for that port regardless of requests' `Host` headers. A reverse proxy that can share ports has the ability to forward requests to Kestrel on a unique IP and port.
+
+Even if a reverse proxy server isn't required, using a reverse proxy server might be a good choice.
+
+A reverse proxy:
+
+* Can limit the exposed public surface area of the apps that it hosts.
+* Provide an additional layer of configuration and defense.
+* Might integrate better with existing infrastructure.
+* Simplify load balancing and secure communication (HTTPS) configuration. Only the reverse proxy server requires an X.509 certificate, and that server can communicate with the app's servers on the internal network using plain HTTP.
+
+> [!WARNING]
+> Hosting in a reverse proxy configuration requires [host filtering](#host-filtering).
+
+## How to use Kestrel in ASP.NET Core apps
+
+The [Microsoft.AspNetCore.Server.Kestrel](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.Kestrel/) package is included in the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app).
+
+ASP.NET Core project templates use Kestrel by default. In *Program.cs*, the template code calls <xref:Microsoft.AspNetCore.WebHost.CreateDefaultBuilder*>, which calls <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderKestrelExtensions.UseKestrel*> behind the scenes.
+
+[!code-csharp[](kestrel/samples/2.x/KestrelSample/Program.cs?name=snippet_DefaultBuilder&highlight=7)]
+
+To provide additional configuration after calling `CreateDefaultBuilder`, use `ConfigureKestrel`:
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .ConfigureKestrel((context, serverOptions) =>
+        {
+            // Set properties and call methods on serverOptions
+        });
+```
+
+If the app doesn't call `CreateDefaultBuilder` to set up the host, call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderKestrelExtensions.UseKestrel*> **before** calling `ConfigureKestrel`:
+
+```csharp
+public static void Main(string[] args)
+{
+    var host = new WebHostBuilder()
+        .UseContentRoot(Directory.GetCurrentDirectory())
+        .UseKestrel()
+        .UseIISIntegration()
+        .UseStartup<Startup>()
+        .ConfigureKestrel((context, serverOptions) =>
+        {
+            // Set properties and call methods on serverOptions
+        })
+        .Build();
+
+    host.Run();
+}
+```
+
+## Kestrel options
+
+The Kestrel web server has constraint configuration options that are especially useful in Internet-facing deployments.
+
+Set constraints on the <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.Limits> property of the <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions> class. The `Limits` property holds an instance of the <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits> class.
+
+The following examples use the <xref:Microsoft.AspNetCore.Server.Kestrel.Core> namespace:
+
+```csharp
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+```
+
+### Keep-alive timeout
+
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.KeepAliveTimeout>
+
+Gets or sets the [keep-alive timeout](https://tools.ietf.org/html/rfc7230#section-6.5). Defaults to 2 minutes.
+
+[!code-csharp[](kestrel/samples/2.x/KestrelSample/Program.cs?name=snippet_Limits&highlight=15)]
+
+### Maximum client connections
+
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxConcurrentConnections>
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxConcurrentUpgradedConnections>
+
+The maximum number of concurrent open TCP connections can be set for the entire app with the following code:
+
+[!code-csharp[](kestrel/samples/2.x/KestrelSample/Program.cs?name=snippet_Limits&highlight=3)]
+
+There's a separate limit for connections that have been upgraded from HTTP or HTTPS to another protocol (for example, on a WebSockets request). After a connection is upgraded, it isn't counted against the `MaxConcurrentConnections` limit.
+
+[!code-csharp[](kestrel/samples/2.x/KestrelSample/Program.cs?name=snippet_Limits&highlight=4)]
+
+The maximum number of connections is unlimited (null) by default.
+
+### Maximum request body size
+
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxRequestBodySize>
+
+The default maximum request body size is 30,000,000 bytes, which is approximately 28.6 MB.
+
+The recommended approach to override the limit in an ASP.NET Core MVC app is to use the <xref:Microsoft.AspNetCore.Mvc.RequestSizeLimitAttribute> attribute on an action method:
+
+```csharp
+[RequestSizeLimit(100000000)]
+public IActionResult MyActionMethod()
+```
+
+Here's an example that shows how to configure the constraint for the app on every request:
+
+[!code-csharp[](kestrel/samples/2.x/KestrelSample/Program.cs?name=snippet_Limits&highlight=5)]
+
+Override the setting on a specific request in middleware:
+
+[!code-csharp[](kestrel/samples/2.x/KestrelSample/Startup.cs?name=snippet_Limits&highlight=3-4)]
+
+An exception is thrown if the app configures the limit on a request after the app has started to read the request. There's an `IsReadOnly` property that indicates if the `MaxRequestBodySize` property is in read-only state, meaning it's too late to configure the limit.
+
+When an app is run [out-of-process](xref:host-and-deploy/iis/index#out-of-process-hosting-model) behind the [ASP.NET Core Module](xref:host-and-deploy/aspnet-core-module), Kestrel's request body size limit is disabled because IIS already sets the limit.
+
+### Minimum request body data rate
+
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MinRequestBodyDataRate>
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MinResponseDataRate>
+
+Kestrel checks every second if data is arriving at the specified rate in bytes/second. If the rate drops below the minimum, the connection is timed out. The grace period is the amount of time that Kestrel gives the client to increase its send rate up to the minimum; the rate isn't checked during that time. The grace period helps avoid dropping connections that are initially sending data at a slow rate due to TCP slow-start.
+
+The default minimum rate is 240 bytes/second with a 5 second grace period.
+
+A minimum rate also applies to the response. The code to set the request limit and the response limit is the same except for having `RequestBody` or `Response` in the property and interface names.
+
+Here's an example that shows how to configure the minimum data rates in *Program.cs*:
+
+[!code-csharp[](kestrel/samples/2.x/KestrelSample/Program.cs?name=snippet_Limits&highlight=6-9)]
+
+Override the minimum rate limits per request in middleware:
+
+[!code-csharp[](kestrel/samples/2.x/KestrelSample/Startup.cs?name=snippet_Limits&highlight=6-21)]
+
+Neither rate feature referenced in the prior sample are present in `HttpContext.Features` for HTTP/2 requests because modifying rate limits on a per-request basis isn't supported for HTTP/2 due to the protocol's support for request multiplexing. Server-wide rate limits configured via `KestrelServerOptions.Limits` still apply to both HTTP/1.x and HTTP/2 connections.
+
+### Request headers timeout
+
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.RequestHeadersTimeout>
+
+Gets or sets the maximum amount of time the server spends receiving request headers. Defaults to 30 seconds.
+
+[!code-csharp[](kestrel/samples/2.x/KestrelSample/Program.cs?name=snippet_Limits&highlight=16)]
+
+### Maximum streams per connection
+
+`Http2.MaxStreamsPerConnection` limits the number of concurrent request streams per HTTP/2 connection. Excess streams are refused.
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .ConfigureKestrel((context, serverOptions) =>
+        {
+            serverOptions.Limits.Http2.MaxStreamsPerConnection = 100;
+        });
+```
+
+The default value is 100.
+
+### Header table size
+
+The HPACK decoder decompresses HTTP headers for HTTP/2 connections. `Http2.HeaderTableSize` limits the size of the header compression table that the HPACK decoder uses. The value is provided in octets and must be greater than zero (0).
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .ConfigureKestrel((context, serverOptions) =>
+        {
+            serverOptions.Limits.Http2.HeaderTableSize = 4096;
+        });
+```
+
+The default value is 4096.
+
+### Maximum frame size
+
+`Http2.MaxFrameSize` indicates the maximum size of the HTTP/2 connection frame payload to receive. The value is provided in octets and must be between 2^14 (16,384) and 2^24-1 (16,777,215).
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .ConfigureKestrel((context, serverOptions) =>
+        {
+            serverOptions.Limits.Http2.MaxFrameSize = 16384;
+        });
+```
+
+The default value is 2^14 (16,384).
+
+### Maximum request header size
+
+`Http2.MaxRequestHeaderFieldSize` indicates the maximum allowed size in octets of request header values. This limit applies to both name and value together in their compressed and uncompressed representations. The value must be greater than zero (0).
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .ConfigureKestrel((context, serverOptions) =>
+        {
+            serverOptions.Limits.Http2.MaxRequestHeaderFieldSize = 8192;
+        });
+```
+
+The default value is 8,192.
+
+### Initial connection window size
+
+`Http2.InitialConnectionWindowSize` indicates the maximum request body data in bytes the server buffers at one time aggregated across all requests (streams) per connection. Requests are also limited by `Http2.InitialStreamWindowSize`. The value must be greater than or equal to 65,535 and less than 2^31 (2,147,483,648).
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .ConfigureKestrel((context, serverOptions) =>
+        {
+            serverOptions.Limits.Http2.InitialConnectionWindowSize = 131072;
+        });
+```
+
+The default value is 128 KB (131,072).
+
+### Initial stream window size
+
+`Http2.InitialStreamWindowSize` indicates the maximum request body data in bytes the server buffers at one time per request (stream). Requests are also limited by `Http2.InitialStreamWindowSize`. The value must be greater than or equal to 65,535 and less than 2^31 (2,147,483,648).
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .ConfigureKestrel((context, serverOptions) =>
+        {
+            serverOptions.Limits.Http2.InitialStreamWindowSize = 98304;
+        });
+```
+
+The default value is 96 KB (98,304).
+
+### Synchronous IO
+
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.AllowSynchronousIO> controls whether synchronous IO is allowed for the request and response. The  default value is `true`.
+
+> [!WARNING]
+> A large number of blocking synchronous IO operations can lead to thread pool starvation, which makes the app unresponsive. Only enable `AllowSynchronousIO` when using a library that doesn't support asynchronous IO.
+
+The following example enables synchronous IO:
+
+[!code-csharp[](kestrel/samples/2.x/KestrelSample/Program.cs?name=snippet_SyncIO)]
+
+For information about other Kestrel options and limits, see:
+
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions>
+
+## Endpoint configuration
+
+By default, ASP.NET Core binds to:
+
+* `http://localhost:5000`
+* `https://localhost:5001` (when a local development certificate is present)
+
+Specify URLs using the:
+
+* `ASPNETCORE_URLS` environment variable.
+* `--urls` command-line argument.
+* `urls` host configuration key.
+* `UseUrls` extension method.
+
+The value provided using these approaches can be one or more HTTP and HTTPS endpoints (HTTPS if a default cert is available). Configure the value as a semicolon-separated list (for example, `"Urls": "http://localhost:8000;http://localhost:8001"`).
+
+For more information on these approaches, see [Server URLs](xref:fundamentals/host/web-host#server-urls) and [Override configuration](xref:fundamentals/host/web-host#override-configuration).
+
+A development certificate is created:
+
+* When the [.NET Core SDK](/dotnet/core/sdk) is installed.
+* The [dev-certs tool](xref:aspnetcore-2.1#https) is used to create a certificate.
+
+Some browsers require granting explicit permission to trust the local development certificate.
+
+Project templates configure apps to run on HTTPS by default and include [HTTPS redirection and HSTS support](xref:security/enforcing-ssl).
+
+Call <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.Listen*> or <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenUnixSocket*> methods on <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions> to configure URL prefixes and ports for Kestrel.
+
+`UseUrls`, the `--urls` command-line argument, `urls` host configuration key, and the `ASPNETCORE_URLS` environment variable also work but have the limitations noted later in this section (a default certificate must be available for HTTPS endpoint configuration).
+
+`KestrelServerOptions` configuration:
+
+### ConfigureEndpointDefaults(Action\<ListenOptions>)
+
+Specifies a configuration `Action` to run for each specified endpoint. Calling `ConfigureEndpointDefaults` multiple times replaces prior `Action`s with the last `Action` specified.
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .ConfigureKestrel((context, serverOptions) =>
+        {
+            serverOptions.ConfigureEndpointDefaults(listenOptions =>
+            {
+                // Configure endpoint defaults
+            });
+        });
+```
+
+### ConfigureHttpsDefaults(Action\<HttpsConnectionAdapterOptions>)
+
+Specifies a configuration `Action` to run for each HTTPS endpoint. Calling `ConfigureHttpsDefaults` multiple times replaces prior `Action`s with the last `Action` specified.
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .ConfigureKestrel((context, serverOptions) =>
+        {
+            serverOptions.ConfigureHttpsDefaults(listenOptions =>
+            {
+                // certificate is an X509Certificate2
+                listenOptions.ServerCertificate = certificate;
+            });
+        });
+```
+
+### Configure(IConfiguration)
+
+Creates a configuration loader for setting up Kestrel that takes an <xref:Microsoft.Extensions.Configuration.IConfiguration> as input. The configuration must be scoped to the configuration section for Kestrel.
+
+### ListenOptions.UseHttps
+
+Configure Kestrel to use HTTPS.
+
+`ListenOptions.UseHttps` extensions:
+
+* `UseHttps` &ndash; Configure Kestrel to use HTTPS with the default certificate. Throws an exception if no default certificate is configured.
+* `UseHttps(string fileName)`
+* `UseHttps(string fileName, string password)`
+* `UseHttps(string fileName, string password, Action<HttpsConnectionAdapterOptions> configureOptions)`
+* `UseHttps(StoreName storeName, string subject)`
+* `UseHttps(StoreName storeName, string subject, bool allowInvalid)`
+* `UseHttps(StoreName storeName, string subject, bool allowInvalid, StoreLocation location)`
+* `UseHttps(StoreName storeName, string subject, bool allowInvalid, StoreLocation location, Action<HttpsConnectionAdapterOptions> configureOptions)`
+* `UseHttps(X509Certificate2 serverCertificate)`
+* `UseHttps(X509Certificate2 serverCertificate, Action<HttpsConnectionAdapterOptions> configureOptions)`
+* `UseHttps(Action<HttpsConnectionAdapterOptions> configureOptions)`
+
+`ListenOptions.UseHttps` parameters:
+
+* `filename` is the path and file name of a certificate file, relative to the directory that contains the app's content files.
+* `password` is the password required to access the X.509 certificate data.
+* `configureOptions` is an `Action` to configure the `HttpsConnectionAdapterOptions`. Returns the `ListenOptions`.
+* `storeName` is the certificate store from which to load the certificate.
+* `subject` is the subject name for the certificate.
+* `allowInvalid` indicates if invalid certificates should be considered, such as self-signed certificates.
+* `location` is the store location to load the certificate from.
+* `serverCertificate` is the X.509 certificate.
+
+In production, HTTPS must be explicitly configured. At a minimum, a default certificate must be provided.
+
+Supported configurations described next:
+
+* No configuration
+* Replace the default certificate from configuration
+* Change the defaults in code
+
+*No configuration*
+
+Kestrel listens on `http://localhost:5000` and `https://localhost:5001` (if a default cert is available).
+
+<a name="configuration"></a>
+
+*Replace the default certificate from configuration*
+
+`CreateDefaultBuilder` calls `Configure(context.Configuration.GetSection("Kestrel"))` by default to load Kestrel configuration. A default HTTPS app settings configuration schema is available for Kestrel. Configure multiple endpoints, including the URLs and the certificates to use, either from a file on disk or from a certificate store.
+
+In the following *appsettings.json* example:
+
+* Set **AllowInvalid** to `true` to permit the use of invalid certificates (for example, self-signed certificates).
+* Any HTTPS endpoint that doesn't specify a certificate (**HttpsDefaultCert** in the example that follows) falls back to the cert defined under **Certificates** > **Default** or the development certificate.
+
+```json
+{
+  "Kestrel": {
+    "Endpoints": {
+      "Http": {
+        "Url": "http://localhost:5000"
+      },
+
+      "HttpsInlineCertFile": {
+        "Url": "https://localhost:5001",
+        "Certificate": {
+          "Path": "<path to .pfx file>",
+          "Password": "<certificate password>"
+        }
+      },
+
+      "HttpsInlineCertStore": {
+        "Url": "https://localhost:5002",
+        "Certificate": {
+          "Subject": "<subject; required>",
+          "Store": "<certificate store; required>",
+          "Location": "<location; defaults to CurrentUser>",
+          "AllowInvalid": "<true or false; defaults to false>"
+        }
+      },
+
+      "HttpsDefaultCert": {
+        "Url": "https://localhost:5003"
+      },
+
+      "Https": {
+        "Url": "https://*:5004",
+        "Certificate": {
+          "Path": "<path to .pfx file>",
+          "Password": "<certificate password>"
+        }
+      }
+    },
+    "Certificates": {
+      "Default": {
+        "Path": "<path to .pfx file>",
+        "Password": "<certificate password>"
+      }
+    }
+  }
+}
+```
+
+An alternative to using **Path** and **Password** for any certificate node is to specify the certificate using certificate store fields. For example, the **Certificates** > **Default** certificate can be specified as:
+
+```json
+"Default": {
+  "Subject": "<subject; required>",
+  "Store": "<cert store; required>",
+  "Location": "<location; defaults to CurrentUser>",
+  "AllowInvalid": "<true or false; defaults to false>"
+}
+```
+
+Schema notes:
+
+* Endpoints names are case-insensitive. For example, `HTTPS` and `Https` are valid.
+* The `Url` parameter is required for each endpoint. The format for this parameter is the same as the top-level `Urls` configuration parameter except that it's limited to a single value.
+* These endpoints replace those defined in the top-level `Urls` configuration rather than adding to them. Endpoints defined in code via `Listen` are cumulative with the endpoints defined in the configuration section.
+* The `Certificate` section is optional. If the `Certificate` section isn't specified, the defaults defined in earlier scenarios are used. If no defaults are available, the server throws an exception and fails to start.
+* The `Certificate` section supports both **Path**&ndash;**Password** and **Subject**&ndash;**Store** certificates.
+* Any number of endpoints may be defined in this way so long as they don't cause port conflicts.
+* `options.Configure(context.Configuration.GetSection("{SECTION}"))` returns a `KestrelConfigurationLoader` with an `.Endpoint(string name, listenOptions => { })` method that can be used to supplement a configured endpoint's settings:
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .UseKestrel((context, serverOptions) =>
+        {
+            serverOptions.Configure(context.Configuration.GetSection("Kestrel"))
+                .Endpoint("HTTPS", listenOptions =>
+                {
+                    listenOptions.HttpsOptions.SslProtocols = SslProtocols.Tls12;
+                });
+        });
+```
+
+`KestrelServerOptions.ConfigurationLoader` can be directly accessed to continue iterating on the existing loader, such as the one provided by <xref:Microsoft.AspNetCore.WebHost.CreateDefaultBuilder*>.
+
+* The configuration section for each endpoint is a available on the options in the `Endpoint` method so that custom settings may be read.
+* Multiple configurations may be loaded by calling `options.Configure(context.Configuration.GetSection("{SECTION}"))` again with another section. Only the last configuration is used, unless `Load` is explicitly called on prior instances. The metapackage doesn't call `Load` so that its default configuration section may be replaced.
+* `KestrelConfigurationLoader` mirrors the `Listen` family of APIs from `KestrelServerOptions` as `Endpoint` overloads, so code and config endpoints may be configured in the same place. These overloads don't use names and only consume default settings from configuration.
+
+*Change the defaults in code*
+
+`ConfigureEndpointDefaults` and `ConfigureHttpsDefaults` can be used to change default settings for `ListenOptions` and `HttpsConnectionAdapterOptions`, including overriding the default certificate specified in the prior scenario. `ConfigureEndpointDefaults` and `ConfigureHttpsDefaults` should be called before any endpoints are configured.
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .UseKestrel((context, serverOptions) =>
+        {
+            serverOptions.ConfigureEndpointDefaults(listenOptions =>
+            {
+                // Configure endpoint defaults
+            });
+            
+            serverOptions.ConfigureHttpsDefaults(listenOptions =>
+            {
+                listenOptions.SslProtocols = SslProtocols.Tls12;
+            });
+        });
+```
+
+*Kestrel support for SNI*
+
+[Server Name Indication (SNI)](https://tools.ietf.org/html/rfc6066#section-3) can be used to host multiple domains on the same IP address and port. For SNI to function, the client sends the host name for the secure session to the server during the TLS handshake so that the server can provide the correct certificate. The client uses the furnished certificate for encrypted communication with the server during the secure session that follows the TLS handshake.
+
+Kestrel supports SNI via the `ServerCertificateSelector` callback. The callback is invoked once per connection to allow the app to inspect the host name and select the appropriate certificate.
+
+SNI support requires:
+
+* Running on target framework `netcoreapp2.1` or later. On `net461` or later, the callback is invoked but the `name` is always `null`. The `name` is also `null` if the client doesn't provide the host name parameter in the TLS handshake.
+* All websites run on the same Kestrel instance. Kestrel doesn't support sharing an IP address and port across multiple instances without a reverse proxy.
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .ConfigureKestrel((context, serverOptions) =>
+        {
+            serverOptions.ListenAnyIP(5005, listenOptions =>
+            {
+                listenOptions.UseHttps(httpsOptions =>
+                {
+                    var localhostCert = CertificateLoader.LoadFromStoreCert(
+                        "localhost", "My", StoreLocation.CurrentUser,
+                        allowInvalid: true);
+                    var exampleCert = CertificateLoader.LoadFromStoreCert(
+                        "example.com", "My", StoreLocation.CurrentUser,
+                        allowInvalid: true);
+                    var subExampleCert = CertificateLoader.LoadFromStoreCert(
+                        "sub.example.com", "My", StoreLocation.CurrentUser,
+                        allowInvalid: true);
+                    var certs = new Dictionary<string, X509Certificate2>(
+                        StringComparer.OrdinalIgnoreCase);
+                    certs["localhost"] = localhostCert;
+                    certs["example.com"] = exampleCert;
+                    certs["sub.example.com"] = subExampleCert;
+
+                    httpsOptions.ServerCertificateSelector = (connectionContext, name) =>
+                    {
+                        if (name != null && certs.TryGetValue(name, out var cert))
+                        {
+                            return cert;
+                        }
+
+                        return exampleCert;
+                    };
+                });
+            });
+        });
+```
+
+### Bind to a TCP socket
+
+The <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.Listen*> method binds to a TCP socket, and an options lambda permits X.509 certificate configuration:
+
+[!code-csharp[](kestrel/samples/2.x/KestrelSample/Program.cs?name=snippet_TCPSocket&highlight=9-16)]
+
+The example configures HTTPS for an endpoint with <xref:Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions>. Use the same API to configure other Kestrel settings for specific endpoints.
+
+[!INCLUDE [How to make an X.509 cert](~/includes/make-x509-cert.md)]
+
+### Bind to a Unix socket
+
+Listen on a Unix socket with <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenUnixSocket*> for improved performance with Nginx, as shown in this example:
+
+[!code-csharp[](kestrel/samples/2.x/KestrelSample/Program.cs?name=snippet_UnixSocket)]
+
+### Port 0
+
+When the port number `0` is specified, Kestrel dynamically binds to an available port. The following example shows how to determine which port Kestrel actually bound at runtime:
+
+[!code-csharp[](kestrel/samples/2.x/KestrelSample/Startup.cs?name=snippet_Configure&highlight=3-4,15-21)]
+
+When the app is run, the console window output indicates the dynamic port where the app can be reached:
+
+```console
+Listening on the following addresses: http://127.0.0.1:48508
+```
+
+### Limitations
+
+Configure endpoints with the following approaches:
+
+* <xref:Microsoft.AspNetCore.Hosting.HostingAbstractionsWebHostBuilderExtensions.UseUrls*>
+* `--urls` command-line argument
+* `urls` host configuration key
+* `ASPNETCORE_URLS` environment variable
+
+These methods are useful for making code work with servers other than Kestrel. However, be aware of the following limitations:
+
+* HTTPS can't be used with these approaches unless a default certificate is provided in the HTTPS endpoint configuration (for example, using `KestrelServerOptions` configuration or a configuration file as shown earlier in this topic).
+* When both the `Listen` and `UseUrls` approaches are used simultaneously, the `Listen` endpoints override the `UseUrls` endpoints.
+
+### IIS endpoint configuration
+
+When using IIS, the URL bindings for IIS override bindings are set by either `Listen` or `UseUrls`. For more information, see the [ASP.NET Core Module](xref:host-and-deploy/aspnet-core-module) topic.
 
 ### ListenOptions.Protocols
 
@@ -1577,44 +1643,7 @@ The following configuration file example establishes a connection protocol for a
 
 Protocols specified in code override values set by configuration.
 
-::: moniker-end
-
 ## Transport configuration
-
-::: moniker range=">= aspnetcore-3.0"
-
-For projects that require the use of Libuv (<xref:Microsoft.AspNetCore.Hosting.WebHostBuilderLibuvExtensions.UseLibuv*>):
-
-* Add a dependency for the [Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/) package to the app's project file:
-
-   ```xml
-   <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv"
-                     Version="{VERSION}" />
-   ```
-
-* Call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderLibuvExtensions.UseLibuv*> on the `IWebHostBuilder`:
-
-   ```csharp
-   public class Program
-   {
-       public static void Main(string[] args)
-       {
-           CreateHostBuilder(args).Build().Run();
-       }
-
-       public static IHostBuilder CreateHostBuilder(string[] args) =>
-           Host.CreateDefaultBuilder(args)
-               .ConfigureWebHostDefaults(webBuilder =>
-               {
-                   webBuilder.UseLibuv();
-                   webBuilder.UseStartup<Startup>();
-               });
-   }
-   ```
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-3.0"
 
 With the release of ASP.NET Core 2.1, Kestrel's default transport is no longer based on Libuv but instead based on managed sockets. This is a breaking change for ASP.NET Core 2.0 apps upgrading to 2.1 that call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderLibuvExtensions.UseLibuv*> and depend on either of the following packages:
 
@@ -1646,8 +1675,6 @@ For projects that require the use of Libuv:
               .UseStartup<Startup>();
   }
   ```
-
-::: moniker-end
 
 ### URL prefixes
 
@@ -1697,7 +1724,7 @@ Only HTTP URL prefixes are valid. Kestrel doesn't support HTTPS when configuring
 
 While Kestrel supports configuration based on prefixes such as `http://example.com:5000`, Kestrel largely ignores the host name. Host `localhost` is a special case used for binding to loopback addresses. Any host other than an explicit IP address binds to all public IP addresses. `Host` headers aren't validated.
 
-As a workaround, use Host Filtering Middleware. Host Filtering Middleware is provided by the [Microsoft.AspNetCore.HostFiltering](https://www.nuget.org/packages/Microsoft.AspNetCore.HostFiltering) package, which is included in the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app) (ASP.NET Core 2.1 or later). The middleware is added by <xref:Microsoft.AspNetCore.WebHost.CreateDefaultBuilder*>, which calls <xref:Microsoft.AspNetCore.Builder.HostFilteringServicesExtensions.AddHostFiltering*>:
+As a workaround, use Host Filtering Middleware. Host Filtering Middleware is provided by the [Microsoft.AspNetCore.HostFiltering](https://www.nuget.org/packages/Microsoft.AspNetCore.HostFiltering) package, which is included in the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app) (ASP.NET Core 2.1 or 2.2). The middleware is added by <xref:Microsoft.AspNetCore.WebHost.CreateDefaultBuilder*>, which calls <xref:Microsoft.AspNetCore.Builder.HostFilteringServicesExtensions.AddHostFiltering*>:
 
 [!code-csharp[](kestrel/samples-snapshot/2.x/KestrelSample/Program.cs?name=snippet_Program&highlight=9)]
 
@@ -1715,6 +1742,709 @@ Host Filtering Middleware is disabled by default. To enable the middleware, defi
 > [Forwarded Headers Middleware](xref:host-and-deploy/proxy-load-balancer) also has an <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.AllowedHosts> option. Forwarded Headers Middleware and Host Filtering Middleware have similar functionality for different scenarios. Setting `AllowedHosts` with Forwarded Headers Middleware is appropriate when the `Host` header isn't preserved while forwarding requests with a reverse proxy server or load balancer. Setting `AllowedHosts` with Host Filtering Middleware is appropriate when Kestrel is used as a public-facing edge server or when the `Host` header is directly forwarded.
 >
 > For more information on Forwarded Headers Middleware, see <xref:host-and-deploy/proxy-load-balancer>.
+
+::: moniker-end
+
+::: moniker range="= aspnetcore-2.1"
+
+Kestrel is a cross-platform [web server for ASP.NET Core](xref:fundamentals/servers/index). Kestrel is the web server that's included by default in ASP.NET Core project templates.
+
+Kestrel supports the following scenarios:
+
+* HTTPS
+* Opaque upgrade used to enable [WebSockets](https://github.com/aspnet/websockets)
+* Unix sockets for high performance behind Nginx
+
+Kestrel is supported on all platforms and versions that .NET Core supports.
+
+[View or download sample code](https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/fundamentals/servers/kestrel/samples) ([how to download](xref:index#how-to-download-a-sample))
+
+## When to use Kestrel with a reverse proxy
+
+Kestrel can be used by itself or with a *reverse proxy server*, such as [Internet Information Services (IIS)](https://www.iis.net/), [Nginx](https://nginx.org), or [Apache](https://httpd.apache.org/). A reverse proxy server receives HTTP requests from the network and forwards them to Kestrel.
+
+Kestrel used as an edge (Internet-facing) web server:
+
+![Kestrel communicates directly with the Internet without a reverse proxy server](kestrel/_static/kestrel-to-internet2.png)
+
+Kestrel used in a reverse proxy configuration:
+
+![Kestrel communicates indirectly with the Internet through a reverse proxy server, such as IIS, Nginx, or Apache](kestrel/_static/kestrel-to-internet.png)
+
+Either configuration, with or without a reverse proxy server, is a supported hosting configuration.
+
+Kestrel used as an edge server without a reverse proxy server doesn't support sharing the same IP and port among multiple processes. When Kestrel is configured to listen on a port, Kestrel handles all of the traffic for that port regardless of requests' `Host` headers. A reverse proxy that can share ports has the ability to forward requests to Kestrel on a unique IP and port.
+
+Even if a reverse proxy server isn't required, using a reverse proxy server might be a good choice.
+
+A reverse proxy:
+
+* Can limit the exposed public surface area of the apps that it hosts.
+* Provide an additional layer of configuration and defense.
+* Might integrate better with existing infrastructure.
+* Simplify load balancing and secure communication (HTTPS) configuration. Only the reverse proxy server requires an X.509 certificate, and that server can communicate with the app's servers on the internal network using plain HTTP.
+
+> [!WARNING]
+> Hosting in a reverse proxy configuration requires [host filtering](#host-filtering).
+
+## How to use Kestrel in ASP.NET Core apps
+
+The [Microsoft.AspNetCore.Server.Kestrel](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.Kestrel/) package is included in the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app).
+
+ASP.NET Core project templates use Kestrel by default. In *Program.cs*, the template code calls <xref:Microsoft.AspNetCore.WebHost.CreateDefaultBuilder*>, which calls <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderKestrelExtensions.UseKestrel*> behind the scenes.
+
+To provide additional configuration after calling `CreateDefaultBuilder`, call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderKestrelExtensions.UseKestrel*>:
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .UseKestrel(serverOptions =>
+        {
+            // Set properties and call methods on serverOptions
+        });
+```
+
+## Kestrel options
+
+The Kestrel web server has constraint configuration options that are especially useful in Internet-facing deployments.
+
+Set constraints on the <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.Limits> property of the <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions> class. The `Limits` property holds an instance of the <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits> class.
+
+The following examples use the <xref:Microsoft.AspNetCore.Server.Kestrel.Core> namespace:
+
+```csharp
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+```
+
+### Keep-alive timeout
+
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.KeepAliveTimeout>
+
+Gets or sets the [keep-alive timeout](https://tools.ietf.org/html/rfc7230#section-6.5). Defaults to 2 minutes.
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .UseKestrel(serverOptions =>
+        {
+            serverOptions.Limits.KeepAliveTimeout = TimeSpan.FromMinutes(2);
+        });
+```
+
+### Maximum client connections
+
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxConcurrentConnections>
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxConcurrentUpgradedConnections>
+
+The maximum number of concurrent open TCP connections can be set for the entire app with the following code:
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .UseKestrel(serverOptions =>
+        {
+            serverOptions.Limits.MaxConcurrentConnections = 100;
+        });
+```
+
+There's a separate limit for connections that have been upgraded from HTTP or HTTPS to another protocol (for example, on a WebSockets request). After a connection is upgraded, it isn't counted against the `MaxConcurrentConnections` limit.
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .UseKestrel(serverOptions =>
+        {
+            serverOptions.Limits.MaxConcurrentUpgradedConnections = 100;
+        });
+```
+
+The maximum number of connections is unlimited (null) by default.
+
+### Maximum request body size
+
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxRequestBodySize>
+
+The default maximum request body size is 30,000,000 bytes, which is approximately 28.6 MB.
+
+The recommended approach to override the limit in an ASP.NET Core MVC app is to use the <xref:Microsoft.AspNetCore.Mvc.RequestSizeLimitAttribute> attribute on an action method:
+
+```csharp
+[RequestSizeLimit(100000000)]
+public IActionResult MyActionMethod()
+```
+
+Here's an example that shows how to configure the constraint for the app on every request:
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .UseKestrel(serverOptions =>
+        {
+            serverOptions.Limits.MaxRequestBodySize = 10 * 1024;
+        });
+```
+
+Override the setting on a specific request in middleware:
+
+[!code-csharp[](kestrel/samples/2.x/KestrelSample/Startup.cs?name=snippet_Limits&highlight=3-4)]
+
+An exception is thrown if the app configures the limit on a request after the app has started to read the request. There's an `IsReadOnly` property that indicates if the `MaxRequestBodySize` property is in read-only state, meaning it's too late to configure the limit.
+
+When an app is run [out-of-process](xref:host-and-deploy/iis/index#out-of-process-hosting-model) behind the [ASP.NET Core Module](xref:host-and-deploy/aspnet-core-module), Kestrel's request body size limit is disabled because IIS already sets the limit.
+
+### Minimum request body data rate
+
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MinRequestBodyDataRate>
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MinResponseDataRate>
+
+Kestrel checks every second if data is arriving at the specified rate in bytes/second. If the rate drops below the minimum, the connection is timed out. The grace period is the amount of time that Kestrel gives the client to increase its send rate up to the minimum; the rate isn't checked during that time. The grace period helps avoid dropping connections that are initially sending data at a slow rate due to TCP slow-start.
+
+The default minimum rate is 240 bytes/second with a 5 second grace period.
+
+A minimum rate also applies to the response. The code to set the request limit and the response limit is the same except for having `RequestBody` or `Response` in the property and interface names.
+
+Here's an example that shows how to configure the minimum data rates in *Program.cs*:
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .UseKestrel(serverOptions =>
+        {
+            serverOptions.Limits.MinRequestBodyDataRate =
+                new MinDataRate(bytesPerSecond: 100, gracePeriod: TimeSpan.FromSeconds(10));
+            serverOptions.Limits.MinResponseDataRate =
+                new MinDataRate(bytesPerSecond: 100, gracePeriod: TimeSpan.FromSeconds(10));
+        });
+```
+
+### Request headers timeout
+
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.RequestHeadersTimeout>
+
+Gets or sets the maximum amount of time the server spends receiving request headers. Defaults to 30 seconds.
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .UseKestrel(serverOptions =>
+        {
+            serverOptions.Limits.RequestHeadersTimeout = TimeSpan.FromMinutes(1);
+        });
+```
+
+### Synchronous IO
+
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.AllowSynchronousIO> controls whether synchronous IO is allowed for the request and response. The  default value is `true`.
+
+> [!WARNING]
+> A large number of blocking synchronous IO operations can lead to thread pool starvation, which makes the app unresponsive. Only enable `AllowSynchronousIO` when using a library that doesn't support asynchronous IO.
+
+The following example disables synchronous IO:
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .UseKestrel(serverOptions =>
+        {
+            serverOptions.AllowSynchronousIO = false;
+        });
+```
+
+For information about other Kestrel options and limits, see:
+
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions>
+
+## Endpoint configuration
+
+By default, ASP.NET Core binds to:
+
+* `http://localhost:5000`
+* `https://localhost:5001` (when a local development certificate is present)
+
+Specify URLs using the:
+
+* `ASPNETCORE_URLS` environment variable.
+* `--urls` command-line argument.
+* `urls` host configuration key.
+* `UseUrls` extension method.
+
+The value provided using these approaches can be one or more HTTP and HTTPS endpoints (HTTPS if a default cert is available). Configure the value as a semicolon-separated list (for example, `"Urls": "http://localhost:8000;http://localhost:8001"`).
+
+For more information on these approaches, see [Server URLs](xref:fundamentals/host/web-host#server-urls) and [Override configuration](xref:fundamentals/host/web-host#override-configuration).
+
+A development certificate is created:
+
+* When the [.NET Core SDK](/dotnet/core/sdk) is installed.
+* The [dev-certs tool](xref:aspnetcore-2.1#https) is used to create a certificate.
+
+Some browsers require granting explicit permission to trust the local development certificate.
+
+Project templates configure apps to run on HTTPS by default and include [HTTPS redirection and HSTS support](xref:security/enforcing-ssl).
+
+Call <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.Listen*> or <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenUnixSocket*> methods on <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions> to configure URL prefixes and ports for Kestrel.
+
+`UseUrls`, the `--urls` command-line argument, `urls` host configuration key, and the `ASPNETCORE_URLS` environment variable also work but have the limitations noted later in this section (a default certificate must be available for HTTPS endpoint configuration).
+
+`KestrelServerOptions` configuration:
+
+### ConfigureEndpointDefaults(Action\<ListenOptions>)
+
+Specifies a configuration `Action` to run for each specified endpoint. Calling `ConfigureEndpointDefaults` multiple times replaces prior `Action`s with the last `Action` specified.
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .ConfigureKestrel((context, serverOptions) =>
+        {
+            serverOptions.ConfigureEndpointDefaults(listenOptions =>
+            {
+                // Configure endpoint defaults
+            });
+        });
+```
+
+### ConfigureHttpsDefaults(Action\<HttpsConnectionAdapterOptions>)
+
+Specifies a configuration `Action` to run for each HTTPS endpoint. Calling `ConfigureHttpsDefaults` multiple times replaces prior `Action`s with the last `Action` specified.
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .ConfigureKestrel((context, serverOptions) =>
+        {
+            serverOptions.ConfigureHttpsDefaults(listenOptions =>
+            {
+                // certificate is an X509Certificate2
+                listenOptions.ServerCertificate = certificate;
+            });
+        });
+```
+
+### Configure(IConfiguration)
+
+Creates a configuration loader for setting up Kestrel that takes an <xref:Microsoft.Extensions.Configuration.IConfiguration> as input. The configuration must be scoped to the configuration section for Kestrel.
+
+### ListenOptions.UseHttps
+
+Configure Kestrel to use HTTPS.
+
+`ListenOptions.UseHttps` extensions:
+
+* `UseHttps` &ndash; Configure Kestrel to use HTTPS with the default certificate. Throws an exception if no default certificate is configured.
+* `UseHttps(string fileName)`
+* `UseHttps(string fileName, string password)`
+* `UseHttps(string fileName, string password, Action<HttpsConnectionAdapterOptions> configureOptions)`
+* `UseHttps(StoreName storeName, string subject)`
+* `UseHttps(StoreName storeName, string subject, bool allowInvalid)`
+* `UseHttps(StoreName storeName, string subject, bool allowInvalid, StoreLocation location)`
+* `UseHttps(StoreName storeName, string subject, bool allowInvalid, StoreLocation location, Action<HttpsConnectionAdapterOptions> configureOptions)`
+* `UseHttps(X509Certificate2 serverCertificate)`
+* `UseHttps(X509Certificate2 serverCertificate, Action<HttpsConnectionAdapterOptions> configureOptions)`
+* `UseHttps(Action<HttpsConnectionAdapterOptions> configureOptions)`
+
+`ListenOptions.UseHttps` parameters:
+
+* `filename` is the path and file name of a certificate file, relative to the directory that contains the app's content files.
+* `password` is the password required to access the X.509 certificate data.
+* `configureOptions` is an `Action` to configure the `HttpsConnectionAdapterOptions`. Returns the `ListenOptions`.
+* `storeName` is the certificate store from which to load the certificate.
+* `subject` is the subject name for the certificate.
+* `allowInvalid` indicates if invalid certificates should be considered, such as self-signed certificates.
+* `location` is the store location to load the certificate from.
+* `serverCertificate` is the X.509 certificate.
+
+In production, HTTPS must be explicitly configured. At a minimum, a default certificate must be provided.
+
+Supported configurations described next:
+
+* No configuration
+* Replace the default certificate from configuration
+* Change the defaults in code
+
+*No configuration*
+
+Kestrel listens on `http://localhost:5000` and `https://localhost:5001` (if a default cert is available).
+
+<a name="configuration"></a>
+
+*Replace the default certificate from configuration*
+
+`CreateDefaultBuilder` calls `Configure(context.Configuration.GetSection("Kestrel"))` by default to load Kestrel configuration. A default HTTPS app settings configuration schema is available for Kestrel. Configure multiple endpoints, including the URLs and the certificates to use, either from a file on disk or from a certificate store.
+
+In the following *appsettings.json* example:
+
+* Set **AllowInvalid** to `true` to permit the use of invalid certificates (for example, self-signed certificates).
+* Any HTTPS endpoint that doesn't specify a certificate (**HttpsDefaultCert** in the example that follows) falls back to the cert defined under **Certificates** > **Default** or the development certificate.
+
+```json
+{
+  "Kestrel": {
+    "Endpoints": {
+      "Http": {
+        "Url": "http://localhost:5000"
+      },
+
+      "HttpsInlineCertFile": {
+        "Url": "https://localhost:5001",
+        "Certificate": {
+          "Path": "<path to .pfx file>",
+          "Password": "<certificate password>"
+        }
+      },
+
+      "HttpsInlineCertStore": {
+        "Url": "https://localhost:5002",
+        "Certificate": {
+          "Subject": "<subject; required>",
+          "Store": "<certificate store; required>",
+          "Location": "<location; defaults to CurrentUser>",
+          "AllowInvalid": "<true or false; defaults to false>"
+        }
+      },
+
+      "HttpsDefaultCert": {
+        "Url": "https://localhost:5003"
+      },
+
+      "Https": {
+        "Url": "https://*:5004",
+        "Certificate": {
+          "Path": "<path to .pfx file>",
+          "Password": "<certificate password>"
+        }
+      }
+    },
+    "Certificates": {
+      "Default": {
+        "Path": "<path to .pfx file>",
+        "Password": "<certificate password>"
+      }
+    }
+  }
+}
+```
+
+An alternative to using **Path** and **Password** for any certificate node is to specify the certificate using certificate store fields. For example, the **Certificates** > **Default** certificate can be specified as:
+
+```json
+"Default": {
+  "Subject": "<subject; required>",
+  "Store": "<cert store; required>",
+  "Location": "<location; defaults to CurrentUser>",
+  "AllowInvalid": "<true or false; defaults to false>"
+}
+```
+
+Schema notes:
+
+* Endpoints names are case-insensitive. For example, `HTTPS` and `Https` are valid.
+* The `Url` parameter is required for each endpoint. The format for this parameter is the same as the top-level `Urls` configuration parameter except that it's limited to a single value.
+* These endpoints replace those defined in the top-level `Urls` configuration rather than adding to them. Endpoints defined in code via `Listen` are cumulative with the endpoints defined in the configuration section.
+* The `Certificate` section is optional. If the `Certificate` section isn't specified, the defaults defined in earlier scenarios are used. If no defaults are available, the server throws an exception and fails to start.
+* The `Certificate` section supports both **Path**&ndash;**Password** and **Subject**&ndash;**Store** certificates.
+* Any number of endpoints may be defined in this way so long as they don't cause port conflicts.
+* `options.Configure(context.Configuration.GetSection("{SECTION}"))` returns a `KestrelConfigurationLoader` with an `.Endpoint(string name, listenOptions => { })` method that can be used to supplement a configured endpoint's settings:
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .UseKestrel((context, serverOptions) =>
+        {
+            serverOptions.Configure(context.Configuration.GetSection("Kestrel"))
+                .Endpoint("HTTPS", listenOptions =>
+                {
+                    listenOptions.HttpsOptions.SslProtocols = SslProtocols.Tls12;
+                });
+        });
+```
+
+`KestrelServerOptions.ConfigurationLoader` can be directly accessed to continue iterating on the existing loader, such as the one provided by <xref:Microsoft.AspNetCore.WebHost.CreateDefaultBuilder*>.
+
+* The configuration section for each endpoint is a available on the options in the `Endpoint` method so that custom settings may be read.
+* Multiple configurations may be loaded by calling `options.Configure(context.Configuration.GetSection("{SECTION}"))` again with another section. Only the last configuration is used, unless `Load` is explicitly called on prior instances. The metapackage doesn't call `Load` so that its default configuration section may be replaced.
+* `KestrelConfigurationLoader` mirrors the `Listen` family of APIs from `KestrelServerOptions` as `Endpoint` overloads, so code and config endpoints may be configured in the same place. These overloads don't use names and only consume default settings from configuration.
+
+*Change the defaults in code*
+
+`ConfigureEndpointDefaults` and `ConfigureHttpsDefaults` can be used to change default settings for `ListenOptions` and `HttpsConnectionAdapterOptions`, including overriding the default certificate specified in the prior scenario. `ConfigureEndpointDefaults` and `ConfigureHttpsDefaults` should be called before any endpoints are configured.
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .UseKestrel((context, serverOptions) =>
+        {
+            serverOptions.ConfigureEndpointDefaults(listenOptions =>
+            {
+                // Configure endpoint defaults
+            });
+            
+            serverOptions.ConfigureHttpsDefaults(listenOptions =>
+            {
+                listenOptions.SslProtocols = SslProtocols.Tls12;
+            });
+        });
+```
+
+*Kestrel support for SNI*
+
+[Server Name Indication (SNI)](https://tools.ietf.org/html/rfc6066#section-3) can be used to host multiple domains on the same IP address and port. For SNI to function, the client sends the host name for the secure session to the server during the TLS handshake so that the server can provide the correct certificate. The client uses the furnished certificate for encrypted communication with the server during the secure session that follows the TLS handshake.
+
+Kestrel supports SNI via the `ServerCertificateSelector` callback. The callback is invoked once per connection to allow the app to inspect the host name and select the appropriate certificate.
+
+SNI support requires:
+
+* Running on target framework `netcoreapp2.1` or later. On `net461` or later, the callback is invoked but the `name` is always `null`. The `name` is also `null` if the client doesn't provide the host name parameter in the TLS handshake.
+* All websites run on the same Kestrel instance. Kestrel doesn't support sharing an IP address and port across multiple instances without a reverse proxy.
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .UseKestrel((context, serverOptions) =>
+        {
+            serverOptions.ListenAnyIP(5005, listenOptions =>
+            {
+                listenOptions.UseHttps(httpsOptions =>
+                {
+                    var localhostCert = CertificateLoader.LoadFromStoreCert(
+                        "localhost", "My", StoreLocation.CurrentUser,
+                        allowInvalid: true);
+                    var exampleCert = CertificateLoader.LoadFromStoreCert(
+                        "example.com", "My", StoreLocation.CurrentUser,
+                        allowInvalid: true);
+                    var subExampleCert = CertificateLoader.LoadFromStoreCert(
+                        "sub.example.com", "My", StoreLocation.CurrentUser,
+                        allowInvalid: true);
+                    var certs = new Dictionary<string, X509Certificate2>(
+                        StringComparer.OrdinalIgnoreCase);
+                    certs["localhost"] = localhostCert;
+                    certs["example.com"] = exampleCert;
+                    certs["sub.example.com"] = subExampleCert;
+
+                    httpsOptions.ServerCertificateSelector = (connectionContext, name) =>
+                    {
+                        if (name != null && certs.TryGetValue(name, out var cert))
+                        {
+                            return cert;
+                        }
+
+                        return exampleCert;
+                    };
+                });
+            });
+        })
+        .Build();
+```
+
+### Bind to a TCP socket
+
+The <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.Listen*> method binds to a TCP socket, and an options lambda permits X.509 certificate configuration:
+
+```csharp
+public static void Main(string[] args)
+{
+    CreateWebHostBuilder(args).Build().Run();
+}
+
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .UseKestrel(serverOptions =>
+        {
+            serverOptions.Listen(IPAddress.Loopback, 5000);
+            serverOptions.Listen(IPAddress.Loopback, 5001, listenOptions =>
+            {
+                listenOptions.UseHttps("testCert.pfx", "testPassword");
+            });
+        });
+```
+
+```csharp
+public static void Main(string[] args)
+{
+    CreateWebHostBuilder(args).Build().Run();
+}
+
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .UseKestrel(serverOptions =>
+        {
+            serverOptions.Listen(IPAddress.Loopback, 5000);
+            serverOptions.Listen(IPAddress.Loopback, 5001, listenOptions =>
+            {
+                listenOptions.UseHttps("testCert.pfx", "testPassword");
+            });
+        });
+```
+
+The example configures HTTPS for an endpoint with <xref:Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions>. Use the same API to configure other Kestrel settings for specific endpoints.
+
+[!INCLUDE [How to make an X.509 cert](~/includes/make-x509-cert.md)]
+
+### Bind to a Unix socket
+
+Listen on a Unix socket with <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenUnixSocket*> for improved performance with Nginx, as shown in this example:
+
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .UseKestrel(serverOptions =>
+        {
+            serverOptions.ListenUnixSocket("/tmp/kestrel-test.sock");
+            serverOptions.ListenUnixSocket("/tmp/kestrel-test.sock", listenOptions =>
+            {
+                listenOptions.UseHttps("testCert.pfx", "testpassword");
+            });
+        });
+```
+
+### Port 0
+
+When the port number `0` is specified, Kestrel dynamically binds to an available port. The following example shows how to determine which port Kestrel actually bound at runtime:
+
+[!code-csharp[](kestrel/samples/2.x/KestrelSample/Startup.cs?name=snippet_Configure&highlight=3-4,15-21)]
+
+When the app is run, the console window output indicates the dynamic port where the app can be reached:
+
+```console
+Listening on the following addresses: http://127.0.0.1:48508
+```
+
+### Limitations
+
+Configure endpoints with the following approaches:
+
+* <xref:Microsoft.AspNetCore.Hosting.HostingAbstractionsWebHostBuilderExtensions.UseUrls*>
+* `--urls` command-line argument
+* `urls` host configuration key
+* `ASPNETCORE_URLS` environment variable
+
+These methods are useful for making code work with servers other than Kestrel. However, be aware of the following limitations:
+
+* HTTPS can't be used with these approaches unless a default certificate is provided in the HTTPS endpoint configuration (for example, using `KestrelServerOptions` configuration or a configuration file as shown earlier in this topic).
+* When both the `Listen` and `UseUrls` approaches are used simultaneously, the `Listen` endpoints override the `UseUrls` endpoints.
+
+### IIS endpoint configuration
+
+When using IIS, the URL bindings for IIS override bindings are set by either `Listen` or `UseUrls`. For more information, see the [ASP.NET Core Module](xref:host-and-deploy/aspnet-core-module) topic.
+
+## Transport configuration
+
+With the release of ASP.NET Core 2.1, Kestrel's default transport is no longer based on Libuv but instead based on managed sockets. This is a breaking change for ASP.NET Core 2.0 apps upgrading to 2.1 that call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderLibuvExtensions.UseLibuv*> and depend on either of the following packages:
+
+* [Microsoft.AspNetCore.Server.Kestrel](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.Kestrel/) (direct package reference)
+* [Microsoft.AspNetCore.App](https://www.nuget.org/packages/Microsoft.AspNetCore.App/)
+
+For projects that require the use of Libuv:
+
+* Add a dependency for the [Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv/) package to the app's project file:
+
+  ```xml
+  <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv"
+                    Version="{VERSION}" />
+  ```
+
+* Call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderLibuvExtensions.UseLibuv*>:
+
+  ```csharp
+  public class Program
+  {
+      public static void Main(string[] args)
+      {
+          CreateWebHostBuilder(args).Build().Run();
+      }
+
+      public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+          WebHost.CreateDefaultBuilder(args)
+              .UseLibuv()
+              .UseStartup<Startup>();
+  }
+  ```
+
+### URL prefixes
+
+When using `UseUrls`, `--urls` command-line argument, `urls` host configuration key, or `ASPNETCORE_URLS` environment variable, the URL prefixes can be in any of the following formats.
+
+Only HTTP URL prefixes are valid. Kestrel doesn't support HTTPS when configuring URL bindings using `UseUrls`.
+
+* IPv4 address with port number
+
+  ```
+  http://65.55.39.10:80/
+  ```
+
+  `0.0.0.0` is a special case that binds to all IPv4 addresses.
+
+* IPv6 address with port number
+
+  ```
+  http://[0:0:0:0:0:ffff:4137:270a]:80/
+  ```
+
+  `[::]` is the IPv6 equivalent of IPv4 `0.0.0.0`.
+
+* Host name with port number
+
+  ```
+  http://contoso.com:80/
+  http://*:80/
+  ```
+
+  Host names, `*`, and `+`, aren't special. Anything not recognized as a valid IP address or `localhost` binds to all IPv4 and IPv6 IPs. To bind different host names to different ASP.NET Core apps on the same port, use [HTTP.sys](xref:fundamentals/servers/httpsys) or a reverse proxy server, such as IIS, Nginx, or Apache.
+
+  > [!WARNING]
+  > Hosting in a reverse proxy configuration requires [host filtering](#host-filtering).
+
+* Host `localhost` name with port number or loopback IP with port number
+
+  ```
+  http://localhost:5000/
+  http://127.0.0.1:5000/
+  http://[::1]:5000/
+  ```
+
+  When `localhost` is specified, Kestrel attempts to bind to both IPv4 and IPv6 loopback interfaces. If the requested port is in use by another service on either loopback interface, Kestrel fails to start. If either loopback interface is unavailable for any other reason (most commonly because IPv6 isn't supported), Kestrel logs a warning.
+
+## Host filtering
+
+While Kestrel supports configuration based on prefixes such as `http://example.com:5000`, Kestrel largely ignores the host name. Host `localhost` is a special case used for binding to loopback addresses. Any host other than an explicit IP address binds to all public IP addresses. `Host` headers aren't validated.
+
+As a workaround, use Host Filtering Middleware. Host Filtering Middleware is provided by the [Microsoft.AspNetCore.HostFiltering](https://www.nuget.org/packages/Microsoft.AspNetCore.HostFiltering) package, which is included in the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app) (ASP.NET Core 2.1 or 2.2). The middleware is added by <xref:Microsoft.AspNetCore.WebHost.CreateDefaultBuilder*>, which calls <xref:Microsoft.AspNetCore.Builder.HostFilteringServicesExtensions.AddHostFiltering*>:
+
+[!code-csharp[](kestrel/samples-snapshot/2.x/KestrelSample/Program.cs?name=snippet_Program&highlight=9)]
+
+Host Filtering Middleware is disabled by default. To enable the middleware, define an `AllowedHosts` key in *appsettings.json*/*appsettings.\<EnvironmentName>.json*. The value is a semicolon-delimited list of host names without port numbers:
+
+*appsettings.json*:
+
+```json
+{
+  "AllowedHosts": "example.com;localhost"
+}
+```
+
+> [!NOTE]
+> [Forwarded Headers Middleware](xref:host-and-deploy/proxy-load-balancer) also has an <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.AllowedHosts> option. Forwarded Headers Middleware and Host Filtering Middleware have similar functionality for different scenarios. Setting `AllowedHosts` with Forwarded Headers Middleware is appropriate when the `Host` header isn't preserved while forwarding requests with a reverse proxy server or load balancer. Setting `AllowedHosts` with Host Filtering Middleware is appropriate when Kestrel is used as a public-facing edge server or when the `Host` header is directly forwarded.
+>
+> For more information on Forwarded Headers Middleware, see <xref:host-and-deploy/proxy-load-balancer>.
+
+::: moniker-end
 
 ## Additional resources
 

--- a/aspnetcore/fundamentals/servers/kestrel.md
+++ b/aspnetcore/fundamentals/servers/kestrel.md
@@ -1,6 +1,6 @@
 ---
 title: Kestrel web server implementation in ASP.NET Core
-author: tdykstra
+author: guardrex
 description: Learn about Kestrel, the cross-platform web server for ASP.NET Core.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: tdykstra
@@ -10,7 +10,7 @@ uid: fundamentals/servers/kestrel
 ---
 # Kestrel web server implementation in ASP.NET Core
 
-By [Tom Dykstra](https://github.com/tdykstra), [Chris Ross](https://github.com/Tratcher), and [Stephen Halter](https://twitter.com/halter73)
+By [Tom Dykstra](https://github.com/tdykstra), [Chris Ross](https://github.com/Tratcher), [Stephen Halter](https://twitter.com/halter73), and [Luke Latham](https://github.com/guardrex)
 
 ::: moniker range=">= aspnetcore-3.0"
 

--- a/aspnetcore/fundamentals/servers/kestrel.md
+++ b/aspnetcore/fundamentals/servers/kestrel.md
@@ -73,7 +73,7 @@ Kestrel used in a reverse proxy configuration:
 
 ![Kestrel communicates indirectly with the Internet through a reverse proxy server, such as IIS, Nginx, or Apache](kestrel/_static/kestrel-to-internet.png)
 
-Either configuration&mdash;with or without a reverse proxy server&mdash;is a supported hosting configuration for ASP.NET Core 2.1 or later apps that receive requests from the Internet.
+Either configuration, with or without a reverse proxy server, is a supported hosting configuration.
 
 Kestrel used as an edge server without a reverse proxy server doesn't support sharing the same IP and port among multiple processes. When Kestrel is configured to listen on a port, Kestrel handles all of the traffic for that port regardless of requests' `Host` headers. A reverse proxy that can share ports has the ability to forward requests to Kestrel on a unique IP and port.
 

--- a/aspnetcore/fundamentals/servers/kestrel.md
+++ b/aspnetcore/fundamentals/servers/kestrel.md
@@ -1324,12 +1324,9 @@ The `Protocols` property establishes the HTTP protocols (`HttpProtocols`) enable
 | -------------------------- | ----------------------------- |
 | `Http1`                    | HTTP/1.1 only. Can be used with or without TLS. |
 | `Http2`                    | HTTP/2 only. May be used without TLS only if the client supports a [Prior Knowledge mode](https://tools.ietf.org/html/rfc7540#section-3.4). |
-| `Http1AndHttp2`            | HTTP/1.1 and HTTP/2. HTTP/2 requires a TLS and [Application-Layer Protocol Negotiation (ALPN)](https://tools.ietf.org/html/rfc7301#section-3) connection; otherwise, the connection defaults to HTTP/1.1. |
+| `Http1AndHttp2`            | HTTP/1.1 and HTTP/2. HTTP/2 requires the client to select HTTP/2 in the TLS [Application-Layer Protocol Negotiation (ALPN)](https://tools.ietf.org/html/rfc7301#section-3) handshake; otherwise, the connection defaults to HTTP/1.1. |
 
-The default protocol is:
-
-* HTTP/2 for HTTP connections.
-* HTTP/1.1 for HTTPS connections.
+The default `ListenOptions.Protocols` value for any endpoint is `HttpProtocols.Http1AndHttp2`.
 
 TLS restrictions for HTTP/2:
 
@@ -1350,7 +1347,6 @@ The following example permits HTTP/1.1 and HTTP/2 connections on port 8000. Conn
 {
     serverOptions.Listen(IPAddress.Any, 8000, listenOptions =>
     {
-        listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
         listenOptions.UseHttps("testCert.pfx", "testPassword");
     });
 });
@@ -1366,7 +1362,6 @@ Optionally use Connection Middleware to filter TLS handshakes on a per-connectio
 {
     serverOptions.Listen(IPAddress.Any, 8000, listenOptions =>
     {
-        listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
         listenOptions.UseHttps("testCert.pfx", "testPassword");
         listenOptions.UseConnectionHandler<TlsFilterConnectionHandler>();
     });
@@ -1422,21 +1417,21 @@ public class TlsFilterConnectionHandler : ConnectionHandler
 
 *Set the protocol from configuration*
 
-<xref:Microsoft.AspNetCore.WebHost.CreateDefaultBuilder*> calls `serverOptions.Configure(context.Configuration.GetSection("Kestrel"))` by default to load Kestrel configuration.
+`CreateDefaultBuilder` calls `serverOptions.Configure(context.Configuration.GetSection("Kestrel"))` by default to load Kestrel configuration.
 
-In the following *appsettings.json* example, a default connection protocol (HTTP/1.1 and HTTP/2) is established for all of Kestrel's endpoints:
+The following *appsettings.json* example establishes HTTP/1.1 as the default connection protocol for all endpoints:
 
 ```json
 {
   "Kestrel": {
     "EndpointDefaults": {
-      "Protocols": "Http1AndHttp2"
+      "Protocols": "Http1"
     }
   }
 }
 ```
 
-The following configuration file example establishes a connection protocol for a specific endpoint:
+The following *appsettings.json* example establishes the HTTP/1.1 connection protocol for a specific endpoint:
 
 ```json
 {

--- a/aspnetcore/fundamentals/servers/kestrel.md
+++ b/aspnetcore/fundamentals/servers/kestrel.md
@@ -5,7 +5,7 @@ description: Learn about Kestrel, the cross-platform web server for ASP.NET Core
 monikerRange: '>= aspnetcore-2.1'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 09/09/2019
+ms.date: 09/10/2019
 uid: fundamentals/servers/kestrel
 ---
 # Kestrel web server implementation in ASP.NET Core
@@ -150,9 +150,9 @@ To provide additional configuration after calling `CreateDefaultBuilder`, use `C
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .ConfigureKestrel((context, options) =>
+        .ConfigureKestrel((context, serverOptions) =>
         {
-            // Set properties and call methods on options
+            // Set properties and call methods on serverOptions
         });
 ```
 
@@ -166,9 +166,9 @@ public static void Main(string[] args)
         .UseKestrel()
         .UseIISIntegration()
         .UseStartup<Startup>()
-        .ConfigureKestrel((context, options) =>
+        .ConfigureKestrel((context, serverOptions) =>
         {
-            // Set properties and call methods on options
+            // Set properties and call methods on serverOptions
         })
         .Build();
 
@@ -190,9 +190,9 @@ To provide additional configuration after calling `CreateDefaultBuilder`, call <
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .UseKestrel(options =>
+        .UseKestrel(serverOptions =>
         {
-            // Set properties and call methods on options
+            // Set properties and call methods on serverOptions
         });
 ```
 
@@ -234,9 +234,9 @@ Gets or sets the [keep-alive timeout](https://tools.ietf.org/html/rfc7230#sectio
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .UseKestrel(options =>
+        .UseKestrel(serverOptions =>
         {
-            options.Limits.KeepAliveTimeout = TimeSpan.FromMinutes(2);
+            serverOptions.Limits.KeepAliveTimeout = TimeSpan.FromMinutes(2);
         });
 ```
 
@@ -267,9 +267,9 @@ The maximum number of concurrent open TCP connections can be set for the entire 
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .UseKestrel(options =>
+        .UseKestrel(serverOptions =>
         {
-            options.Limits.MaxConcurrentConnections = 100;
+            serverOptions.Limits.MaxConcurrentConnections = 100;
         });
 ```
 
@@ -295,9 +295,9 @@ There's a separate limit for connections that have been upgraded from HTTP or HT
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .UseKestrel(options =>
+        .UseKestrel(serverOptions =>
         {
-            options.Limits.MaxConcurrentUpgradedConnections = 100;
+            serverOptions.Limits.MaxConcurrentUpgradedConnections = 100;
         });
 ```
 
@@ -346,9 +346,9 @@ Override the setting on a specific request in middleware:
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .UseKestrel(options =>
+        .UseKestrel(serverOptions =>
         {
-            options.Limits.MaxRequestBodySize = 10 * 1024;
+            serverOptions.Limits.MaxRequestBodySize = 10 * 1024;
         });
 ```
 
@@ -393,11 +393,11 @@ Here's an example that shows how to configure the minimum data rates in *Program
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .UseKestrel(options =>
+        .UseKestrel(serverOptions =>
         {
-            options.Limits.MinRequestBodyDataRate =
+            serverOptions.Limits.MinRequestBodyDataRate =
                 new MinDataRate(bytesPerSecond: 100, gracePeriod: TimeSpan.FromSeconds(10));
-            options.Limits.MinResponseDataRate =
+            serverOptions.Limits.MinResponseDataRate =
                 new MinDataRate(bytesPerSecond: 100, gracePeriod: TimeSpan.FromSeconds(10));
         });
 ```
@@ -450,9 +450,9 @@ Gets or sets the maximum amount of time the server spends receiving request head
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .UseKestrel(options =>
+        .UseKestrel(serverOptions =>
         {
-            options.Limits.RequestHeadersTimeout = TimeSpan.FromMinutes(1);
+            serverOptions.Limits.RequestHeadersTimeout = TimeSpan.FromMinutes(1);
         });
 ```
 
@@ -551,9 +551,9 @@ The default value is 96 KB (98,304).
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .ConfigureKestrel((context, options) =>
+        .ConfigureKestrel((context, serverOptions) =>
         {
-            options.Limits.Http2.MaxStreamsPerConnection = 100;
+            serverOptions.Limits.Http2.MaxStreamsPerConnection = 100;
         });
 ```
 
@@ -567,9 +567,9 @@ The HPACK decoder decompresses HTTP headers for HTTP/2 connections. `Http2.Heade
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .ConfigureKestrel((context, options) =>
+        .ConfigureKestrel((context, serverOptions) =>
         {
-            options.Limits.Http2.HeaderTableSize = 4096;
+            serverOptions.Limits.Http2.HeaderTableSize = 4096;
         });
 ```
 
@@ -583,9 +583,9 @@ The default value is 4096.
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .ConfigureKestrel((context, options) =>
+        .ConfigureKestrel((context, serverOptions) =>
         {
-            options.Limits.Http2.MaxFrameSize = 16384;
+            serverOptions.Limits.Http2.MaxFrameSize = 16384;
         });
 ```
 
@@ -599,9 +599,9 @@ The default value is 2^14 (16,384).
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .ConfigureKestrel((context, options) =>
+        .ConfigureKestrel((context, serverOptions) =>
         {
-            options.Limits.Http2.MaxRequestHeaderFieldSize = 8192;
+            serverOptions.Limits.Http2.MaxRequestHeaderFieldSize = 8192;
         });
 ```
 
@@ -615,9 +615,9 @@ The default value is 8,192.
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .ConfigureKestrel((context, options) =>
+        .ConfigureKestrel((context, serverOptions) =>
         {
-            options.Limits.Http2.InitialConnectionWindowSize = 131072;
+            serverOptions.Limits.Http2.InitialConnectionWindowSize = 131072;
         });
 ```
 
@@ -631,9 +631,9 @@ The default value is 128 KB (131,072).
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .ConfigureKestrel((context, options) =>
+        .ConfigureKestrel((context, serverOptions) =>
         {
-            options.Limits.Http2.InitialStreamWindowSize = 98304;
+            serverOptions.Limits.Http2.InitialStreamWindowSize = 98304;
         });
 ```
 
@@ -682,9 +682,9 @@ The following example disables synchronous IO:
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .UseKestrel(options =>
+        .UseKestrel(serverOptions =>
         {
-            options.AllowSynchronousIO = false;
+            serverOptions.AllowSynchronousIO = false;
         });
 ```
 
@@ -742,7 +742,7 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
         {
             webBuilder.ConfigureKestrel(serverOptions =>
             {
-                serverOptions.ConfigureEndpointDefaults(configureOptions =>
+                serverOptions.ConfigureEndpointDefaults(listenOptions =>
                 {
                     // Configure endpoint defaults
                 });
@@ -760,9 +760,9 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .ConfigureKestrel((context, options) =>
+        .ConfigureKestrel((context, serverOptions) =>
         {
-            options.ConfigureEndpointDefaults(configureOptions =>
+            serverOptions.ConfigureEndpointDefaults(listenOptions =>
             {
                 // Configure endpoint defaults
             });
@@ -784,10 +784,10 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
         {
             webBuilder.ConfigureKestrel(serverOptions =>
             {
-                serverOptions.ConfigureHttpsDefaults(configureOptions =>
+                serverOptions.ConfigureHttpsDefaults(listenOptions =>
                 {
                     // certificate is an X509Certificate2
-                    configureOptions.ServerCertificate = certificate;
+                    listenOptions.ServerCertificate = certificate;
                 });
             })
             .UseStartup<Startup>();
@@ -803,12 +803,12 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .ConfigureKestrel((context, options) =>
+        .ConfigureKestrel((context, serverOptions) =>
         {
-            options.ConfigureHttpsDefaults(configureOptions =>
+            serverOptions.ConfigureHttpsDefaults(listenOptions =>
             {
                 // certificate is an X509Certificate2
-                configureOptions.ServerCertificate = certificate;
+                listenOptions.ServerCertificate = certificate;
             });
         });
 ```
@@ -938,7 +938,7 @@ Schema notes:
 * The `Certificate` section is optional. If the `Certificate` section isn't specified, the defaults defined in earlier scenarios are used. If no defaults are available, the server throws an exception and fails to start.
 * The `Certificate` section supports both **Path**&ndash;**Password** and **Subject**&ndash;**Store** certificates.
 * Any number of endpoints may be defined in this way so long as they don't cause port conflicts.
-* `options.Configure(context.Configuration.GetSection("{SECTION}"))` returns a `KestrelConfigurationLoader` with an `.Endpoint(string name, options => { })` method that can be used to supplement a configured endpoint's settings:
+* `options.Configure(context.Configuration.GetSection("{SECTION}"))` returns a `KestrelConfigurationLoader` with an `.Endpoint(string name, listenOptions => { })` method that can be used to supplement a configured endpoint's settings:
 
 ::: moniker range=">= aspnetcore-3.0"
 
@@ -947,9 +947,9 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
     Host.CreateDefaultBuilder(args)
         .ConfigureWebHostDefaults(webBuilder =>
         {
-            webBuilder.UseKestrel((context, options) =>
+            webBuilder.UseKestrel((context, serverOptions) =>
             {
-                options.Configure(context.Configuration.GetSection("Kestrel"))
+                serverOptions.Configure(context.Configuration.GetSection("Kestrel"))
                     .Endpoint("HTTPS", listenOptions =>
                     {
                         listenOptions.HttpsOptions.SslProtocols = SslProtocols.Tls12;
@@ -966,9 +966,9 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .UseKestrel((context, options) =>
+        .UseKestrel((context, serverOptions) =>
         {
-            options.Configure(context.Configuration.GetSection("Kestrel"))
+            serverOptions.Configure(context.Configuration.GetSection("Kestrel"))
                 .Endpoint("HTTPS", listenOptions =>
                 {
                     listenOptions.HttpsOptions.SslProtocols = SslProtocols.Tls12;
@@ -997,14 +997,14 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
         {
             webBuilder.ConfigureKestrel(serverOptions =>
             {
-                serverOptions.ConfigureEndpointDefaults(configureOptions =>
+                serverOptions.ConfigureEndpointDefaults(listenOptions =>
                 {
                     // Configure endpoint defaults
                 });
 
-                serverOptions.ConfigureHttpsDefaults(configureOptions =>
+                serverOptions.ConfigureHttpsDefaults(listenOptions =>
                 {
-                    configureOptions.SslProtocols = SslProtocols.Tls12;
+                    listenOptions.SslProtocols = SslProtocols.Tls12;
                 });
             });
         });
@@ -1018,16 +1018,16 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .UseKestrel((context, options) =>
+        .UseKestrel((context, serverOptions) =>
         {
-            options.ConfigureEndpointDefaults(configureOptions =>
+            serverOptions.ConfigureEndpointDefaults(listenOptions =>
             {
                 // Configure endpoint defaults
             });
             
-            options.ConfigureHttpsDefaults(configureOptions =>
+            serverOptions.ConfigureHttpsDefaults(listenOptions =>
             {
-                configureOptions.SslProtocols = SslProtocols.Tls12;
+                listenOptions.SslProtocols = SslProtocols.Tls12;
             });
         });
 ```
@@ -1097,9 +1097,9 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .ConfigureKestrel((context, options) =>
+        .ConfigureKestrel((context, serverOptions) =>
         {
-            options.ListenAnyIP(5005, listenOptions =>
+            serverOptions.ListenAnyIP(5005, listenOptions =>
             {
                 listenOptions.UseHttps(httpsOptions =>
                 {
@@ -1140,9 +1140,9 @@ public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .UseKestrel((context, options) =>
+        .UseKestrel((context, serverOptions) =>
         {
-            options.ListenAnyIP(5005, listenOptions =>
+            serverOptions.ListenAnyIP(5005, listenOptions =>
             {
                 listenOptions.UseHttps(httpsOptions =>
                 {
@@ -1205,10 +1205,10 @@ public static void Main(string[] args)
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .UseKestrel(options =>
+        .UseKestrel(serverOptions =>
         {
-            options.Listen(IPAddress.Loopback, 5000);
-            options.Listen(IPAddress.Loopback, 5001, listenOptions =>
+            serverOptions.Listen(IPAddress.Loopback, 5000);
+            serverOptions.Listen(IPAddress.Loopback, 5001, listenOptions =>
             {
                 listenOptions.UseHttps("testCert.pfx", "testPassword");
             });
@@ -1224,10 +1224,10 @@ public static void Main(string[] args)
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .UseKestrel(options =>
+        .UseKestrel(serverOptions =>
         {
-            options.Listen(IPAddress.Loopback, 5000);
-            options.Listen(IPAddress.Loopback, 5001, listenOptions =>
+            serverOptions.Listen(IPAddress.Loopback, 5000);
+            serverOptions.Listen(IPAddress.Loopback, 5001, listenOptions =>
             {
                 listenOptions.UseHttps("testCert.pfx", "testPassword");
             });
@@ -1262,10 +1262,10 @@ Listen on a Unix socket with <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Kest
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
     WebHost.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
-        .UseKestrel(options =>
+        .UseKestrel(serverOptions =>
         {
-            options.ListenUnixSocket("/tmp/kestrel-test.sock");
-            options.ListenUnixSocket("/tmp/kestrel-test.sock", listenOptions =>
+            serverOptions.ListenUnixSocket("/tmp/kestrel-test.sock");
+            serverOptions.ListenUnixSocket("/tmp/kestrel-test.sock", listenOptions =>
             {
                 listenOptions.UseHttps("testCert.pfx", "testpassword");
             });
@@ -1484,9 +1484,9 @@ TLS restrictions for HTTP/2:
 The following example permits HTTP/1.1 and HTTP/2 connections on port 8000. Connections are secured by TLS with a supplied certificate:
 
 ```csharp
-.ConfigureKestrel((context, options) =>
+.ConfigureKestrel((context, serverOptions) =>
 {
-    options.Listen(IPAddress.Any, 8000, listenOptions =>
+    serverOptions.Listen(IPAddress.Any, 8000, listenOptions =>
     {
         listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
         listenOptions.UseHttps("testCert.pfx", "testPassword");
@@ -1497,9 +1497,9 @@ The following example permits HTTP/1.1 and HTTP/2 connections on port 8000. Conn
 Optionally create an `IConnectionAdapter` implementation to filter TLS handshakes on a per-connection basis for specific ciphers:
 
 ```csharp
-.ConfigureKestrel((context, options) =>
+.ConfigureKestrel((context, serverOptions) =>
 {
-    options.Listen(IPAddress.Any, 8000, listenOptions =>
+    serverOptions.Listen(IPAddress.Any, 8000, listenOptions =>
     {
         listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
         listenOptions.UseHttps("testCert.pfx", "testPassword");

--- a/aspnetcore/fundamentals/servers/kestrel/samples-snapshot/2.x/KestrelSample/Program.cs
+++ b/aspnetcore/fundamentals/servers/kestrel/samples-snapshot/2.x/KestrelSample/Program.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
-namespace newsample1
+namespace KestrelSample
 {
     #region snippet_Program
     public class Program

--- a/aspnetcore/fundamentals/servers/kestrel/samples-snapshot/3.x/KestrelSample/Program.cs
+++ b/aspnetcore/fundamentals/servers/kestrel/samples-snapshot/3.x/KestrelSample/Program.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace KestrelSample
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/aspnetcore/fundamentals/servers/kestrel/samples/2.x/KestrelSample/Program.cs
+++ b/aspnetcore/fundamentals/servers/kestrel/samples/2.x/KestrelSample/Program.cs
@@ -76,12 +76,13 @@ namespace KestrelSample
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
+                .UseLibuv()
                 .UseStartup<Startup>()
                 #region snippet_FileDescriptor
                 .ConfigureKestrel((context, options) =>
                 {
                     var fds = Environment.GetEnvironmentVariable("SD_LISTEN_FDS_START");
-                    ulong fd = ulong.Parse(fds);
+                    var fd = ulong.Parse(fds);
 
                     options.ListenHandle(fd);
                     options.ListenHandle(fd, listenOptions =>

--- a/aspnetcore/fundamentals/servers/kestrel/samples/2.x/KestrelSample/Program.cs
+++ b/aspnetcore/fundamentals/servers/kestrel/samples/2.x/KestrelSample/Program.cs
@@ -40,10 +40,10 @@ namespace KestrelSample
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .ConfigureKestrel((context, options) =>
+                .ConfigureKestrel((context, serverOptions) =>
                 {
-                    options.Listen(IPAddress.Loopback, 5000);
-                    options.Listen(IPAddress.Loopback, 5001, listenOptions =>
+                    serverOptions.Listen(IPAddress.Loopback, 5000);
+                    serverOptions.Listen(IPAddress.Loopback, 5001, listenOptions =>
                     {
                         listenOptions.UseHttps("testCert.pfx", "testPassword");
                     });
@@ -59,10 +59,10 @@ namespace KestrelSample
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
                 #region snippet_UnixSocket
-                .ConfigureKestrel((context, options) =>
+                .ConfigureKestrel((context, serverOptions) =>
                 {
-                    options.ListenUnixSocket("/tmp/kestrel-test.sock");
-                    options.ListenUnixSocket("/tmp/kestrel-test.sock", listenOptions =>
+                    serverOptions.ListenUnixSocket("/tmp/kestrel-test.sock");
+                    serverOptions.ListenUnixSocket("/tmp/kestrel-test.sock", listenOptions =>
                     {
                         listenOptions.UseHttps("testCert.pfx", "testpassword");
                     });
@@ -79,13 +79,13 @@ namespace KestrelSample
                 .UseLibuv()
                 .UseStartup<Startup>()
                 #region snippet_FileDescriptor
-                .ConfigureKestrel((context, options) =>
+                .ConfigureKestrel((context, serverOptions) =>
                 {
                     var fds = Environment.GetEnvironmentVariable("SD_LISTEN_FDS_START");
                     var fd = ulong.Parse(fds);
 
-                    options.ListenHandle(fd);
-                    options.ListenHandle(fd, listenOptions =>
+                    serverOptions.ListenHandle(fd);
+                    serverOptions.ListenHandle(fd, listenOptions =>
                     {
                         listenOptions.UseHttps("testCert.pfx", "testpassword");
                     });
@@ -101,22 +101,22 @@ namespace KestrelSample
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
                 #region snippet_Limits
-                .ConfigureKestrel((context, options) =>
+                .ConfigureKestrel((context, serverOptions) =>
                 {
-                    options.Limits.MaxConcurrentConnections = 100;
-                    options.Limits.MaxConcurrentUpgradedConnections = 100;
-                    options.Limits.MaxRequestBodySize = 10 * 1024;
-                    options.Limits.MinRequestBodyDataRate =
+                    serverOptions.Limits.MaxConcurrentConnections = 100;
+                    serverOptions.Limits.MaxConcurrentUpgradedConnections = 100;
+                    serverOptions.Limits.MaxRequestBodySize = 10 * 1024;
+                    serverOptions.Limits.MinRequestBodyDataRate =
                         new MinDataRate(bytesPerSecond: 100, gracePeriod: TimeSpan.FromSeconds(10));
-                    options.Limits.MinResponseDataRate =
+                    serverOptions.Limits.MinResponseDataRate =
                         new MinDataRate(bytesPerSecond: 100, gracePeriod: TimeSpan.FromSeconds(10));
-                    options.Listen(IPAddress.Loopback, 5000);
-                    options.Listen(IPAddress.Loopback, 5001, listenOptions =>
+                    serverOptions.Listen(IPAddress.Loopback, 5000);
+                    serverOptions.Listen(IPAddress.Loopback, 5001, listenOptions =>
                     {
                         listenOptions.UseHttps("testCert.pfx", "testPassword");
                     });
-                    options.Limits.KeepAliveTimeout = TimeSpan.FromMinutes(2);
-                    options.Limits.RequestHeadersTimeout = TimeSpan.FromMinutes(1);
+                    serverOptions.Limits.KeepAliveTimeout = TimeSpan.FromMinutes(2);
+                    serverOptions.Limits.RequestHeadersTimeout = TimeSpan.FromMinutes(1);
                 });
                 #endregion
 #elif Port0
@@ -129,9 +129,9 @@ namespace KestrelSample
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
                 #region snippet_Port0
-                .ConfigureKestrel((context, options) =>
+                .ConfigureKestrel((context, serverOptions) =>
                 {
-                    options.Listen(IPAddress.Loopback, 0);
+                    serverOptions.Listen(IPAddress.Loopback, 0);
                 });
                 #endregion
 #elif SyncIO
@@ -144,9 +144,9 @@ namespace KestrelSample
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
                 #region snippet_SyncIO
-                .ConfigureKestrel((context, options) =>
+                .ConfigureKestrel((context, serverOptions) =>
                 {
-                    options.AllowSynchronousIO = true;
+                    serverOptions.AllowSynchronousIO = true;
                 });
                 #endregion
 #endif

--- a/aspnetcore/fundamentals/servers/kestrel/samples/3.x/KestrelSample/KestrelSample.csproj
+++ b/aspnetcore/fundamentals/servers/kestrel/samples/3.x/KestrelSample/KestrelSample.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+  
+</Project>

--- a/aspnetcore/fundamentals/servers/kestrel/samples/3.x/KestrelSample/Program.cs
+++ b/aspnetcore/fundamentals/servers/kestrel/samples/3.x/KestrelSample/Program.cs
@@ -1,0 +1,182 @@
+﻿#define DefaultBuilder
+// Define any of the following for the scenarios described in the Kestrel topic:
+// DefaultBuilder Limits TCPSocket UnixSocket FileDescriptor Port0 SyncIO
+// The following require an X.509 certificate:
+// TCPSocket UnixSocket FileDescriptor Limits
+
+using System;
+using System.Net;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Hosting;
+
+namespace KestrelSample
+{
+    public class Program
+    {
+#if DefaultBuilder
+        #region snippet_DefaultBuilder
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+        #endregion
+#elif TCPSocket
+        #region snippet_TCPSocket
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.ConfigureKestrel(serverOptions =>
+                    {
+                        serverOptions.Listen(IPAddress.Loopback, 5000);
+                        serverOptions.Listen(IPAddress.Loopback, 5001, 
+                            listenOptions =>
+                            {
+                                listenOptions.UseHttps("testCert.pfx", 
+                                    "testPassword");
+                            });
+                    })
+                    .UseStartup<Startup>();
+                });
+        #endregion
+#elif UnixSocket
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    #region snippet_UnixSocket
+                    webBuilder.ConfigureKestrel(serverOptions =>
+                    {
+                        serverOptions.ListenUnixSocket("/tmp/kestrel-test.sock");
+                        serverOptions.ListenUnixSocket("/tmp/kestrel-test.sock", 
+                            listenOptions =>
+                            {
+                                listenOptions.UseHttps("testCert.pfx", 
+                                    "testpassword");
+                            });
+                    })
+                    #endregion
+                    .UseStartup<Startup>();
+                });
+#elif FileDescriptor
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .UseLibuv()
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    #region snippet_FileDescriptor
+                    webBuilder.ConfigureKestrel(serverOptions =>
+                    {
+                        var fds = Environment
+                            .GetEnvironmentVariable("SD_LISTEN_FDS_START");
+                        var fd = ulong.Parse(fds);
+
+                        serverOptions.ListenHandle(fd);
+                        serverOptions.ListenHandle(fd, listenOptions =>
+                        {
+                            listenOptions.UseHttps("testCert.pfx", "testpassword");
+                        });
+                    })
+                    #endregion
+                    .UseStartup<Startup>();
+                });
+#elif Limits
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    #region snippet_Limits
+                    webBuilder.ConfigureKestrel(serverOptions =>
+                    {
+                        serverOptions.Limits.MaxConcurrentConnections = 100;
+                        serverOptions.Limits.MaxConcurrentUpgradedConnections = 100;
+                        serverOptions.Limits.MaxRequestBodySize = 10 * 1024;
+                        serverOptions.Limits.MinRequestBodyDataRate =
+                            new MinDataRate(bytesPerSecond: 100, 
+                                gracePeriod: TimeSpan.FromSeconds(10));
+                        serverOptions.Limits.MinResponseDataRate =
+                            new MinDataRate(bytesPerSecond: 100, 
+                                gracePeriod: TimeSpan.FromSeconds(10));
+                        serverOptions.Listen(IPAddress.Loopback, 5000);
+                        serverOptions.Listen(IPAddress.Loopback, 5001, 
+                            listenOptions =>
+                            {
+                                listenOptions.UseHttps("testCert.pfx", 
+                                    "testPassword");
+                            });
+                        serverOptions.Limits.KeepAliveTimeout = 
+                            TimeSpan.FromMinutes(2);
+                        serverOptions.Limits.RequestHeadersTimeout = 
+                            TimeSpan.FromMinutes(1);
+                    })
+                    #endregion
+                    .UseStartup<Startup>();
+                });
+#elif Port0
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    #region snippet_Port0
+                    webBuilder.ConfigureKestrel(serverOptions =>
+                    {
+                        serverOptions.Listen(IPAddress.Loopback, 0);
+                    })
+                    #endregion
+                    .UseStartup<Startup>();
+                });
+#elif SyncIO
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    #region snippet_SyncIO
+                    webBuilder.ConfigureKestrel(serverOptions =>
+                    {
+                        serverOptions.AllowSynchronousIO = true;
+                    })
+                    #endregion
+                    .UseStartup<Startup>();
+                });
+#endif
+    }
+}

--- a/aspnetcore/fundamentals/servers/kestrel/samples/3.x/KestrelSample/Startup.cs
+++ b/aspnetcore/fundamentals/servers/kestrel/samples/3.x/KestrelSample/Startup.cs
@@ -1,0 +1,96 @@
+﻿#define Default // or Limits
+
+using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
+
+namespace KestrelSample
+{
+    public class Startup
+    {
+#if Default
+        #region snippet_Configure
+        public void Configure(IApplicationBuilder app)
+        {
+            var serverAddressesFeature = 
+                app.ServerFeatures.Get<IServerAddressesFeature>();
+
+            app.UseStaticFiles();
+
+            app.Run(async (context) =>
+            {
+                context.Response.ContentType = "text/html";
+                await context.Response
+                    .WriteAsync("<!DOCTYPE html><html lang=\"en\"><head>" +
+                        "<title></title></head><body><p>Hosted by Kestrel</p>");
+
+                if (serverAddressesFeature != null)
+                {
+                    await context.Response
+                        .WriteAsync("<p>Listening on the following addresses: " +
+                            string.Join(", ", serverAddressesFeature.Addresses) +
+                            "</p>");
+                }
+
+                await context.Response.WriteAsync("<p>Request URL: " +
+                    $"{context.Request.GetDisplayUrl()}<p>");
+            });
+        }
+        #endregion
+#elif Limits
+        public void Configure(IApplicationBuilder app)
+        {
+            var serverAddressesFeature = app.ServerFeatures.Get<IServerAddressesFeature>();
+
+            app.UseStaticFiles();
+
+            #region snippet_Limits
+            app.Run(async (context) =>
+            {
+                context.Features.Get<IHttpMaxRequestBodySizeFeature>()
+                    .MaxRequestBodySize = 10 * 1024;
+
+                var minRequestRateFeature = 
+                    context.Features.Get<IHttpMinRequestBodyDataRateFeature>();
+                var minResponseRateFeature = 
+                    context.Features.Get<IHttpMinResponseDataRateFeature>();
+
+                if (minRequestRateFeature != null)
+                {
+                    minRequestRateFeature.MinDataRate = new MinDataRate(
+                        bytesPerSecond: 100, gracePeriod: TimeSpan.FromSeconds(10));
+                }
+
+                if (minResponseRateFeature != null)
+                {
+                    minResponseRateFeature.MinDataRate = new MinDataRate(
+                        bytesPerSecond: 100, gracePeriod: TimeSpan.FromSeconds(10));
+                }
+            #endregion
+                context.Response.ContentType = "text/html";
+                await context.Response
+                    .WriteAsync("<!DOCTYPE html><html lang=\"en\"><head>" +
+                        "<title></title></head><body><p>Hosted by Kestrel</p>");
+
+                if (serverAddressesFeature != null)
+                {
+                    await context.Response
+                        .WriteAsync("<p>Listening on the following addresses: " +
+                            string.Join(", ", serverAddressesFeature.Addresses) +
+                            "</p>");
+                }
+
+                await context.Response.WriteAsync("<p>Request URL: " +
+                    $"{context.Request.GetDisplayUrl()}<p>");
+            });
+        }
+#endif
+    }
+}


### PR DESCRIPTION
Fixes #12842

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-2.1&branch=pr-en-us-13775)

**WRT HTTP/2: Additional updates (probably) will be made on https://github.com/aspnet/AspNetCore.Docs/issues/10141.**

* No giant rush on this. It's not a *quick review*. It needs a careful :eye: from engineering.
* Sample app
  * Adding the 3.x version.
  * Add `UseLibuv` to the `FileDescriptor` examples.
* We can't use our *whole topic* versioning here because there are *three* versions covered.
* Placing this back under TD's authorship now that he's back from *AzureLand*:tm:. :smile:
* The only obvious breaking change to react to is `NoDelay`, which was only in examples here. I remove it in favor of a nice, generic `// Configure endpoint defaults` code comment.
  Let me know on connection adapter, transport abstractions, request trailer headers, and other changes that might need to be covered. :ear: :ear: :ear:
* After I confirm the content here and react to engineering feedback, I'll take care of the Kestrel updates for the 2.2-to-3.0 migration topic. That work is tracked by https://github.com/aspnet/AspNetCore.Docs/issues/12923.
