### PR TITLE
[Fix] CaptureUnmatchedAttributes => CaptureUnmatchedValues

### DIFF
--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -187,7 +187,7 @@ To accept arbitrary attributes, define a component parameter using the `[Paramet
 
 ```cshtml
 @code {
-    [Parameter(CaptureUnmatchedAttributes = true)]
+    [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object> InputAttributes { get; set; }
 }
 ```


### PR DESCRIPTION
Since the API changed, it's no longer CaptureUnmatchedAttributes but CaptureUnmatchedValues