### PR TITLE
Drop db before seeding

### DIFF
--- a/aspnetcore/data/ef-rp/intro.md
+++ b/aspnetcore/data/ef-rp/intro.md
@@ -373,7 +373,11 @@ Create *Data/DbInitializer.cs* with the following code:
 
 # [Visual Studio](#tab/visual-studio)
 
-* Run the app, delete any student records you created earlier, and stop the app.
+Stop the app if it's running, and run the following command in the **Package Manager Console** (PMC):
+
+```powershell
+Drop-Database
+```
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
@@ -695,7 +699,19 @@ In *Program.cs*, modify the `Main` method to call `Initialize`:
 
 [!code-csharp[](intro/samples/cu21/Program.cs?name=snippet2&highlight=14-15)]
 
-Delete any student records and restart the app. If the DB is not initialized, set a break point in `Initialize` to diagnose the problem.
+# [Visual Studio](#tab/visual-studio)
+
+Stop the app if it's running, and run the following command in the **Package Manager Console** (PMC):
+
+```powershell
+Drop-Database
+```
+
+# [Visual Studio Code](#tab/visual-studio-code)
+
+* Stop the app if it's running, and delete the *CU.db* file.
+
+---
 
 ## View the DB
 


### PR DESCRIPTION
Fixes #10771

Changes both 2.1 and 3.0 versions to drop db before the DbInitializer runs.