### PR TITLE
Update startup.md

### DIFF
--- a/aspnetcore/fundamentals/startup.md
+++ b/aspnetcore/fundamentals/startup.md
@@ -190,6 +190,8 @@ To configure services and the request processing pipeline without using a `Start
 
 ## Extend Startup with startup filters
 
+`Startup` filters are an augmentation to `Startup` rather than an integral part of it. They pair well with `IHostingStartup` as a means of injection into `Startup`, but that's not the only use case.
+
 Use <xref:Microsoft.AspNetCore.Hosting.IStartupFilter> to configure middleware at the beginning or end of an app's [Configure](#the-configure-method) middleware pipeline. `IStartupFilter` is used to create a pipeline of `Configure` methods. [IStartupFilter.Configure](xref:Microsoft.AspNetCore.Hosting.IStartupFilter.Configure*) can set a middleware to run before or after middleware added by libraries.
 
 `IStartupFilter` implements <xref:Microsoft.AspNetCore.Hosting.StartupBase.Configure*>, which receives and returns an `Action<IApplicationBuilder>`. An <xref:Microsoft.AspNetCore.Builder.IApplicationBuilder> defines a class to configure an app's request pipeline. For more information, see [Create a middleware pipeline with IApplicationBuilder](xref:fundamentals/middleware/index#create-a-middleware-pipeline-with-iapplicationbuilder).


### PR DESCRIPTION
@guardrex  see [this comment](https://github.com/aspnet/AspNetCore.Docs/issues/8407#issuecomment-418798089)

Startup filters are definitely an augmentation to Startup rather than an integral piece of it. They pair well with IHostingStartup as a means of injection into Startup, but that's not the only use case.

Is that worth adding or should we close this PR?