### PR TITLE
Deploy to Azure Apps update to 3.0

### DIFF
--- a/aspnetcore/host-and-deploy/azure-apps/index.md
+++ b/aspnetcore/host-and-deploy/azure-apps/index.md
@@ -5,7 +5,7 @@ description: This article contains links to Azure host and deploy resources.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 07/28/2019
+ms.date: 08/20/2019
 uid: host-and-deploy/azure-apps/index
 ---
 # Deploy ASP.NET Core apps to Azure App Service
@@ -91,17 +91,7 @@ The [IIS Integration Middleware](xref:host-and-deploy/iis/index#enable-the-iisin
 
 ## Monitoring and logging
 
-::: moniker range=">= aspnetcore-3.0"
-
-ASP.NET Core apps deployed to App Service automatically receive an App Service extension, **ASP.NET Core Logging Integration**. The extension enables logging integration for ASP.NET Core apps on Azure App Service.
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-3.0"
-
 ASP.NET Core apps deployed to App Service automatically receive an App Service extension, **ASP.NET Core Logging Extensions**. The extension enables logging integration for ASP.NET Core apps on Azure App Service.
-
-::: moniker-end
 
 For monitoring, logging, and troubleshooting information, see the following articles:
 

--- a/aspnetcore/host-and-deploy/azure-apps/index.md
+++ b/aspnetcore/host-and-deploy/azure-apps/index.md
@@ -91,7 +91,7 @@ The [IIS Integration Middleware](xref:host-and-deploy/iis/index#enable-the-iisin
 
 ## Monitoring and logging
 
-Azure App Service offers the **ASP.NET Core Logging Extensions**, which enable logging integration for ASP.NET Core apps. To automatically add the extension to an App Service, use Visual Studio's **Publish** process with an **App Service** publish profile. When not using Visual Studio to deploy an app, install the extension manually in the Azure Portal via the App Service's **Development Tools** > **Extensions** dialog.
+Azure App Service offers the **ASP.NET Core Logging Extensions**, which enable logging integration for ASP.NET Core apps. To automatically add the extension to an App Service, use Visual Studio's **Publish** process with an **App Service** publish profile. When not using Visual Studio to deploy an app, manually install the extension in the Azure Portal via the App Service's **Development Tools** > **Extensions** dialog.
 
 For monitoring, logging, and troubleshooting information, see the following articles:
 

--- a/aspnetcore/host-and-deploy/azure-apps/index.md
+++ b/aspnetcore/host-and-deploy/azure-apps/index.md
@@ -5,7 +5,7 @@ description: This article contains links to Azure host and deploy resources.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 08/20/2019
+ms.date: 09/07/2019
 uid: host-and-deploy/azure-apps/index
 ---
 # Deploy ASP.NET Core apps to Azure App Service
@@ -91,7 +91,7 @@ The [IIS Integration Middleware](xref:host-and-deploy/iis/index#enable-the-iisin
 
 ## Monitoring and logging
 
-ASP.NET Core apps deployed to App Service automatically receive an App Service extension, **ASP.NET Core Logging Extensions**. The extension enables logging integration for ASP.NET Core apps on Azure App Service.
+Azure App Service offers the **ASP.NET Core Logging Extensions**, which enable logging integration for ASP.NET Core apps. To automatically add the extension to an App Service, use Visual Studio's **Publish** process with an **App Service** publish profile. When not using Visual Studio to deploy an app, install the extension manually in the Azure Portal via the App Service's **Development Tools** > **Extensions** dialog.
 
 For monitoring, logging, and troubleshooting information, see the following articles:
 


### PR DESCRIPTION
Fixes #13339
Fixes #11658

I don't see any obvious changes for 3.0, except ..........

For logging extension coverage, we have ...

> ASP.NET Core apps deployed to App Service automatically receive an App Service extension, **ASP.NET Core Logging Extensions**. The extension enables logging integration for ASP.NET Core apps on Azure App Service.

1. The name didn't change to **ASP.NET Core Logging Integration**. I guess we'll strip that here. If that's still in the works, what's the ETA on it?
1. We say that the extension is automatically added, but I just spun up an App Service and didn't get it automatically. Should we **_not_** say it's automatic here?
