### PR TITLE
RP auth conventions topic+sample updates for 3.0

### DIFF
--- a/aspnetcore/security/authorization/razor-pages-authorization.md
+++ b/aspnetcore/security/authorization/razor-pages-authorization.md
@@ -5,12 +5,126 @@ description: Learn how to control access to pages with conventions that authoriz
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 03/03/2019
+ms.date: 08/12/2019
 uid: security/authorization/razor-pages-authorization
 ---
 # Razor Pages authorization conventions in ASP.NET Core
 
 By [Luke Latham](https://github.com/guardrex)
+
+::: moniker range=">= aspnetcore-3.0"
+
+One way to control access in your Razor Pages app is to use authorization conventions at startup. These conventions allow you to authorize users and allow anonymous users to access individual pages or folders of pages. The conventions described in this topic automatically apply [authorization filters](xref:mvc/controllers/filters#authorization-filters) to control access.
+
+[View or download sample code](https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/security/authorization/razor-pages-authorization/samples) ([how to download](xref:index#how-to-download-a-sample))
+
+The sample app uses [cookie authentication without ASP.NET Core Identity](xref:security/authentication/cookie). The concepts and examples shown in this topic apply equally to apps that use ASP.NET Core Identity. To use ASP.NET Core Identity, follow the guidance in <xref:security/authentication/identity>.
+
+## Require authorization to access a page
+
+Use the <xref:Microsoft.Extensions.DependencyInjection.PageConventionCollectionExtensions.AuthorizePage*> convention via <xref:Microsoft.Extensions.DependencyInjection.MvcRazorPagesMvcBuilderExtensions.AddRazorPagesOptions*> to add an <xref:Microsoft.AspNetCore.Mvc.Authorization.AuthorizeFilter> to the page at the specified path:
+
+[!code-csharp[](razor-pages-authorization/samples/3.x/AuthorizationSample/Startup.cs?name=snippet1&highlight=2,4)]
+
+The specified path is the View Engine path, which is the Razor Pages root relative path without an extension and containing only forward slashes.
+
+To specify an [authorization policy](xref:security/authorization/policies), use an [AuthorizePage overload](xref:Microsoft.Extensions.DependencyInjection.PageConventionCollectionExtensions.AuthorizePage*):
+
+```csharp
+options.Conventions.AuthorizePage("/Contact", "AtLeast21");
+```
+
+> [!NOTE]
+> An <xref:Microsoft.AspNetCore.Mvc.Authorization.AuthorizeFilter> can be applied to a page model class with the `[Authorize]` filter attribute. For more information, see [Authorize filter attribute](xref:razor-pages/filter#authorize-filter-attribute).
+
+## Require authorization to access a folder of pages
+
+Use the <xref:Microsoft.Extensions.DependencyInjection.PageConventionCollectionExtensions.AuthorizeFolder*> convention via <xref:Microsoft.Extensions.DependencyInjection.MvcRazorPagesMvcBuilderExtensions.AddRazorPagesOptions*> to add an <xref:Microsoft.AspNetCore.Mvc.Authorization.AuthorizeFilter> to all of the pages in a folder at the specified path:
+
+[!code-csharp[](razor-pages-authorization/samples/3.x/AuthorizationSample/Startup.cs?name=snippet1&highlight=2,5)]
+
+The specified path is the View Engine path, which is the Razor Pages root relative path.
+
+To specify an [authorization policy](xref:security/authorization/policies), use an [AuthorizeFolder overload](xref:Microsoft.Extensions.DependencyInjection.PageConventionCollectionExtensions.AuthorizeFolder*):
+
+```csharp
+options.Conventions.AuthorizeFolder("/Private", "AtLeast21");
+```
+
+## Require authorization to access an area page
+
+Use the <xref:Microsoft.Extensions.DependencyInjection.PageConventionCollectionExtensions.AuthorizeAreaPage*> convention via <xref:Microsoft.Extensions.DependencyInjection.MvcRazorPagesMvcBuilderExtensions.AddRazorPagesOptions*> to add an <xref:Microsoft.AspNetCore.Mvc.Authorization.AuthorizeFilter> to the area page at the specified path:
+
+```csharp
+options.Conventions.AuthorizeAreaPage("Identity", "/Manage/Accounts");
+```
+
+The page name is the path of the file without an extension relative to the pages root directory for the specified area. For example, the page name for the file *Areas/Identity/Pages/Manage/Accounts.cshtml* is */Manage/Accounts*.
+
+To specify an [authorization policy](xref:security/authorization/policies), use an [AuthorizeAreaPage overload](xref:Microsoft.Extensions.DependencyInjection.PageConventionCollectionExtensions.AuthorizeAreaPage*):
+
+```csharp
+options.Conventions.AuthorizeAreaPage("Identity", "/Manage/Accounts", "AtLeast21");
+```
+
+## Require authorization to access a folder of areas
+
+Use the <xref:Microsoft.Extensions.DependencyInjection.PageConventionCollectionExtensions.AuthorizeAreaFolder*> convention via <xref:Microsoft.Extensions.DependencyInjection.MvcRazorPagesMvcBuilderExtensions.AddRazorPagesOptions*> to add an <xref:Microsoft.AspNetCore.Mvc.Authorization.AuthorizeFilter> to all of the areas in a folder at the specified path:
+
+```csharp
+options.Conventions.AuthorizeAreaFolder("Identity", "/Manage");
+```
+
+The folder path is the path of the folder relative to the pages root directory for the specified area. For example, the folder path for the files under *Areas/Identity/Pages/Manage/* is */Manage*.
+
+To specify an [authorization policy](xref:security/authorization/policies), use an [AuthorizeAreaFolder overload](xref:Microsoft.Extensions.DependencyInjection.PageConventionCollectionExtensions.AuthorizeAreaFolder*):
+
+```csharp
+options.Conventions.AuthorizeAreaFolder("Identity", "/Manage", "AtLeast21");
+```
+
+## Allow anonymous access to a page
+
+Use the <xref:Microsoft.Extensions.DependencyInjection.PageConventionCollectionExtensions.AllowAnonymousToPage*> convention via <xref:Microsoft.Extensions.DependencyInjection.MvcRazorPagesMvcBuilderExtensions.AddRazorPagesOptions*> to add an <xref:Microsoft.AspNetCore.Mvc.Authorization.AllowAnonymousFilter> to a page at the specified path:
+
+[!code-csharp[](razor-pages-authorization/samples/3.x/AuthorizationSample/Startup.cs?name=snippet1&highlight=2,6)]
+
+The specified path is the View Engine path, which is the Razor Pages root relative path without an extension and containing only forward slashes.
+
+## Allow anonymous access to a folder of pages
+
+Use the <xref:Microsoft.Extensions.DependencyInjection.PageConventionCollectionExtensions.AllowAnonymousToFolder*> convention via <xref:Microsoft.Extensions.DependencyInjection.MvcRazorPagesMvcBuilderExtensions.AddRazorPagesOptions*> to add an <xref:Microsoft.AspNetCore.Mvc.Authorization.AllowAnonymousFilter> to all of the pages in a folder at the specified path:
+
+[!code-csharp[](razor-pages-authorization/samples/3.x/AuthorizationSample/Startup.cs?name=snippet1&highlight=2,7)]
+
+The specified path is the View Engine path, which is the Razor Pages root relative path.
+
+## Note on combining authorized and anonymous access
+
+It's valid to specify that a folder of pages that require authorization and than specify that a page within that folder allows anonymous access:
+
+```csharp
+// This works.
+.AuthorizeFolder("/Private").AllowAnonymousToPage("/Private/Public")
+```
+
+The reverse, however, isn't valid. You can't declare a folder of pages for anonymous access and then specify a page within that folder that requires authorization:
+
+```csharp
+// This doesn't work!
+.AllowAnonymousToFolder("/Public").AuthorizePage("/Public/Private")
+```
+
+Requiring authorization on the Private page fails. When both the <xref:Microsoft.AspNetCore.Mvc.Authorization.AllowAnonymousFilter> and <xref:Microsoft.AspNetCore.Mvc.Authorization.AuthorizeFilter> are applied to the page, the <xref:Microsoft.AspNetCore.Mvc.Authorization.AllowAnonymousFilter> takes precedence and controls access.
+
+## Additional resources
+
+* <xref:razor-pages/razor-pages-conventions>
+* <xref:Microsoft.AspNetCore.Mvc.ApplicationModels.PageConventionCollection>
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-3.0"
 
 One way to control access in your Razor Pages app is to use authorization conventions at startup. These conventions allow you to authorize users and allow anonymous users to access individual pages or folders of pages. The conventions described in this topic automatically apply [authorization filters](xref:mvc/controllers/filters#authorization-filters) to control access.
 
@@ -119,3 +233,5 @@ Requiring authorization on the Private page fails. When both the <xref:Microsoft
 
 * <xref:razor-pages/razor-pages-conventions>
 * <xref:Microsoft.AspNetCore.Mvc.ApplicationModels.PageConventionCollection>
+
+::: moniker-end

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/AuthorizationSample.csproj
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/AuthorizationSample.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Controllers/AccountController.cs
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Controllers/AccountController.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+
+namespace AuthorizationSample.Controllers
+{
+    [Route("[controller]/[action]")]
+    public class AccountController : Controller
+    {
+        [HttpPost]
+        public async Task<IActionResult> Logout()
+        {
+            await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+
+            return RedirectToPage("/Account/SignedOut");
+        }
+    }
+}

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Data/ApplicationUser.cs
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Data/ApplicationUser.cs
@@ -1,0 +1,8 @@
+namespace AuthorizationSample.Data
+{
+    public class ApplicationUser
+    {
+        public string Email { get; set; }
+        public string FullName { get; set; }
+    }
+}

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Extensions/UrlHelperExtensions.cs
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Extensions/UrlHelperExtensions.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    public static class UrlHelperExtensions
+    {
+        public static string GetLocalUrl(this IUrlHelper urlHelper, string localUrl)
+        {
+            if (!urlHelper.IsLocalUrl(localUrl))
+            {
+                return urlHelper.Page("/Index");
+            }
+
+            return localUrl;
+        }
+    }
+}

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Account/Login.cshtml
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Account/Login.cshtml
@@ -1,0 +1,27 @@
+@page
+@model LoginModel
+@{
+    ViewData["Title"] = "Log in";
+}
+
+<h1>@ViewData["Title"]</h1>
+<div class="row">
+    <form method="post">
+        <h2>Use a local account to log in.</h2>
+        <hr>
+        <div asp-validation-summary="All"></div>
+        <div>
+            <label asp-for="Input.Email"></label>
+            <input asp-for="Input.Email">
+            <span asp-validation-for="Input.Email"></span>
+        </div>
+        <div>
+            <label asp-for="Input.Password"></label>
+            <input asp-for="Input.Password">
+            <span asp-validation-for="Input.Password"></span>
+        </div>
+        <div>
+            <button type="submit">Log in</button>
+        </div>
+    </form>
+</div>

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Account/Login.cshtml.cs
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Account/Login.cshtml.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using AuthorizationSample.Data;
+
+namespace AuthorizationSample.Pages.Account
+{
+    public class LoginModel : PageModel
+    {
+        [BindProperty]
+        public InputModel Input { get; set; }
+
+        public string ReturnUrl { get; private set; }
+
+        [TempData]
+        public string ErrorMessage { get; set; }
+
+        public class InputModel
+        {
+            [Required]
+            [EmailAddress]
+            public string Email { get; set; }
+
+            [Required]
+            [DataType(DataType.Password)]
+            public string Password { get; set; }
+        }
+
+        public async Task OnGetAsync(string returnUrl = null)
+        {
+            if (!string.IsNullOrEmpty(ErrorMessage))
+            {
+                ModelState.AddModelError(string.Empty, ErrorMessage);
+            }
+
+            // Clear the existing external cookie
+            await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+
+            ReturnUrl = returnUrl;
+        }
+
+        public async Task<IActionResult> OnPostAsync(string returnUrl = null)
+        {
+            ReturnUrl = returnUrl;
+
+            if (ModelState.IsValid)
+            {
+                var user = await AuthenticateUser(Input.Email, Input.Password);
+
+                if (user == null)
+                {
+                    ModelState.AddModelError(string.Empty, "Invalid login attempt.");
+                    return Page();
+                }
+
+                var claims = new List<Claim>
+                {
+                    new Claim(ClaimTypes.Name, user.Email),
+                    new Claim("FullName", user.FullName)
+                };
+
+                var claimsIdentity = new ClaimsIdentity(
+                    claims, CookieAuthenticationDefaults.AuthenticationScheme);
+
+                await HttpContext.SignInAsync(
+                    CookieAuthenticationDefaults.AuthenticationScheme, 
+                    new ClaimsPrincipal(claimsIdentity));
+
+                return LocalRedirect(Url.GetLocalUrl(returnUrl));
+            }
+
+            // Something failed. Redisplay the form.
+            return Page();
+        }
+
+        private async Task<ApplicationUser> AuthenticateUser(string email, string password)
+        {
+            // For demonstration purposes, authenticate a user
+            // with a static email address. Ignore the password.
+            // Assume that checking the database takes 500ms
+
+            await Task.Delay(500);
+
+            if (string.Equals(email, "maria.rodriguez@contoso.com", StringComparison.OrdinalIgnoreCase))
+            {
+                return new ApplicationUser()
+                {
+                    Email = "maria.rodriguez@contoso.com",
+                    FullName = "Maria Rodriguez"
+                };
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Account/SignedOut.cshtml
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Account/SignedOut.cshtml
@@ -1,0 +1,10 @@
+@page
+@model SignedOutModel
+@{
+    ViewData["Title"] = "Signed out";
+}
+
+<h1>@ViewData["Title"]</h1>
+<p>
+    You have successfully signed out.
+</p>

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Account/SignedOut.cshtml.cs
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Account/SignedOut.cshtml.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace AuthorizationSample.Pages.Account
+{
+    public class SignedOutModel : PageModel
+    {
+        public IActionResult OnGet()
+        {
+            if (User.Identity.IsAuthenticated)
+            {
+                // Redirect to home page if the user is authenticated.
+                return RedirectToPage("/Index");
+            }
+
+            return Page();
+        }
+    }
+}

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Account/_ViewImports.cshtml
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Account/_ViewImports.cshtml
@@ -1,0 +1,1 @@
+@using AuthorizationSample.Pages.Account

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Contact.cshtml
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Contact.cshtml
@@ -1,0 +1,27 @@
+﻿@page
+@model ContactModel
+@{
+    ViewData["Title"] = "Contact";
+}
+
+<h1>@ViewData["Title"]</h1>
+<h2>@Model.Message</h2>
+
+<p>
+    This page requires authorization by convention:
+    <code>
+        options.Conventions.AuthorizePage("/Contact");
+    </code>
+</p>
+
+<address>
+    One Microsoft Way<br>
+    Redmond, WA 98052-6399<br>
+    <abbr title="Phone">P:</abbr>
+    425.555.0100
+</address>
+
+<address>
+    <strong>Support:</strong> <a href="mailto:Support@example.com">Support@example.com</a><br>
+    <strong>Marketing:</strong> <a href="mailto:Marketing@example.com">Marketing@example.com</a>
+</address>

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Contact.cshtml.cs
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Contact.cshtml.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace AuthorizationSample.Pages
+{
+    public class ContactModel : PageModel
+    {
+        public string Message { get; private set; }
+
+        public void OnGet()
+        {
+            Message = "Your contact page.";
+        }
+    }
+}

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Error.cshtml
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Error.cshtml
@@ -1,0 +1,26 @@
+﻿@page
+@model ErrorModel
+@{
+    ViewData["Title"] = "Error";
+}
+
+<h1>Error.</h1>
+<h2>An error occurred while processing your request.</h2>
+
+@if (Model.ShowRequestId)
+{
+    <p>
+        <strong>Request ID:</strong> <code>@Model.RequestId</code>
+    </p>
+}
+
+<h3>Development Mode</h3>
+<p>
+    Swapping to the <strong>Development</strong> environment displays detailed information about the error that occurred.
+</p>
+<p>
+    <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
+    It can result in displaying sensitive information from exceptions to end users.
+    For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
+    and restarting the app.
+</p>

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Error.cshtml.cs
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Error.cshtml.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace AuthorizationSample.Pages
+{
+    [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+    public class ErrorModel : PageModel
+    {
+        public string RequestId { get; set; }
+
+        public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+
+        public void OnGet()
+        {
+            RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
+        }
+    }
+}

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Index.cshtml
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Index.cshtml
@@ -1,0 +1,13 @@
+﻿@page
+@model IndexModel
+@{
+    ViewData["Title"] = "Authorization Sample";
+}
+
+@if (User.Identity.IsAuthenticated)
+{
+    <div class="row">
+        <div>Hello @User.Claims.FirstOrDefault(c => c.Type == "FullName")?.Value!</div>
+        <p>Username: @User.Identity.Name</p>
+    </div>
+}

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Index.cshtml.cs
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Index.cshtml.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace AuthorizationSample.Pages
+{
+    public class IndexModel : PageModel
+    {
+        public void OnGet()
+        {
+
+        }
+    }
+}

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Private/PrivatePage1.cshtml
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Private/PrivatePage1.cshtml
@@ -1,0 +1,16 @@
+﻿@page
+@namespace AuthorizationSample.Pages.Private
+@model PrivatePage1Model
+@{
+    ViewData["Title"] = "Private Folder: Private Page 1";
+}
+
+<h1>@ViewData["Title"]</h1>
+<h2>@Model.Message</h2>
+
+<p>
+    This page requires authorization by convention:
+    <code>
+        options.Conventions.AuthorizeFolder("/Private");
+    </code>
+</p>

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Private/PrivatePage1.cshtml.cs
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Private/PrivatePage1.cshtml.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace AuthorizationSample.Pages.Private
+{
+    public class PrivatePage1Model : PageModel
+    {
+        public string Message { get; private set; }
+
+        public void OnGet()
+        {
+            Message = "A private page inside the Private folder.";
+        }
+    }
+}

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Private/PrivatePage2.cshtml
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Private/PrivatePage2.cshtml
@@ -1,0 +1,16 @@
+﻿@page
+@namespace AuthorizationSample.Pages.Private
+@model PrivatePage2Model
+@{
+    ViewData["Title"] = "Private Folder: Private Page 2";
+}
+
+<h1>@ViewData["Title"]</h1>
+<h2>@Model.Message</h2>
+
+<p>
+    This page requires authorization by convention:
+    <code>
+        options.Conventions.AuthorizeFolder("/Private");
+    </code>
+</p>

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Private/PrivatePage2.cshtml.cs
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Private/PrivatePage2.cshtml.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace AuthorizationSample.Pages.Private
+{
+    public class PrivatePage2Model : PageModel
+    {
+        public string Message { get; private set; }
+
+        public void OnGet()
+        {
+            Message = "A private page inside the Private folder.";
+        }
+    }
+}

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Private/PublicPage.cshtml
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Private/PublicPage.cshtml
@@ -1,0 +1,16 @@
+﻿@page
+@namespace AuthorizationSample.Pages.Private
+@model PublicPageModel
+@{
+    ViewData["Title"] = "Private Folder: Public Page";
+}
+
+<h1>@ViewData["Title"]</h1>
+<h2>@Model.Message</h2>
+
+<p>
+    The <i>Private</i> folder requires authorization, but this page allows anonymous visitors by convention:
+    <code>
+        options.Conventions.AllowAnonymousToPage("/Private/PublicPage");
+    </code>
+</p>

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Private/PublicPage.cshtml.cs
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Private/PublicPage.cshtml.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace AuthorizationSample.Pages.Private
+{
+    public class PublicPageModel : PageModel
+    {
+        public string Message { get; private set; }
+
+        public void OnGet()
+        {
+            Message = "A public page inside the Private folder.";
+        }
+    }
+}

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Private/PublicPages/PublicPage.cshtml
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Private/PublicPages/PublicPage.cshtml
@@ -1,0 +1,16 @@
+﻿@page
+@namespace AuthorizationSample.Pages.Private.Public
+@model PublicPageModel
+@{
+    ViewData["Title"] = "Private Folder: PublicPages Folder: Public Page";
+}
+
+<h1>@ViewData["Title"]</h1>
+<h2>@Model.Message</h2>
+
+<p>
+    The <i>Private</i> folder requires authorization, but this page is inside a <i>PublicPages</i> folder that allows anonymous visitors by convention:
+    <code>
+        options.Conventions.AllowAnonymousToFolder("/Private/PublicPages");
+    </code>
+</p>

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Private/PublicPages/PublicPage.cshtml.cs
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Private/PublicPages/PublicPage.cshtml.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace AuthorizationSample.Pages.Private.Public
+{
+    public class PublicPageModel : PageModel
+    {
+        public string Message { get; private set; }
+
+        public void OnGet()
+        {
+            Message = "A public page inside a PublicPages folder inside the Private folder.";
+        }
+    }
+}

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Private/PublicPages/_ViewImports.cshtml
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Private/PublicPages/_ViewImports.cshtml
@@ -1,0 +1,1 @@
+@using AuthorizationSample.Pages.Private.Public

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Private/_ViewImports.cshtml
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Private/_ViewImports.cshtml
@@ -1,0 +1,1 @@
+@using AuthorizationSample.Pages.Private

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Shared/_Layout.cshtml
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/Shared/_Layout.cshtml
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>@ViewData["Title"]</title>
+    <style>body{margin:0;padding-bottom:20px;font-family:"Helvetica Neue", Helvetica, Arial, sans-serif;font-size:14px;line-height:1.42857143;color:#333;background-color:#fff;}h1{font-size:24px;margin:.67em 0;}pre{overflow:auto;}code,pre{font-family:monospace, monospace;font-size:1em;}button,input{margin:0;font:inherit;color:inherit;}button{overflow:visible;}button{text-transform:none;}input{line-height:normal;}{box-sizing:border-box;}:before,*:after{box-sizing:border-box;}input,button{font-family:inherit;font-size:inherit;line-height:inherit;}a{color:#337ab7;text-decoration:none;}h1,h2,h3,h4{font-family:inherit;font-weight:500;line-height:1.1;color:inherit;margin-top:20px;margin-bottom:10px;}h3{font-size:16px;}h4{font-size:18px;}p{margin:0 0 10px;}ol{margin-top:0;margin-bottom:10px;}code,pre{font-family:Menlo, Monaco, Consolas, "Courier New", monospace;}code{padding:2px 4px;font-size:90%;color:#c7254e;background-color:#f9f2f4;border-radius:4px;}pre{display:block;padding:9.5px;margin:0 0 10px;font-size:13px;line-height:1.42857143;color:#333;word-break:break-all;word-wrap:break-word;background-color:#f5f5f5;border:1px solid #ccc;-radius:4px;}pre code{padding:0;font-size:inherit;color:inherit;white-space:pre-wrap;background-color:transparent;border-radius:0;}.container{padding-right:15px;padding-left:15px;margin-right:auto;margin-left:auto;}.container{width:800px;}.btn{display:inline-block;padding:6px 12px;margin-bottom:0;font-size:14px;font-weight:normal;line-height:1.42857143;text-align:center;white-space:nowrap;vertical-align:middle;background-image:none;border:1px solid transparent;border-radius:4px;;color:#fff;background-color:green;border-color:gray;float:right}.panel{margin-bottom:20px;background-color:#fff;border:1px solid transparent;border-radius:4px;box-shadow:0 1px 1px rgba(0, 0, 0, .05);}.panel-body{padding:15px;}.panel-heading{padding:10px 15px;border-bottom:1px solid transparent;border-top-left-radius:3px;border-top-right-radius:3px;}.panel-title{margin-top:0;margin-bottom:0;font-size:16px;color:inherit;}.panel-default{border-color:#ddd;}.panel-default > .panel-heading{color:#333;background-color:#f5f5f5;border-color:#ddd;}.clearfix:before,.clearfix:after,.container:before,.container:after,.panel-body:before,.panel-body:after{display:table;content:" ";}.clearfix:after,.container:after,.panel-body:after{clear:both;}.body-content{padding-left:15px;padding-right:15px;}.panel-body{font-size:16px;}</style>
+</head>
+<body>
+    <div class="container">
+        <ul>
+            <li><a asp-page="/Index">Home</a></li>
+            <li>
+                <ul>
+                    <li><a asp-page="/Private/PrivatePage1">Private Folder: Private Page 1 (Authentication Required)</a></li>
+                    <li><a asp-page="/Private/PrivatePage2">Private Folder: Private Page 2 (Authentication Required)</a></li>
+                    <li><a asp-page="/Private/PublicPage">Private Folder: Public Page</a></li>
+                    <li><a asp-page="/Private/PublicPages/PublicPage">Private Folder: Public Folder: Public Page</a></li>
+                </ul>
+            </li>
+            <li><a asp-page="/Contact">Contact (Authentication Required)</a></li>
+        </ul>
+        @await Html.PartialAsync("_LoginPartial")
+    </div>
+
+    <div class="container body-content">
+        @RenderBody()
+    </div>
+
+    @RenderSection("Scripts", required: false)
+</body>
+</html>

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/_LoginPartial.cshtml
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/_LoginPartial.cshtml
@@ -1,0 +1,16 @@
+@if (User.Identity.IsAuthenticated)
+{
+    <form asp-controller="Account" asp-action="Logout" method="post" id="logoutForm">
+        <ul>
+            <li>
+                <button type="submit">Log out</button>
+            </li>
+        </ul>
+    </form>
+}
+else
+{
+    <ul>
+        <li><a asp-page="/Account/Login">Log in</a></li>
+    </ul>
+}

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/_ViewImports.cshtml
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/_ViewImports.cshtml
@@ -1,0 +1,4 @@
+@using AuthorizationSample
+@using AuthorizationSample.Data
+@namespace AuthorizationSample.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/_ViewStart.cshtml
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Pages/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+﻿@{
+    Layout = "_Layout";
+}

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Program.cs
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Program.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace AuthorizationSample
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/README.md
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/README.md
@@ -1,0 +1,16 @@
+# ASP.NET Core Authorization Sample
+
+This sample illustrates use of Razor Pages authorization by conventions. This sample demonstrates the features described in the [Razor Pages authorization conventions](https://docs.microsoft.com/aspnet/core/security/authorization/razor-pages-authorization) topic.
+
+User authorization in this sample uses the cookie authentication features described in the [Use cookie authentication without ASP.NET Core Identity](https://docs.microsoft.com/aspnet/core/security/authentication/cookie) topic. The concepts and examples shown in this topic apply equally to apps that use ASP.NET Core Identity. For information on using ASP.NET Core Identity, see [Introduction to Identity on ASP.NET Core](https://docs.microsoft.com/aspnet/core/security/authentication/identity).
+
+Use the email address **maria.rodriguez@contoso.com** to authenticate the user with any password. The user is authenticated in the `AuthenticateUser` method in the *Pages/Account/Login.cshtml.cs* file. In a real-world example, the user would be authenticated against a database.
+
+## Examples in this sample
+
+| Feature | Description |
+| --- | --- |
+| [AuthorizePage](https://docs.microsoft.com/dotnet/api/microsoft.extensions.dependencyinjection.pageconventioncollectionextensions.authorizepage) | Adds an [AuthorizeFilter](https://docs.microsoft.com/dotnet/api/microsoft.aspnetcore.mvc.authorization.authorizefilter) to the page with the specified path. |
+| [AuthorizeFolder](https://docs.microsoft.com/dotnet/api/microsoft.extensions.dependencyinjection.pageconventioncollectionextensions.authorizefolder) | Adds an [AuthorizeFilter](https://docs.microsoft.com/dotnet/api/microsoft.aspnetcore.mvc.authorization.authorizefilter) to all of the pages in a folder with the specified path. |
+| [AllowAnonymousToPage](https://docs.microsoft.com/dotnet/api/microsoft.extensions.dependencyinjection.pageconventioncollectionextensions.allowanonymoustopage) | Adds an [AllowAnonymousFilter](https://docs.microsoft.com/dotnet/api/microsoft.aspnetcore.mvc.authorization.allowanonymousfilter) to a page with the specified path. |
+| [AllowAnonymousToFolder](https://docs.microsoft.com/dotnet/api/microsoft.extensions.dependencyinjection.pageconventioncollectionextensions.allowanonymoustofolder) | Adds an [AllowAnonymousFilter](https://docs.microsoft.com/dotnet/api/microsoft.aspnetcore.mvc.authorization.allowanonymousfilter) to all of the pages in a folder with the specified path. |

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Startup.cs
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Startup.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace AuthorizationSample
+{
+    public class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers();
+
+            #region snippet1
+            services.AddRazorPages()
+                .AddRazorPagesOptions(options =>
+                {
+                    options.Conventions.AuthorizePage("/Contact");
+                    options.Conventions.AuthorizeFolder("/Private");
+                    options.Conventions.AllowAnonymousToPage("/Private/PublicPage");
+                    options.Conventions.AllowAnonymousToFolder("/Private/PublicPages");
+                });
+            #endregion
+
+            services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+                .AddCookie();
+        }
+
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                app.UseExceptionHandler("/Error");
+                app.UseHsts();
+            }
+
+            app.UseHttpsRedirection();
+            app.UseStaticFiles();
+            app.UseRouting();
+
+            app.UseAuthentication();
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+                endpoints.MapRazorPages();
+            });
+        }
+    }
+}

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/appsettings.Development.json
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/appsettings.Development.json
@@ -1,0 +1,9 @@
+﻿{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/appsettings.json
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/appsettings.json
@@ -1,0 +1,8 @@
+﻿{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Fixes #13351

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/security/authorization/razor-pages-authorization?view=aspnetcore-2.1&branch=pr-en-us-13785)

* Straightforward sample update ... we can handle it.
* This uses the *whole topic* versioning approach. The only thing that changes in the topic between the two version blocks are the sample links (to `3.x` in the >=3.0 block).