### PR TITLE
Health Checks topic+sample updates for 3.0

### DIFF
--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -318,7 +318,10 @@ Register health check services with <xref:Microsoft.Extensions.DependencyInjecti
 A health check endpoint is created by calling `MapHealthChecks` in `Startup.Configure`:
 
 ```csharp
-app.UseHealthChecks("/health");
+app.UseEndpoints(endpoints =>
+{
+    endpoints.MapHealthChecks("/health");
+}
 ```
 
 To run the database probe scenario using the sample app, execute the following command from the project's folder in a command shell:
@@ -351,7 +354,10 @@ In the sample app, `AppDbContext` is provided to `AddDbContextCheck` and registe
 A health check endpoint is created by calling `MapHealthChecks` in `Startup.Configure`:
 
 ```csharp
-app.UseHealthChecks("/health");
+app.UseEndpoints(endpoints =>
+{
+    endpoints.MapHealthChecks("/health");
+}
 ```
 
 To run the `DbContext` probe scenario using the sample app, confirm that the database specified by the connection string doesn't exist in the SQL Server instance. If the database exists, delete it.

--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -794,7 +794,7 @@ For many apps, a basic health probe configuration that reports the app's availab
 
 The basic configuration registers health check services and calls the Health Checks Middleware to respond at a URL endpoint with a health response. By default, no specific health checks are registered to test any particular dependency or subsystem. The app is considered healthy if it's capable of responding at the health endpoint URL. The default response writer writes the status (<xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus>) as a plaintext response back to the client, indicating either a [HealthStatus.Healthy](xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus), [HealthStatus.Degraded](xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus) or [HealthStatus.Unhealthy](xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus) status.
 
-Register health check services with <xref:Microsoft.Extensions.DependencyInjection.HealthCheckServiceCollectionExtensions.AddHealthChecks*> in `Startup.ConfigureServices`. Add Health Checks Middleware with <xref:Microsoft.AspNetCore.Builder.HealthCheckApplicationBuilderExtensions.UseHealthChecks*> in the request processing pipeline of `Startup.Configure`.
+Register health check services with <xref:Microsoft.Extensions.DependencyInjection.HealthCheckServiceCollectionExtensions.AddHealthChecks*> in `Startup.ConfigureServices`. Add an endpoint for Health Checks Middleware with <xref:Microsoft.AspNetCore.Builder.HealthCheckApplicationBuilderExtensions.UseHealthChecks*> in the request processing pipeline of `Startup.Configure`.
 
 In the sample app, the health check endpoint is created at `/health` (*BasicStartup.cs*):
 

--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -5,12 +5,727 @@ description: Learn how to set up health checks for ASP.NET Core infrastructure, 
 monikerRange: '>= aspnetcore-2.2'
 ms.author: riande
 ms.custom: mvc
-ms.date: 07/11/2019
+ms.date: 08/21/2019
 uid: host-and-deploy/health-checks
 ---
 # Health checks in ASP.NET Core
 
 By [Luke Latham](https://github.com/guardrex) and [Glenn Condron](https://github.com/glennc)
+
+::: moniker range=">= aspnetcore-3.0"
+
+ASP.NET Core offers Health Check Middleware and libraries for reporting the health of app infrastructure components.
+
+Health checks are exposed by an app as HTTP endpoints. Health check endpoints can be configured for a variety of real-time monitoring scenarios:
+
+* Health probes can be used by container orchestrators and load balancers to check an app's status. For example, a container orchestrator may respond to a failing health check by halting a rolling deployment or restarting a container. A load balancer might react to an unhealthy app by routing traffic away from the failing instance to a healthy instance.
+* Use of memory, disk, and other physical server resources can be monitored for healthy status.
+* Health checks can test an app's dependencies, such as databases and external service endpoints, to confirm availability and normal functioning.
+
+[View or download sample code](https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/host-and-deploy/health-checks/samples) ([how to download](xref:index#how-to-download-a-sample))
+
+The sample app includes examples of the scenarios described in this topic. To run the sample app for a given scenario, use the [dotnet run](/dotnet/core/tools/dotnet-run) command from the project's folder in a command shell. See the sample app's *README.md* file and the scenario descriptions in this topic for details on how to use the sample app.
+
+## Prerequisites
+
+Health checks are usually used with an external monitoring service or container orchestrator to check the status of an app. Before adding health checks to an app, decide on which monitoring system to use. The monitoring system dictates what types of health checks to create and how to configure their endpoints.
+
+Add a package reference to the [Microsoft.AspNetCore.Diagnostics.HealthChecks](https://www.nuget.org/packages/Microsoft.AspNetCore.Diagnostics.HealthChecks) package. To perform health checks using Entity Framework Core, add a package reference to the [Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore](https://www.nuget.org/packages/Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore) package.
+
+The sample app provides startup code to demonstrate health checks for several scenarios. The [database probe](#database-probe) scenario checks the health of a database connection using [AspNetCore.Diagnostics.HealthChecks](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks). The [DbContext probe](#entity-framework-core-dbcontext-probe) scenario checks a database using an EF Core `DbContext`. To explore the database scenarios, the sample app:
+
+* Creates a database and provides its connection string in the *appsettings.json* file.
+* Has the following package references in its project file:
+  * [AspNetCore.HealthChecks.SqlServer](https://www.nuget.org/packages/AspNetCore.HealthChecks.SqlServer/)
+  * [Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore](https://www.nuget.org/packages/Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore/)
+
+> [!NOTE]
+> [AspNetCore.Diagnostics.HealthChecks](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks) is a port of [BeatPulse](https://github.com/xabaril/beatpulse) and isn't maintained or supported by Microsoft.
+
+Another health check scenario demonstrates how to filter health checks to a management port. The sample app requires you to create a *Properties/launchSettings.json* file that includes the management URL and management port. For more information, see the [Filter by port](#filter-by-port) section.
+
+## Basic health probe
+
+For many apps, a basic health probe configuration that reports the app's availability to process requests (*liveness*) is sufficient to discover the status of the app.
+
+The basic configuration registers health check services and calls the Health Check Middleware to respond at a URL endpoint with a health response. By default, no specific health checks are registered to test any particular dependency or subsystem. The app is considered healthy if it's capable of responding at the health endpoint URL. The default response writer writes the status (<xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus>) as a plaintext response back to the client, indicating either a [HealthStatus.Healthy](xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus), [HealthStatus.Degraded](xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus) or [HealthStatus.Unhealthy](xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus) status.
+
+Register health check services with <xref:Microsoft.Extensions.DependencyInjection.HealthCheckServiceCollectionExtensions.AddHealthChecks*> in `Startup.ConfigureServices`. Create a health check endpoint by calling `MapHealthChecks` in `Startup.Configure`.
+
+In the sample app, the health check endpoint is created at `/health` (*BasicStartup.cs*):
+
+[!code-csharp[](health-checks/samples/3.x/HealthChecksSample/BasicStartup.cs?name=snippet1&highlight=5,12)]
+
+To run the basic configuration scenario using the sample app, execute the following command from the project's folder in a command shell:
+
+```console
+dotnet run --scenario basic
+```
+
+### Docker example
+
+[Docker](xref:host-and-deploy/docker/index) offers a built-in `HEALTHCHECK` directive that can be used to check the status of an app that uses the basic health check configuration:
+
+```
+HEALTHCHECK CMD curl --fail http://localhost:5000/health || exit
+```
+
+## Create health checks
+
+Health checks are created by implementing the <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck> interface. The <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck.CheckHealthAsync*> method returns a `Task<` <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> `>` that indicates the health as `Healthy`, `Degraded`, or `Unhealthy`. The result is written as a plaintext response with a configurable status code (configuration is described in the [Health check options](#health-check-options) section). <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> can also return optional key-value pairs.
+
+The following `ExampleHealthCheck` class demonstrates the layout of a health check:
+
+```csharp
+public class ExampleHealthCheck : IHealthCheck
+{
+    public ExampleHealthCheck()
+    {
+        // Use dependency injection (DI) to supply any required services to the
+        // health check.
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default(CancellationToken))
+    {
+        // Execute health check logic here. This example sets a dummy
+        // variable to true.
+        var healthCheckResultHealthy = true;
+
+        if (healthCheckResultHealthy)
+        {
+            return Task.FromResult(
+                HealthCheckResult.Healthy("A healthy result."));
+        }
+
+        return Task.FromResult(
+            HealthCheckResult.Unhealthy("An unhealthy result."));
+    }
+}
+```
+
+## Register health check services
+
+The `ExampleHealthCheck` type is added to health check services with <xref:Microsoft.Extensions.DependencyInjection.HealthChecksBuilderAddCheckExtensions.AddCheck*> in `Startup.ConfigureServices`:
+
+```csharp
+services.AddHealthChecks()
+    .AddCheck<ExampleHealthCheck>("example_health_check");
+```
+
+The <xref:Microsoft.Extensions.DependencyInjection.HealthChecksBuilderAddCheckExtensions.AddCheck*> overload shown in the following example sets the failure status (<xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus>) to report when the health check reports a failure. If the failure status is set to `null` (default), [HealthStatus.Unhealthy](xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus) is reported. This overload is a useful scenario for library authors, where the failure status indicated by the library is enforced by the app when a health check failure occurs if the health check implementation honors the setting.
+
+*Tags* can be used to filter health checks (described further in the [Filter health checks](#filter-health-checks) section).
+
+```csharp
+services.AddHealthChecks()
+    .AddCheck<ExampleHealthCheck>(
+        "example_health_check",
+        failureStatus: HealthStatus.Degraded,
+        tags: new[] { "example" });
+```
+
+<xref:Microsoft.Extensions.DependencyInjection.HealthChecksBuilderAddCheckExtensions.AddCheck*> can also execute a lambda function. In the following example, the health check name is specified as `Example` and the check always returns a healthy state:
+
+```csharp
+services.AddHealthChecks()
+    .AddCheck("Example", () =>
+        HealthCheckResult.Healthy("Example is OK!"), tags: new[] { "example" });
+```
+
+## Use Health Checks Routing
+
+In `Startup.Configure`, call `MapHealthChecks` on the endpoint builder with the endpoint URL or relative path:
+
+```csharp
+app.UseEndpoints(endpoints =>
+{
+    endpoints.MapHealthChecks("/health");
+});
+```
+
+Health Checks Middleware is a *terminal middleware* in the app's request processing pipeline. The first health check endpoint encountered that's an exact match to the request URL executes and short-circuits the rest of the middleware pipeline. When short-circuiting occurs, no middleware following the matched health check executes.
+
+### Require host
+
+Call `RequireHost` to specify one or more permitted hosts for the health check endpoint. Hosts should be Unicode rather than punycode and may include a port. If a collection isn't supplied, any host is accepted.
+
+```csharp
+app.UseEndpoints(endpoints =>
+{
+    endpoints.MapHealthChecks("/health").RequireHost("www.contoso.com:5001");
+});
+```
+
+For more information, see the [Filter by port](#filter-by-port) section.
+
+### Require authorization
+
+Call `RequireAuthorization` to run Authorization Middleware on the health check request endpoint. A `RequireAuthorization` overload accepts one or more authorization policies. If a policy isn't provided, the default authorization policy is used.
+
+```csharp
+app.UseEndpoints(endpoints =>
+{
+    endpoints.MapHealthChecks("/health").RequireAuthorization();
+});
+```
+
+### Enable Cross-Origin Requests (CORS)
+
+Call `RequireCors` to run CORS Middleware on the health check request endpoint. A `RequireCors` overload accepts a CORS policy builder delegate (`CorsPolicyBuilder`) or a policy name. If a policy isn't provided, the default CORS policy is used.
+
+In `Startup.ConfigureServices`:
+
+```csharp
+services.AddCors(options =>
+{
+    options.AddPolicy("MyAllowSpecificOrigins",
+        builder =>
+        {
+            builder.WithOrigins("http://example.com",
+                                "http://www.contoso.com");
+        });
+});
+```
+
+In `Startup.Configure`:
+
+```csharp
+app.UseEndpoints(endpoints =>
+{
+    endpoints.MapHealthChecks("/health").RequireCors("MyAllowSpecificOrigins");
+});
+```
+
+For more information, see <xref:security/cors>.
+
+## Health check options
+
+<xref:Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions> provide an opportunity to customize health check behavior:
+
+* [Filter health checks](#filter-health-checks)
+* [Customize the HTTP status code](#customize-the-http-status-code)
+* [Suppress cache headers](#suppress-cache-headers)
+* [Customize output](#customize-output)
+
+### Filter health checks
+
+By default, Health Check Middleware runs all registered health checks. To run a subset of health checks, provide a function that returns a boolean to the <xref:Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions.Predicate> option. In the following example, the `Bar` health check is filtered out by its tag (`bar_tag`) in the function's conditional statement, where `true` is only returned if the health check's <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckRegistration.Tags> property matches `foo_tag` or `baz_tag`:
+
+In `Startup.ConfigureServices`:
+
+```csharp
+services.AddHealthChecks()
+    .AddCheck("Foo", () =>
+        HealthCheckResult.Healthy("Foo is OK!"), tags: new[] { "foo_tag" })
+    .AddCheck("Bar", () =>
+        HealthCheckResult.Unhealthy("Bar is unhealthy!"), tags: new[] { "bar_tag" })
+    .AddCheck("Baz", () =>
+        HealthCheckResult.Healthy("Baz is OK!"), tags: new[] { "baz_tag" });
+```
+
+In `Startup.Configure`:
+
+```csharp
+app.UseEndpoints(endpoints =>
+{
+    endpoints.MapHealthChecks("/health", new HealthCheckOptions()
+    {
+        // Filter out the 'Bar' health check. Only Foo and Baz execute.
+        Predicate = (check) => check.Tags.Contains("foo_tag") ||
+            check.Tags.Contains("baz_tag")
+    });
+});
+```
+
+### Customize the HTTP status code
+
+Use <xref:Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions.ResultStatusCodes> to customize the mapping of health status to HTTP status codes. The following <xref:Microsoft.AspNetCore.Http.StatusCodes> assignments are the default values used by the middleware. Change the status code values to meet your requirements.
+
+In `Startup.Configure`:
+
+```csharp
+app.UseEndpoints(endpoints =>
+{
+    endpoints.MapHealthChecks("/health", new HealthCheckOptions()
+    {
+        ResultStatusCodes =
+        {
+            [HealthStatus.Healthy] = StatusCodes.Status200OK,
+            [HealthStatus.Degraded] = StatusCodes.Status200OK,
+            [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
+        }
+    });
+});
+```
+
+### Suppress cache headers
+
+<xref:Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions.AllowCachingResponses> controls whether the Health Check Middleware adds HTTP headers to a probe response to prevent response caching. If the value is `false` (default), the middleware sets or overrides the `Cache-Control`, `Expires`, and `Pragma` headers to prevent response caching. If the value is `true`, the middleware doesn't modify the cache headers of the response.
+
+In `Startup.Configure`:
+
+```csharp
+app.UseEndpoints(endpoints =>
+{
+    endpoints.MapHealthChecks("/health", new HealthCheckOptions()
+    {
+        AllowCachingResponses = false
+    });
+});
+```
+
+### Customize output
+
+The <xref:Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions.ResponseWriter> option gets or sets a delegate used to write the response.
+
+In `Startup.Configure`:
+
+```csharp
+app.UseEndpoints(endpoints =>
+{
+    endpoints.MapHealthChecks("/health", new HealthCheckOptions()
+    {
+        ResponseWriter = WriteResponse
+    });
+});
+```
+
+The default delegate writes a minimal plaintext response with the string value of [HealthReport.Status](xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthReport.Status). The following custom delegate, `WriteResponse`, outputs a custom JSON response:
+
+```csharp
+private static Task WriteResponse(HttpContext httpContext,
+    HealthReport result)
+{
+    httpContext.Response.ContentType = "application/json";
+
+    var json = new JObject(
+        new JProperty("status", result.Status.ToString()),
+        new JProperty("results", new JObject(result.Entries.Select(pair =>
+            new JProperty(pair.Key, new JObject(
+                new JProperty("status", pair.Value.Status.ToString()),
+                new JProperty("description", pair.Value.Description),
+                new JProperty("data", new JObject(pair.Value.Data.Select(
+                    p => new JProperty(p.Key, p.Value))))))))));
+    return httpContext.Response.WriteAsync(
+        json.ToString(Formatting.Indented));
+}
+```
+
+## Database probe
+
+A health check can specify a database query to run as a boolean test to indicate if the database is responding normally.
+
+The sample app uses [AspNetCore.Diagnostics.HealthChecks](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks), a health check library for ASP.NET Core apps, to perform a health check on a SQL Server database. `AspNetCore.Diagnostics.HealthChecks` executes a `SELECT 1` query against the database to confirm the connection to the database is healthy.
+
+> [!WARNING]
+> When checking a database connection with a query, choose a query that returns quickly. The query approach runs the risk of overloading the database and degrading its performance. In most cases, running a test query isn't necessary. Merely making a successful connection to the database is sufficient. If you find it necessary to run a query, choose a simple SELECT query, such as `SELECT 1`.
+
+Include a package reference to [AspNetCore.HealthChecks.SqlServer](https://www.nuget.org/packages/AspNetCore.HealthChecks.SqlServer/).
+
+Supply a valid database connection string in the *appsettings.json* file of the sample app. The app uses a SQL Server database named `HealthCheckSample`:
+
+[!code-json[](health-checks/samples/3.x/HealthChecksSample/appsettings.json?highlight=3)]
+
+Register health check services with <xref:Microsoft.Extensions.DependencyInjection.HealthCheckServiceCollectionExtensions.AddHealthChecks*> in `Startup.ConfigureServices`. The sample app calls the `AddSqlServer` method with the database's connection string (*DbHealthStartup.cs*):
+
+[!code-csharp[](health-checks/samples/3.x/HealthChecksSample/DbHealthStartup.cs?name=snippet_ConfigureServices)]
+
+A health check endpoint is created by calling `MapHealthChecks` in `Startup.Configure`:
+
+[!code-csharp[](health-checks/samples/3.x/HealthChecksSample/DbHealthStartup.cs?name=snippet_Configure)]
+
+To run the database probe scenario using the sample app, execute the following command from the project's folder in a command shell:
+
+```console
+dotnet run --scenario db
+```
+
+> [!NOTE]
+> [AspNetCore.Diagnostics.HealthChecks](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks) is a port of [BeatPulse](https://github.com/xabaril/beatpulse) and isn't maintained or supported by Microsoft.
+
+## Entity Framework Core DbContext probe
+
+The `DbContext` check confirms that the app can communicate with the database configured for an EF Core `DbContext`. The `DbContext` check is supported in apps that:
+
+* Use [Entity Framework (EF) Core](/ef/core/).
+* Include a package reference to [Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore](https://www.nuget.org/packages/Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore/).
+
+`AddDbContextCheck<TContext>` registers a health check for a `DbContext`. The `DbContext` is supplied as the `TContext` to the method. An overload is available to configure the failure status, tags, and a custom test query.
+
+By default:
+
+* The `DbContextHealthCheck` calls EF Core's `CanConnectAsync` method. You can customize what operation is run when checking health using `AddDbContextCheck` method overloads.
+* The name of the health check is the name of the `TContext` type.
+
+In the sample app, `AppDbContext` is provided to `AddDbContextCheck` and registered as a service in `Startup.ConfigureServices`.
+
+*DbContextHealthStartup.cs*:
+
+[!code-csharp[](health-checks/samples/3.x/HealthChecksSample/DbContextHealthStartup.cs?name=snippet_ConfigureServices)]
+
+A health check endpoint is created by calling `MapHealthChecks` in `Startup.Configure`:
+
+*DbContextHealthStartup.cs*:
+
+[!code-csharp[](health-checks/samples/3.x/HealthChecksSample/DbContextHealthStartup.cs?name=snippet_Configure)]
+
+To run the `DbContext` probe scenario using the sample app, confirm that the database specified by the connection string doesn't exist in the SQL Server instance. If the database exists, delete it.
+
+Execute the following command from the project's folder in a command shell:
+
+```console
+dotnet run --scenario dbcontext
+```
+
+After the app is running, check the health status by making a request to the `/health` endpoint in a browser. The database and `AppDbContext` don't exist, so app provides the following response:
+
+```
+Unhealthy
+```
+
+Trigger the sample app to create the database. Make a request to `/createdatabase`. The app responds:
+
+```
+Creating the database...
+Done!
+Navigate to /health to see the health status.
+```
+
+Make a request to the `/health` endpoint. The database and context exist, so app responds:
+
+```
+Healthy
+```
+
+Trigger the sample app to delete the database. Make a request to `/deletedatabase`. The app responds:
+
+```
+Deleting the database...
+Done!
+Navigate to /health to see the health status.
+```
+
+Make a request to the `/health` endpoint. The app provides an unhealthy response:
+
+```
+Unhealthy
+```
+
+## Separate readiness and liveness probes
+
+In some hosting scenarios, a pair of health checks are used that distinguish two app states:
+
+* The app is functioning but not yet ready to receive requests. This state is the app's *readiness*.
+* The app is functioning and responding to requests. This state is the app's *liveness*.
+
+The readiness check usually performs a more extensive and time-consuming set of checks to determine if all of the app's subsystems and resources are available. A liveness check merely performs a quick check to determine if the app is available to process requests. After the app passes its readiness check, there's no need to burden the app further with the expensive set of readiness checks&mdash;further checks only require checking for liveness.
+
+The sample app contains a health check to report the completion of long-running startup task in a [Hosted Service](xref:fundamentals/host/hosted-services). The `StartupHostedServiceHealthCheck` exposes a property, `StartupTaskCompleted`, that the hosted service can set to `true` when its long-running task is finished (*StartupHostedServiceHealthCheck.cs*):
+
+[!code-csharp[](health-checks/samples/3.x/HealthChecksSample/StartupHostedServiceHealthCheck.cs?name=snippet1&highlight=7-11)]
+
+The long-running background task is started by a [Hosted Service](xref:fundamentals/host/hosted-services) (*Services/StartupHostedService*). At the conclusion of the task, `StartupHostedServiceHealthCheck.StartupTaskCompleted` is set to `true`:
+
+[!code-csharp[](health-checks/samples/3.x/HealthChecksSample/Services/StartupHostedService.cs?name=snippet1&highlight=18-20)]
+
+The health check is registered with <xref:Microsoft.Extensions.DependencyInjection.HealthChecksBuilderAddCheckExtensions.AddCheck*> in `Startup.ConfigureServices` along with the hosted service. Because the hosted service must set the property on the health check, the health check is also registered in the service container (*LivenessProbeStartup.cs*):
+
+[!code-csharp[](health-checks/samples/3.x/HealthChecksSample/LivenessProbeStartup.cs?name=snippet_ConfigureServices)]
+
+A health check endpoint is created by calling `MapHealthChecks` in `Startup.Configure`. In the sample app, the health check endpoints are created at:
+
+* `/health/ready` for the readiness check. The readiness check filters health checks to the health check with the `ready` tag.
+* `/health/live` for the liveness check. The liveness check filters out the `StartupHostedServiceHealthCheck` by returning `false` in the [HealthCheckOptions.Predicate](xref:Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions.Predicate) (for more information, see [Filter health checks](#filter-health-checks))
+
+[!code-csharp[](health-checks/samples/3.x/HealthChecksSample/LivenessProbeStartup.cs?name=snippet_Configure)]
+
+To run the readiness/liveness configuration scenario using the sample app, execute the following command from the project's folder in a command shell:
+
+```console
+dotnet run --scenario liveness
+```
+
+In a browser, visit `/health/ready` several times until 15 seconds have passed. The health check reports *Unhealthy* for the first 15 seconds. After 15 seconds, the endpoint reports *Healthy*, which reflects the completion of the long-running task by the hosted service.
+
+This example also creates a Health Check Publisher (<xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> implementation) that runs the first readiness check with a two second delay. For more information, see the [Health Check Publisher](#health-check-publisher) section.
+
+### Kubernetes example
+
+Using separate readiness and liveness checks is useful in an environment such as [Kubernetes](https://kubernetes.io/). In Kubernetes, an app might be required to perform time-consuming startup work before accepting requests, such as a test of the underlying database availability. Using separate checks allows the orchestrator to distinguish whether the app is functioning but not yet ready or if the app has failed to start. For more information on readiness and liveness probes in Kubernetes, see [Configure Liveness and Readiness Probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/) in the Kubernetes documentation.
+
+The following example demonstrates a Kubernetes readiness probe configuration:
+
+```
+spec:
+  template:
+  spec:
+    readinessProbe:
+      # an http probe
+      httpGet:
+        path: /health/ready
+        port: 80
+      # length of time to wait for a pod to initialize
+      # after pod startup, before applying health checking
+      initialDelaySeconds: 30
+      timeoutSeconds: 1
+    ports:
+      - containerPort: 80
+```
+
+## Metric-based probe with a custom response writer
+
+The sample app demonstrates a memory health check with a custom response writer.
+
+`MemoryHealthCheck` reports a degraded status if the app uses more than a given threshold of memory (1 GB in the sample app). The <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> includes Garbage Collector (GC) information for the app (*MemoryHealthCheck.cs*):
+
+[!code-csharp[](health-checks/samples/3.x/HealthChecksSample/MemoryHealthCheck.cs?name=snippet1)]
+
+Register health check services with <xref:Microsoft.Extensions.DependencyInjection.HealthCheckServiceCollectionExtensions.AddHealthChecks*> in `Startup.ConfigureServices`. Instead of enabling the health check by passing it to <xref:Microsoft.Extensions.DependencyInjection.HealthChecksBuilderAddCheckExtensions.AddCheck*>, the `MemoryHealthCheck` is registered as a service. All <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck> registered services are available to the health check services and middleware. We recommend registering health check services as Singleton services.
+
+*CustomWriterStartup.cs*:
+
+[!code-csharp[](health-checks/samples/3.x/HealthChecksSample/CustomWriterStartup.cs?name=snippet_ConfigureServices&highlight=4)]
+
+A health check endpoint is created by calling `MapHealthChecks` in `Startup.Configure`. A `WriteResponse` delegate is provided to the `ResponseWriter` property to output a custom JSON response when the health check executes:
+
+[!code-csharp[](health-checks/samples/3.x/HealthChecksSample/CustomWriterStartup.cs?name=snippet_Configure)]
+
+The `WriteResponse` method formats the `CompositeHealthCheckResult` into a JSON object and yields JSON output for the health check response:
+
+[!code-csharp[](health-checks/samples/3.x/HealthChecksSample/CustomWriterStartup.cs?name=snippet_WriteResponse)]
+
+To run the metric-based probe with custom response writer output using the sample app, execute the following command from the project's folder in a command shell:
+
+```console
+dotnet run --scenario writer
+```
+
+> [!NOTE]
+> [AspNetCore.Diagnostics.HealthChecks](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks) includes metric-based health check scenarios, including disk storage and maximum value liveness checks.
+>
+> [AspNetCore.Diagnostics.HealthChecks](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks) is a port of [BeatPulse](https://github.com/xabaril/beatpulse) and isn't maintained or supported by Microsoft.
+
+## Filter by port
+
+Call `RequireHost` on `MapHealthChecks` with a URL pattern that specifies a port to restrict health check requests to the port specified. This is typically used in a container environment to expose a port for monitoring services.
+
+The sample app configures the port using the [Environment Variable Configuration Provider](xref:fundamentals/configuration/index#environment-variables-configuration-provider). The port is set in the *launchSettings.json* file and passed to the configuration provider via an environment variable. You must also configure the server to listen to requests on the management port.
+
+To use the sample app to demonstrate management port configuration, create the *launchSettings.json* file in a *Properties* folder.
+
+The following *launchSettings.json* file isn't included in the sample app's project files and must be created manually.
+
+*Properties/launchSettings.json*:
+
+```json
+{
+  "profiles": {
+    "SampleApp": {
+      "commandName": "Project",
+      "commandLineArgs": "",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_URLS": "http://localhost:5000/;http://localhost:5001/",
+        "ASPNETCORE_MANAGEMENTPORT": "5001"
+      },
+      "applicationUrl": "http://localhost:5000/"
+    }
+  }
+}
+```
+
+Register health check services with <xref:Microsoft.Extensions.DependencyInjection.HealthCheckServiceCollectionExtensions.AddHealthChecks*> in `Startup.ConfigureServices`. Create a health check endpoint by calling `MapHealthChecks` in `Startup.Configure`.
+
+In the sample app, a call to `RequireHost` on the endpoint specifies the management port.
+
+`Startup.Configure` in *ManagementPortStartup.cs*:
+
+[!code-csharp[](health-checks/samples/3.x/HealthChecksSample/ManagementPortStartup.cs?name=snippet_Configure)]
+
+> [!NOTE]
+> You can avoid creating the *launchSettings.json* file in the sample app by setting the management port explicitly in code. In *Program.cs* where the <xref:Microsoft.Extensions.Hosting.HostBuilder> is created, add a call to <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenAnyIP*> and provide the app's management port endpoint. In `Configure` of *ManagementPortStartup.cs*, specify the management port with `RequireHost`:
+>
+> *Program.cs*:
+>
+> ```csharp
+> return new HostBuilder()
+>     .ConfigureWebHostDefaults(webBuilder =>
+>     {
+>         webBuilder.UseKestrel()
+>             .ConfigureKestrel(serverOptions =>
+>             {
+>                 serverOptions.ListenAnyIP(5001);
+>             })
+>             .UseStartup(startupType);
+>     })
+>     .Build();
+> ```
+>
+> `Configure` in *ManagementPortStartup.cs*:
+>
+> ```csharp
+> app.UseEndpoints(endpoints =>
+> {
+>     endpoints.MapHealthChecks("/health").RequireHost("*:5001");
+> });
+> ```
+
+To run the management port configuration scenario using the sample app, execute the following command from the project's folder in a command shell:
+
+```console
+dotnet run --scenario port
+```
+
+## Distribute a health check library
+
+To distribute a health check as a library:
+
+1. Write a health check that implements the <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck> interface as a standalone class. The class can rely on [dependency injection (DI)](xref:fundamentals/dependency-injection), type activation, and [named options](xref:fundamentals/configuration/options) to access configuration data.
+
+   ```csharp
+   using System;
+   using System.Threading;
+   using System.Threading.Tasks;
+   using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+   namespace SampleApp
+   {
+       public class ExampleHealthCheck : IHealthCheck
+       {
+           private readonly string _data1;
+           private readonly int? _data2;
+
+           public ExampleHealthCheck(string data1, int? data2)
+           {
+               _data1 = data1 ?? throw new ArgumentNullException(nameof(data1));
+               _data2 = data2 ?? throw new ArgumentNullException(nameof(data2));
+           }
+
+           public async Task<HealthCheckResult> CheckHealthAsync(
+               HealthCheckContext context, CancellationToken cancellationToken)
+           {
+               try
+               {
+                   // Health check logic
+                   //
+                   // data1 and data2 are used in the method to
+                   // run the probe's health check logic.
+
+                   // Assume that it's possible for this health check
+                   // to throw an AccessViolationException.
+
+                   return HealthCheckResult.Healthy();
+               }
+               catch (AccessViolationException ex)
+               {
+                   return new HealthCheckResult(
+                       context.Registration.FailureStatus,
+                       description: "An access violation occurred during the check.",
+                       exception: ex,
+                       data: null);
+               }
+           }
+       }
+   }
+   ```
+
+1. Write an extension method with parameters that the consuming app calls in its `Startup.Configure` method. In the following example, assume the following health check method signature:
+
+   ```csharp
+   ExampleHealthCheck(string, string, int )
+   ```
+
+   The preceding signature indicates that the `ExampleHealthCheck` requires additional data to process the health check probe logic. The data is provided to the delegate used to create the health check instance when the health check is registered with an extension method. In the following example, the caller specifies optional:
+
+   * health check name (`name`). If `null`, `example_health_check` is used.
+   * string data point for the health check (`data1`).
+   * integer data point for the health check (`data2`). If `null`, `1` is used.
+   * failure status (<xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus>). The default is `null`. If `null`, [HealthStatus.Unhealthy](xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus) is reported for a failure status.
+   * tags (`IEnumerable<string>`).
+
+   ```csharp
+   using System.Collections.Generic;
+   using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+   public static class ExampleHealthCheckBuilderExtensions
+   {
+       const string NAME = "example_health_check";
+
+       public static IHealthChecksBuilder AddExampleHealthCheck(
+           this IHealthChecksBuilder builder,
+           string name = default,
+           string data1,
+           int data2 = 1,
+           HealthStatus? failureStatus = default,
+           IEnumerable<string> tags = default)
+       {
+           return builder.Add(new HealthCheckRegistration(
+               name ?? NAME,
+               sp => new ExampleHealthCheck(data1, data2),
+               failureStatus,
+               tags));
+       }
+   }
+   ```
+
+## Health Check Publisher
+
+When an <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> is added to the service container, the health check system periodically executes your health checks and calls `PublishAsync` with the result. This is useful in a push-based health monitoring system scenario that expects each process to call the monitoring system periodically in order to determine health.
+
+The <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> interface has a single method:
+
+```csharp
+Task PublishAsync(HealthReport report, CancellationToken cancellationToken);
+```
+
+<xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions> allow you to set:
+
+* <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions.Delay> &ndash; The initial delay applied after the app starts before executing <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> instances. The delay is applied once at startup and doesn't apply to subsequent iterations. The default value is five seconds.
+* <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions.Period> &ndash; The period of <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> execution. The default value is 30 seconds.
+* <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions.Predicate> &ndash; If <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions.Predicate> is `null` (default), the health check publisher service runs all registered health checks. To run a subset of health checks, provide a function that filters the set of checks. The predicate is evaluated each period.
+* <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions.Timeout> &ndash; The timeout for executing the health checks for all <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> instances. Use <xref:System.Threading.Timeout.InfiniteTimeSpan> to execute without a timeout. The default value is 30 seconds.
+
+In the sample app, `ReadinessPublisher` is an <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> implementation. The health check status is recorded in `Entries` and logged for each check:
+
+[!code-csharp[](health-checks/samples/3.x/HealthChecksSample/ReadinessPublisher.cs?name=snippet_ReadinessPublisher&highlight=20,22-23)]
+
+In the sample app's `LivenessProbeStartup` example, the `StartupHostedService` readiness check has a two second startup delay and runs the check every 30 seconds. To activate the <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> implementation, the sample registers `ReadinessPublisher` as a singleton service in the [dependency injection (DI)](xref:fundamentals/dependency-injection) container:
+
+[!code-csharp[](health-checks/samples/3.x/HealthChecksSample/LivenessProbeStartup.cs?name=snippet_ConfigureServices)]
+
+> [!NOTE]
+> [AspNetCore.Diagnostics.HealthChecks](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks) includes publishers for several systems, including [Application Insights](/azure/application-insights/app-insights-overview).
+>
+> [AspNetCore.Diagnostics.HealthChecks](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks) is a port of [BeatPulse](https://github.com/xabaril/beatpulse) and isn't maintained or supported by Microsoft.
+
+## Restrict health checks with MapWhen
+
+Use <xref:Microsoft.AspNetCore.Builder.MapWhenExtensions.MapWhen*> to conditionally branch the request pipeline for health check endpoints.
+
+In the following example, `MapWhen` branches the request pipeline to activate Health Check Middleware if a GET request is received for the `api/HealthCheck` endpoint:
+
+```csharp
+app.MapWhen(
+    context => context.Request.Method == HttpMethod.Get.Method && 
+        context.Request.Path.StartsWith("/api/HealthCheck"),
+    builder => builder.UseHealthChecks());
+
+app.UseEndpoints(endpoints =>
+{
+    endpoints.MapRazorPages();
+});
+
+app.UseMvc();
+```
+
+For more information, see <xref:fundamentals/middleware/index#use-run-and-map>.
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-3.0"
 
 ASP.NET Core offers Health Check Middleware and libraries for reporting the health of app infrastructure components.
 
@@ -136,7 +851,7 @@ public void ConfigureServices(IServiceCollection services)
 {
     services.AddHealthChecks()
         .AddCheck("Example", () =>
-            HealthCheckResult.Healthy("Example is OK!"), tags: new[] { "example" })
+            HealthCheckResult.Healthy("Example is OK!"), tags: new[] { "example" });
 }
 ```
 
@@ -183,7 +898,8 @@ public void ConfigureServices(IServiceCollection services)
         .AddCheck("Foo", () =>
             HealthCheckResult.Healthy("Foo is OK!"), tags: new[] { "foo_tag" })
         .AddCheck("Bar", () =>
-            HealthCheckResult.Unhealthy("Bar is unhealthy!"), tags: new[] { "bar_tag" })
+            HealthCheckResult.Unhealthy("Bar is unhealthy!"), 
+                tags: new[] { "bar_tag" })
         .AddCheck("Baz", () =>
             HealthCheckResult.Healthy("Baz is OK!"), tags: new[] { "baz_tag" });
 }
@@ -211,8 +927,6 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 {
     app.UseHealthChecks("/health", new HealthCheckOptions()
     {
-        // The following StatusCodes are the default assignments for
-        // the HealthStatus properties.
         ResultStatusCodes =
         {
             [HealthStatus.Healthy] = StatusCodes.Status200OK,
@@ -235,7 +949,6 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 {
     app.UseHealthChecks("/health", new HealthCheckOptions()
     {
-        // The default value is false.
         AllowCachingResponses = false
     });
 }
@@ -253,7 +966,6 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 {
     app.UseHealthChecks("/health", new HealthCheckOptions()
     {
-        // WriteResponse is a delegate used to write the response.
         ResponseWriter = WriteResponse
     });
 }
@@ -642,12 +1354,8 @@ Task PublishAsync(HealthReport report, CancellationToken cancellationToken);
 * <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions.Predicate> &ndash; If <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions.Predicate> is `null` (default), the health check publisher service runs all registered health checks. To run a subset of health checks, provide a function that filters the set of checks. The predicate is evaluated each period.
 * <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions.Timeout> &ndash; The timeout for executing the health checks for all <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> instances. Use <xref:System.Threading.Timeout.InfiniteTimeSpan> to execute without a timeout. The default value is 30 seconds.
 
-::: moniker range="= aspnetcore-2.2"
-
 > [!WARNING]
-> In the ASP.NET Core 2.2 release, setting <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions.Period> isn't honored by the <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> implementation; it sets the value of <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions.Delay>. This issue will be fixed in ASP.NET Core 3.0. For more information, see [HealthCheckPublisherOptions.Period sets the value of .Delay](https://github.com/aspnet/Extensions/issues/1041).
-
-::: moniker-end
+> In the ASP.NET Core 2.2 release, setting <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions.Period> isn't honored by the <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> implementation; it sets the value of <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions.Delay>. This issue has been addressed in ASP.NET Core 3.0.
 
 In the sample app, `ReadinessPublisher` is an <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> implementation. The health check status is recorded in `Entries` and logged for each check:
 
@@ -657,10 +1365,8 @@ In the sample app's `LivenessProbeStartup` example, the `StartupHostedService` r
 
 [!code-csharp[](health-checks/samples/2.x/HealthChecksSample/LivenessProbeStartup.cs?name=snippet_ConfigureServices&highlight=12-17,28)]
 
-::: moniker range="= aspnetcore-2.2"
-
 > [!NOTE]
-> The following workaround permits adding an <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> instance to the service container when one or more other hosted services have already been added to the app. This workaround won't be required with the release of ASP.NET Core 3.0. For more information, see: https://github.com/aspnet/Extensions/issues/639.
+> The following workaround permits adding an <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> instance to the service container when one or more other hosted services have already been added to the app. This workaround won't isn't required in ASP.NET Core 3.0.
 >
 > ```csharp
 > private const string HealthCheckServiceAssembly =
@@ -671,8 +1377,6 @@ In the sample app's `LivenessProbeStartup` example, the `StartupHostedService` r
 >         typeof(HealthCheckPublisherOptions).Assembly
 >             .GetType(HealthCheckServiceAssembly)));
 > ```
-
-::: moniker-end
 
 > [!NOTE]
 > [AspNetCore.Diagnostics.HealthChecks](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks) includes publishers for several systems, including [Application Insights](/azure/application-insights/app-insights-overview).
@@ -695,3 +1399,5 @@ app.UseMvc();
 ```
 
 For more information, see <xref:fundamentals/middleware/index#use-run-and-map>.
+
+::: moniker-end

--- a/aspnetcore/host-and-deploy/health-checks/samples/2.x/HealthChecksSample/BasicStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/2.x/HealthChecksSample/BasicStartup.cs
@@ -15,7 +15,6 @@ namespace SampleApp
     //
     // This is the simplest way to perform health checks. It's suitable for systems that want to check for 'liveness' of an app.
 
-    #region snippet1
     public class BasicStartup
     {
         public void ConfigureServices(IServiceCollection services)
@@ -34,5 +33,4 @@ namespace SampleApp
             });
         }
     }
-    #endregion
 }

--- a/aspnetcore/host-and-deploy/health-checks/samples/2.x/HealthChecksSample/CustomWriterStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/2.x/HealthChecksSample/CustomWriterStartup.cs
@@ -29,7 +29,6 @@ namespace SampleApp
         }
         #endregion
 
-        #region snippet_Configure
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             app.UseHealthChecks("/health", new HealthCheckOptions()
@@ -37,7 +36,6 @@ namespace SampleApp
                 // This custom writer formats the detailed status as JSON.
                 ResponseWriter = WriteResponse
             });
-        #endregion
 
             app.Run(async (context) =>
             {

--- a/aspnetcore/host-and-deploy/health-checks/samples/2.x/HealthChecksSample/DBHealthStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/2.x/HealthChecksSample/DBHealthStartup.cs
@@ -16,7 +16,6 @@ namespace SampleApp
     //
     // This approach is suitable for systems that check for 'liveness' of an app with a database.
 
-    #region snippet1
     public class DbHealthStartup
     {
         public DbHealthStartup(IConfiguration configuration)
@@ -34,11 +33,9 @@ namespace SampleApp
         }
         #endregion
 
-        #region snippet_Configure
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             app.UseHealthChecks("/health");
-        #endregion
 
             app.Run(async (context) =>
             {
@@ -47,5 +44,4 @@ namespace SampleApp
             });
         }
     }
-    #endregion
 }

--- a/aspnetcore/host-and-deploy/health-checks/samples/2.x/HealthChecksSample/DbContextHealthStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/2.x/HealthChecksSample/DbContextHealthStartup.cs
@@ -42,11 +42,9 @@ namespace SampleApp
         }
         #endregion
 
-        #region snippet_Configure
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             app.UseHealthChecks("/health");
-        #endregion
 
             app.Map("/createdatabase", b => b.Run(async (context) =>
             {

--- a/aspnetcore/host-and-deploy/health-checks/samples/2.x/HealthChecksSample/LivenessProbeStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/2.x/HealthChecksSample/LivenessProbeStartup.cs
@@ -62,7 +62,6 @@ namespace SampleApp
         }
         #endregion
 
-        #region snippet_Configure
         public void Configure(IApplicationBuilder app)
         {
             // The readiness check uses all registered checks with the 'ready' tag.
@@ -76,7 +75,6 @@ namespace SampleApp
                 // Exclude all checks and return a 200-Ok.
                 Predicate = (_) => false
             });
-        #endregion
 
             app.Run(async (context) =>
             {

--- a/aspnetcore/host-and-deploy/health-checks/samples/2.x/HealthChecksSample/ManagementPortStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/2.x/HealthChecksSample/ManagementPortStartup.cs
@@ -29,7 +29,6 @@ namespace SampleApp
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-
             app.UseHealthChecks("/health", port: Configuration["ManagementPort"]);
 
             app.Run(async (context) =>

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/BasicStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/BasicStartup.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SampleApp
+{
+    // Use the `--scenario basic` switch to run this version of the sample.
+    //
+    // Register Health Check Middleware at the URL: /health
+    // 
+    // By default, health checks return a 200-Ok with 'Healthy'.
+    // - No health checks are registered by default. The app is healthy if it's reachable.
+    // - The default response writer writes the HealthStatus as text/plain content.
+    //
+    // This is the simplest way to perform health checks. It's suitable for systems that want to check for 'liveness' of an app.
+
+    #region snippet1
+    public class BasicStartup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddHealthChecks();
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapHealthChecks("/health");
+            });
+
+            app.Run(async (context) =>
+            {
+                await context.Response.WriteAsync(
+                    "Navigate to /health to see the health status.");
+            });
+        }
+    }
+    #endregion
+}

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/BasicStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/BasicStartup.cs
@@ -15,7 +15,6 @@ namespace SampleApp
     //
     // This is the simplest way to perform health checks. It's suitable for systems that want to check for 'liveness' of an app.
 
-    #region snippet1
     public class BasicStartup
     {
         public void ConfigureServices(IServiceCollection services)
@@ -30,14 +29,13 @@ namespace SampleApp
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapHealthChecks("/health");
-            });
 
-            app.Run(async (context) =>
-            {
-                await context.Response.WriteAsync(
-                    "Navigate to /health to see the health status.");
+                endpoints.MapGet("/{**path}", async context =>
+                {
+                    await context.Response.WriteAsync(
+                        "Navigate to /health to see the health status.");
+                });
             });
         }
     }
-    #endregion
 }

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/CustomWriterStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/CustomWriterStartup.cs
@@ -33,7 +33,6 @@ namespace SampleApp
         {
             app.UseRouting();
 
-            #region snippet_Configure
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapHealthChecks("/health", new HealthCheckOptions()
@@ -41,13 +40,12 @@ namespace SampleApp
                     // This custom writer formats the detailed status as JSON.
                     ResponseWriter = WriteResponse
                 });
-            });
-            #endregion
 
-            app.Run(async (context) =>
-            {
-                await context.Response.WriteAsync(
-                    "Navigate to /health to see the health status.");
+                endpoints.MapGet("/{**path}", async context =>
+                {
+                    await context.Response.WriteAsync(
+                        "Navigate to /health to see the health status.");
+                });
             });
         }
 

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/CustomWriterStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/CustomWriterStartup.cs
@@ -1,0 +1,73 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace SampleApp
+{
+    // Use the `--scenario writer` switch to run this version of the sample.
+    //
+    // This is an example of registering a custom health check as a service. All IHealthCheck services are available to the health check service and middleware. We recommend registering all health checks as Singleton services.
+    //
+    // Register Health Check Middleware at the URL: /health
+    // 
+    // This example overrides the HealthCheckOptions.ResponseWriter to write a custom health check result.
+
+    public class CustomWriterStartup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            #region snippet_ConfigureServices
+            services.AddHealthChecks()
+                .AddMemoryHealthCheck("memory");
+            #endregion
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseRouting();
+
+            #region snippet_Configure
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapHealthChecks("/health", new HealthCheckOptions()
+                {
+                    // This custom writer formats the detailed status as JSON.
+                    ResponseWriter = WriteResponse
+                });
+            });
+            #endregion
+
+            app.Run(async (context) =>
+            {
+                await context.Response.WriteAsync(
+                    "Navigate to /health to see the health status.");
+            });
+        }
+
+        #region snippet_WriteResponse
+        private static Task WriteResponse(HttpContext httpContext, 
+            HealthReport result)
+        {
+            httpContext.Response.ContentType = "application/json";
+
+            var json = new JObject(
+                new JProperty("status", result.Status.ToString()),
+                new JProperty("results", new JObject(result.Entries.Select(pair =>
+                    new JProperty(pair.Key, new JObject(
+                        new JProperty("status", pair.Value.Status.ToString()),
+                        new JProperty("description", pair.Value.Description),
+                        new JProperty("data", new JObject(pair.Value.Data.Select(
+                            p => new JProperty(p.Key, p.Value))))))))));
+            return httpContext.Response.WriteAsync(
+                json.ToString(Formatting.Indented));
+        }
+        #endregion
+    }
+}

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/DBHealthStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/DBHealthStartup.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SampleApp
+{
+    // Use the `--scenario db` switch to run this version of the sample.
+    //
+    // Register Health Check Middleware at the URL: /health
+    // 
+    // By default, health checks return a 200-Ok with 'Healthy' when the database is responsive.
+    // - A BeatPulse SQL Server health check is used in the example for a SQL database. For more information on BeatPulse, see https://github.com/Xabaril/BeatPulse.
+    // - The default response writer writes the HealthStatus as text/plain content.
+    //
+    // This approach is suitable for systems that check for 'liveness' of an app with a database.
+
+    #region snippet1
+    public class DbHealthStartup
+    {
+        public DbHealthStartup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            #region snippet_ConfigureServices
+            services.AddHealthChecks()
+                .AddSqlServer(Configuration["ConnectionStrings:DefaultConnection"]);
+            #endregion
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseRouting();
+
+            #region snippet_Configure
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapHealthChecks("/health");
+            });
+            #endregion
+
+            app.Run(async (context) =>
+            {
+                await context.Response.WriteAsync(
+                    "Navigate to /health to see the health status.");
+            });
+        }
+    }
+    #endregion
+}

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/DBHealthStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/DBHealthStartup.cs
@@ -16,7 +16,6 @@ namespace SampleApp
     //
     // This approach is suitable for systems that check for 'liveness' of an app with a database.
 
-    #region snippet1
     public class DbHealthStartup
     {
         public DbHealthStartup(IConfiguration configuration)
@@ -38,19 +37,16 @@ namespace SampleApp
         {
             app.UseRouting();
 
-            #region snippet_Configure
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapHealthChecks("/health");
-            });
-            #endregion
 
-            app.Run(async (context) =>
-            {
-                await context.Response.WriteAsync(
-                    "Navigate to /health to see the health status.");
+                endpoints.MapGet("/{**path}", async context =>
+                {
+                    await context.Response.WriteAsync(
+                        "Navigate to /health to see the health status.");
+                });
             });
         }
     }
-    #endregion
 }

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/Data/AppDbContext.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/Data/AppDbContext.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace SampleApp.Data
+{
+    public class AppDbContext : DbContext
+    {
+        public AppDbContext(DbContextOptions options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Blog> Blogs { get; set; }
+    }
+}

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/Data/Blog.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/Data/Blog.cs
@@ -1,0 +1,8 @@
+namespace SampleApp.Data
+{
+    public class Blog
+    {
+        public int BlogId { get; set; }
+        public string Url { get; set; }
+    }
+}

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/DbContextHealthStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/DbContextHealthStartup.cs
@@ -46,54 +46,52 @@ namespace SampleApp
         {
             app.UseRouting();
 
-            #region snippet_Configure
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapHealthChecks("/health");
-            });
-            #endregion
 
-            app.Map("/createdatabase", b => b.Run(async (context) =>
-            {
-                await context.Response.WriteAsync("Creating the database...");
-                await context.Response.WriteAsync(Environment.NewLine);
-                await context.Response.Body.FlushAsync();
+                endpoints.MapGet("/createdatabase", async context =>
+                {
+                    await context.Response.WriteAsync("Creating the database...");
+                    await context.Response.WriteAsync(Environment.NewLine);
+                    await context.Response.Body.FlushAsync();
 
-                var appDbContext = 
-                    context.RequestServices.GetRequiredService<AppDbContext>();
-                await appDbContext.Database.EnsureCreatedAsync();
+                    var appDbContext = 
+                        context.RequestServices.GetRequiredService<AppDbContext>();
+                    await appDbContext.Database.EnsureCreatedAsync();
 
-                await context.Response.WriteAsync("Done!");
-                await context.Response.WriteAsync(Environment.NewLine);
-                await context.Response.WriteAsync(
-                    "Navigate to /health to see the health status.");
-                await context.Response.WriteAsync(Environment.NewLine);
-            }));
+                    await context.Response.WriteAsync("Done!");
+                    await context.Response.WriteAsync(Environment.NewLine);
+                    await context.Response.WriteAsync(
+                        "Navigate to /health to see the health status.");
+                    await context.Response.WriteAsync(Environment.NewLine);
+                });
 
-            app.Map("/deletedatabase", b => b.Run(async (context) =>
-            {
-                await context.Response.WriteAsync("Deleting the database...");
-                await context.Response.WriteAsync(Environment.NewLine);
-                await context.Response.Body.FlushAsync();
+                endpoints.MapGet("deletedatabase", async context =>
+                {
+                    await context.Response.WriteAsync("Deleting the database...");
+                    await context.Response.WriteAsync(Environment.NewLine);
+                    await context.Response.Body.FlushAsync();
 
-                var appDbContext = 
-                    context.RequestServices.GetRequiredService<AppDbContext>();
-                await appDbContext.Database.EnsureDeletedAsync();
+                    var appDbContext = 
+                        context.RequestServices.GetRequiredService<AppDbContext>();
+                    await appDbContext.Database.EnsureDeletedAsync();
 
-                await context.Response.WriteAsync("Done!");
-                await context.Response.WriteAsync(Environment.NewLine);
-                await context.Response.WriteAsync("Navigate to /health to see the health status.");
-                await context.Response.WriteAsync(Environment.NewLine);
-            }));
+                    await context.Response.WriteAsync("Done!");
+                    await context.Response.WriteAsync(Environment.NewLine);
+                    await context.Response.WriteAsync("Navigate to /health to see the health status.");
+                    await context.Response.WriteAsync(Environment.NewLine);
+                });
 
-            app.Run(async (context) =>
-            {
-                await context.Response.WriteAsync("Navigate to /health to see the health status.");
-                await context.Response.WriteAsync(Environment.NewLine);
-                await context.Response.WriteAsync("Navigate to /createdatabase to create the database.");
-                await context.Response.WriteAsync(Environment.NewLine);
-                await context.Response.WriteAsync("Navigate to /deletedatabase to delete the database.");
-                await context.Response.WriteAsync(Environment.NewLine);
+                endpoints.MapGet("/{**path}", async context =>
+                {
+                    await context.Response.WriteAsync("Navigate to /health to see the health status.");
+                    await context.Response.WriteAsync(Environment.NewLine);
+                    await context.Response.WriteAsync("Navigate to /createdatabase to create the database.");
+                    await context.Response.WriteAsync(Environment.NewLine);
+                    await context.Response.WriteAsync("Navigate to /deletedatabase to delete the database.");
+                    await context.Response.WriteAsync(Environment.NewLine);
+                });
             });
         }
     }

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/DbContextHealthStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/DbContextHealthStartup.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using SampleApp.Data;
+
+namespace SampleApp
+{
+    // Use the `--scenario dbcontext` switch to run this version of the sample.
+    //
+    // Register Health Check Middleware at the URL: /health
+    // 
+    // By default, health checks return a 200-Ok with 'Healthy' when the database is responsive.
+    // - A a SqlConnectionHealthCheck is used in the example for a SQL database.
+    // - The default response writer writes the HealthStatus as text/plain content.
+    //
+    // AddDbContextCheck<TContext> registers a health check for the TContext type. By default, the name of the health check is the name of the TContext type. There are other options available through AddDbContextCheck to configure failure status, tags, and a custom test query.
+
+    public class DbContextHealthStartup
+    {
+        public DbContextHealthStartup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            #region snippet_ConfigureServices
+            services.AddHealthChecks()
+                .AddDbContextCheck<AppDbContext>();
+
+            services.AddDbContext<AppDbContext>(options =>
+            {
+                options.UseSqlServer(
+                    Configuration["ConnectionStrings:DefaultConnection"]);
+            });
+            #endregion
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseRouting();
+
+            #region snippet_Configure
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapHealthChecks("/health");
+            });
+            #endregion
+
+            app.Map("/createdatabase", b => b.Run(async (context) =>
+            {
+                await context.Response.WriteAsync("Creating the database...");
+                await context.Response.WriteAsync(Environment.NewLine);
+                await context.Response.Body.FlushAsync();
+
+                var appDbContext = 
+                    context.RequestServices.GetRequiredService<AppDbContext>();
+                await appDbContext.Database.EnsureCreatedAsync();
+
+                await context.Response.WriteAsync("Done!");
+                await context.Response.WriteAsync(Environment.NewLine);
+                await context.Response.WriteAsync(
+                    "Navigate to /health to see the health status.");
+                await context.Response.WriteAsync(Environment.NewLine);
+            }));
+
+            app.Map("/deletedatabase", b => b.Run(async (context) =>
+            {
+                await context.Response.WriteAsync("Deleting the database...");
+                await context.Response.WriteAsync(Environment.NewLine);
+                await context.Response.Body.FlushAsync();
+
+                var appDbContext = 
+                    context.RequestServices.GetRequiredService<AppDbContext>();
+                await appDbContext.Database.EnsureDeletedAsync();
+
+                await context.Response.WriteAsync("Done!");
+                await context.Response.WriteAsync(Environment.NewLine);
+                await context.Response.WriteAsync("Navigate to /health to see the health status.");
+                await context.Response.WriteAsync(Environment.NewLine);
+            }));
+
+            app.Run(async (context) =>
+            {
+                await context.Response.WriteAsync("Navigate to /health to see the health status.");
+                await context.Response.WriteAsync(Environment.NewLine);
+                await context.Response.WriteAsync("Navigate to /createdatabase to create the database.");
+                await context.Response.WriteAsync(Environment.NewLine);
+                await context.Response.WriteAsync("Navigate to /deletedatabase to delete the database.");
+                await context.Response.WriteAsync(Environment.NewLine);
+            });
+        }
+    }
+}

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/LivenessProbeStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/LivenessProbeStartup.cs
@@ -48,16 +48,6 @@ namespace SampleApp
                 options.Predicate = (check) => check.Tags.Contains("ready");
             });
 
-            // The following workaround permits adding an IHealthCheckPublisher 
-            // instance to the service container when one or more other hosted 
-            // services have already been added to the app. This workaround
-            // won't be required with the release of ASP.NET Core 3.0. For more 
-            // information, see: https://github.com/aspnet/Extensions/issues/639.
-            services.TryAddEnumerable(
-                ServiceDescriptor.Singleton(typeof(IHostedService), 
-                    typeof(HealthCheckPublisherOptions).Assembly
-                        .GetType(HealthCheckServiceAssembly)));
-
             services.AddSingleton<IHealthCheckPublisher, ReadinessPublisher>();
             #endregion
         }
@@ -66,7 +56,6 @@ namespace SampleApp
         {
             app.UseRouting();
 
-            #region snippet_Configure
             app.UseEndpoints(endpoints =>
             {
                 // The readiness check uses all registered checks with the 'ready' tag.
@@ -80,16 +69,15 @@ namespace SampleApp
                     // Exclude all checks and return a 200-Ok.
                     Predicate = (_) => false
                 });
-            });
-            #endregion
 
-            app.Run(async (context) =>
-            {
-                await context.Response.WriteAsync(
-                    "Navigate to /health/ready to see the readiness status.");
-                await context.Response.WriteAsync(Environment.NewLine);
-                await context.Response.WriteAsync(
-                    "Navigate to /health/live to see the liveness status.");
+                endpoints.MapGet("/{**path}", async context =>
+                {
+                    await context.Response.WriteAsync(
+                        "Navigate to /health/ready to see the readiness status.");
+                    await context.Response.WriteAsync(Environment.NewLine);
+                    await context.Response.WriteAsync(
+                        "Navigate to /health/live to see the liveness status.");
+                });
             });
         }
     }

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/LivenessProbeStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/LivenessProbeStartup.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using SampleApp.Services;
+
+namespace SampleApp
+{
+    // Use the `--scenario liveness` switch to run this version of the sample.
+    //
+    // Register Health Check Middleware twice at URLs:
+    // - /health/ready for 'readiness'
+    // - /health/live for 'liveness'
+    //
+    // The readiness check might do a set of more expensive or time-consuming checks to determine if all other resources are responding. The liveness check performs a quick set of checks to determine if the process is functioning correctly.
+    //
+    // Using a separate readiness and liveness checks is useful in an environment such as Kubernetes when an app is required to perform significant work before accepting requests. Using separate checks allows the orchestrator to distinguish whether the app is functioning but not yet ready or if the app has failed to start.
+    //
+    // See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/ for more details about readiness and liveness probes in Kubernetes.
+    //
+    // The readiness check runs all registered checks, including a check with a long initialization time (15 seconds). The liveness check uses an 'identity' check that always returns healthy.
+    //
+    // This example also creates a ReadinessPublisher (IHealthCheckPublisher implementation) that runs the readiness check with a two second delay.
+
+    public class LivenessProbeStartup
+    {
+        private const string HealthCheckServiceAssembly = "Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherHostedService";
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            #region snippet_ConfigureServices
+            services.AddHostedService<StartupHostedService>();
+            services.AddSingleton<StartupHostedServiceHealthCheck>();
+
+            services.AddHealthChecks()
+                .AddCheck<StartupHostedServiceHealthCheck>(
+                    "hosted_service_startup", 
+                    failureStatus: HealthStatus.Degraded, 
+                    tags: new[] { "ready" });
+
+            services.Configure<HealthCheckPublisherOptions>(options =>
+            {
+                options.Delay = TimeSpan.FromSeconds(2);
+                options.Predicate = (check) => check.Tags.Contains("ready");
+            });
+
+            // The following workaround permits adding an IHealthCheckPublisher 
+            // instance to the service container when one or more other hosted 
+            // services have already been added to the app. This workaround
+            // won't be required with the release of ASP.NET Core 3.0. For more 
+            // information, see: https://github.com/aspnet/Extensions/issues/639.
+            services.TryAddEnumerable(
+                ServiceDescriptor.Singleton(typeof(IHostedService), 
+                    typeof(HealthCheckPublisherOptions).Assembly
+                        .GetType(HealthCheckServiceAssembly)));
+
+            services.AddSingleton<IHealthCheckPublisher, ReadinessPublisher>();
+            #endregion
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseRouting();
+
+            #region snippet_Configure
+            app.UseEndpoints(endpoints =>
+            {
+                // The readiness check uses all registered checks with the 'ready' tag.
+                endpoints.MapHealthChecks("/health/ready", new HealthCheckOptions()
+                {
+                    Predicate = (check) => check.Tags.Contains("ready"),
+                });
+
+                endpoints.MapHealthChecks("/health/live", new HealthCheckOptions()
+                {
+                    // Exclude all checks and return a 200-Ok.
+                    Predicate = (_) => false
+                });
+            });
+            #endregion
+
+            app.Run(async (context) =>
+            {
+                await context.Response.WriteAsync(
+                    "Navigate to /health/ready to see the readiness status.");
+                await context.Response.WriteAsync(Environment.NewLine);
+                await context.Response.WriteAsync(
+                    "Navigate to /health/live to see the liveness status.");
+            });
+        }
+    }
+}

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/ManagementPortStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/ManagementPortStartup.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SampleApp
+{
+    // Use the `--scenario port` switch to run this version of the sample.
+    //
+    // RequireHost with a port only processes health checks requests on a connection to the specified URI. This is typically used in a container environment to expose a port for monitoring services.
+    //  The management port is configured in the launchSettings.json file and passed through an environment variable.
+    //  The server must also be configured to listen to requests on the management port.
+
+    public class ManagementPortStartup
+    {
+        public ManagementPortStartup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddHealthChecks();
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseRouting();
+
+            #region snippet_Configure
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapHealthChecks("/health")
+                    .RequireHost($"*:{Configuration["ManagementPort"]}");
+            });
+            #endregion
+
+            app.Run(async (context) =>
+            {
+                await context.Response.WriteAsync(
+                    "Navigate to " + 
+                    $"http://localhost:{Configuration["ManagementPort"]}/health " +
+                    "to see the health status.");
+            });
+        }
+    }
+    
+}

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/ManagementPortStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/ManagementPortStartup.cs
@@ -30,20 +30,18 @@ namespace SampleApp
         {
             app.UseRouting();
 
-            #region snippet_Configure
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapHealthChecks("/health")
                     .RequireHost($"*:{Configuration["ManagementPort"]}");
-            });
-            #endregion
 
-            app.Run(async (context) =>
-            {
-                await context.Response.WriteAsync(
-                    "Navigate to " + 
-                    $"http://localhost:{Configuration["ManagementPort"]}/health " +
-                    "to see the health status.");
+                endpoints.MapGet("/{**path}", async context =>
+                {
+                    await context.Response.WriteAsync(
+                        "Navigate to " + 
+                        $"http://localhost:{Configuration["ManagementPort"]}/health " +
+                        "to see the health status.");
+                });
             });
         }
     }

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/MemoryHealthCheck.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/MemoryHealthCheck.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace SampleApp
+{
+    // This is an example of a custom health check that implements IHealthCheck. See CustomWriterStartup to see how this health check is registered.
+    //
+    // This example also shows a technique for authoring a health check that requires registration with additional configuration data. This technique works via named options and is useful for authoring health checks that will be distributed as libraries.
+
+    #region snippet1
+    public class MemoryHealthCheck : IHealthCheck
+    {
+        private readonly IOptionsMonitor<MemoryCheckOptions> _options;
+
+        public MemoryHealthCheck(IOptionsMonitor<MemoryCheckOptions> options)
+        {
+            _options = options;
+        }
+
+        public string Name => "memory_check";
+
+        public Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context, 
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var options = _options.Get(context.Registration.Name);
+
+            // Include GC information in the reported diagnostics.
+            var allocated = GC.GetTotalMemory(forceFullCollection: false);
+            var data = new Dictionary<string, object>()
+            {
+                { "AllocatedBytes", allocated },
+                { "Gen0Collections", GC.CollectionCount(0) },
+                { "Gen1Collections", GC.CollectionCount(1) },
+                { "Gen2Collections", GC.CollectionCount(2) },
+            };
+
+            var status = (allocated < options.Threshold) ? 
+                HealthStatus.Healthy : HealthStatus.Unhealthy;
+
+            return Task.FromResult(new HealthCheckResult(
+                status,
+                description: "Reports degraded status if allocated bytes " +
+                    $">= {options.Threshold} bytes.",
+                exception: null,
+                data: data));
+        }
+    }
+    #endregion
+
+    #region snippet2
+    public static class GCInfoHealthCheckBuilderExtensions
+    {
+        public static IHealthChecksBuilder AddMemoryHealthCheck(
+            this IHealthChecksBuilder builder,
+            string name,
+            HealthStatus? failureStatus = null,
+            IEnumerable<string> tags = null,
+            long? thresholdInBytes = null)
+        {
+            // Register a check of type GCInfo.
+            builder.AddCheck<MemoryHealthCheck>(
+                name, failureStatus ?? HealthStatus.Degraded, tags);
+
+            // Configure named options to pass the threshold into the check.
+            if (thresholdInBytes.HasValue)
+            {
+                builder.Services.Configure<MemoryCheckOptions>(name, options =>
+                {
+                    options.Threshold = thresholdInBytes.Value;
+                });
+            }
+
+            return builder;
+        }
+    }
+    #endregion
+
+    #region snippet3
+    public class MemoryCheckOptions
+    {
+        // Failure threshold (in bytes)
+        public long Threshold { get; set; } = 1024L * 1024L * 1024L;
+    }
+    #endregion
+}

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/MemoryHealthCheck.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/MemoryHealthCheck.cs
@@ -40,11 +40,8 @@ namespace SampleApp
                 { "Gen2Collections", GC.CollectionCount(2) },
             };
 
-            var status = (allocated < options.Threshold) ? 
-                HealthStatus.Healthy : HealthStatus.Unhealthy;
-
             return Task.FromResult(new HealthCheckResult(
-                status,
+                context.Registration.FailureStatus,
                 description: "Reports degraded status if allocated bytes " +
                     $">= {options.Threshold} bytes.",
                 exception: null,

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/Program.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/Program.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace SampleApp
+{
+    public class Program
+    {
+        private static readonly Dictionary<string, Type> _scenarios;
+
+        static Program()
+        {
+            _scenarios = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "basic", typeof(BasicStartup) },
+                { "db", typeof(DbHealthStartup) },
+                { "dbcontext", typeof(DbContextHealthStartup) },
+                { "liveness", typeof(LivenessProbeStartup) },
+                { "writer", typeof(CustomWriterStartup) },
+                { "port", typeof(ManagementPortStartup) },
+                
+            };
+        }
+
+        public static void Main(string[] args)
+        {
+            BuildHost(args).Run();
+        }
+
+        public static IHost BuildHost(string[] args)
+        {
+            var config1 = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json")
+                .AddEnvironmentVariables(prefix: "ASPNETCORE_")
+                .AddCommandLine(args)
+                .Build();
+
+            var scenario = config1["scenario"] ?? "basic";
+
+            if (!_scenarios.TryGetValue(scenario, out var startupType))
+            {
+                startupType = typeof(BasicStartup);
+            }
+
+            return new HostBuilder()
+                .ConfigureAppConfiguration(config =>
+                {
+                    config.AddConfiguration(config1);
+                })
+                .ConfigureLogging(builder =>
+                {
+                    builder.SetMinimumLevel(LogLevel.Trace);
+                    builder.AddConfiguration(config1);
+                    builder.AddConsole();
+                })
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseKestrel();
+                    webBuilder.UseStartup(startupType);
+                })
+                .Build();
+        }
+    }
+}

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/README.md
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/README.md
@@ -1,0 +1,15 @@
+# ASP.NET Core Health Check Sample
+
+This sample illustrates the use of Health Check Middleware and services. This sample demonstrates the scenario described in the [Health checks in ASP.NET Core](https://docs.microsoft.com/aspnet/core/host-and-deploy/health-checks) topic.
+
+To run the sample app for a scenario described in the topic, use the [dotnet run](https://docs.microsoft.com/dotnet/core/tools/dotnet-run) command from the project's folder in a command shell. Pass a switch for the scenario that you're exploring. The app defaults to the `basic` configuration when a switch isn't provided to `dotnet run`.
+
+| Scenario                                               | Sample app command               | Description |
+| ------------------------------------------------------ | -------------------------------- | ----------- |
+| Basic health probe (default)                           | `dotnet run --scenario basic`    | Confirms that the app can process HTTP requests. |
+| Database probe                                         | `dotnet run --scenario db`       | Checks a SQL Server database connection. See the [Database probe](https://docs.microsoft.com/aspnet/core/host-and-deploy/health-checks#database-probe) section of the topic for instructions. |
+| Readiness/liveness probes                              | `dotnet run --scenario liveness` | Performs checks for a live app status (*liveness*) versus the app preparing to become live (*readiness*). |
+| Metric-based probe (memory)/<br>custom response writer | `dotnet run --scenario writer`   | Checks against memory use and writes out custom JSON when the health endpoint is checked. |
+| Filter by port                                         | `dotnet run --scenario port`     | Filters health checks to a given port. See the [Filter by port](https://docs.microsoft.com/aspnet/core/host-and-deploy/health-checks#filter-by-port) section of the topic for instructions. |
+
+The database probe and port filter scenarios require additional configuration. See the [Health checks](https://docs.microsoft.com/aspnet/core/host-and-deploy/health-checks) topic for details.

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/ReadinessPublisher.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/ReadinessPublisher.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+namespace SampleApp
+{
+    #region snippet_ReadinessPublisher
+    public class ReadinessPublisher : IHealthCheckPublisher
+    {
+        private readonly ILogger _logger;
+
+        public ReadinessPublisher(ILogger<ReadinessPublisher> logger)
+        {
+            _logger = logger;
+        }
+
+        public List<(HealthReport report, CancellationToken cancellationToken)> 
+            Entries { get; } = 
+                new List<(HealthReport report, 
+                    CancellationToken cancellationToken)>();
+
+        public Exception Exception { get; set; }
+
+        public Task PublishAsync(HealthReport report, 
+            CancellationToken cancellationToken)
+        {
+            Entries.Add((report, cancellationToken));
+
+            _logger.LogInformation("{TIMESTAMP} Readiness Probe Status: {RESULT}", 
+                DateTime.UtcNow, report.Status);
+
+            if (Exception != null)
+            {
+                throw Exception;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return Task.CompletedTask;
+        }
+    }
+    #endregion
+}

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/SampleApp.csproj
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/SampleApp.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.0.0-preview8.19405.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0-preview8.19405.11" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.0.0-preview8.19405.7" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.7.0-preview8.19405.3" />
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="2.2.1" />
+  </ItemGroup>
+
+</Project>

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/Services/StartupHostedService.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/Services/StartupHostedService.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace SampleApp.Services
+{
+    #region snippet1
+    public class StartupHostedService : IHostedService, IDisposable
+    {
+        private readonly int _delaySeconds = 15;
+        private readonly ILogger _logger;
+        private readonly StartupHostedServiceHealthCheck _startupHostedServiceHealthCheck;
+
+        public StartupHostedService(ILogger<StartupHostedService> logger, 
+            StartupHostedServiceHealthCheck startupHostedServiceHealthCheck)
+        {
+            _logger = logger;
+            _startupHostedServiceHealthCheck = startupHostedServiceHealthCheck;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogInformation($"Startup Background Service is starting.");
+
+            // Simulate the effect of a long-running startup task.
+            Task.Run(async () =>
+            {
+                await Task.Delay(_delaySeconds * 1000);
+
+                _startupHostedServiceHealthCheck.StartupTaskCompleted = true;
+
+                _logger.LogInformation($"Startup Background Service has started.");
+            });
+
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Startup Background Service is stopping.");
+
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+    #endregion
+}

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/StartupHostedServiceHealthCheck.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/StartupHostedServiceHealthCheck.cs
@@ -1,0 +1,39 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace SampleApp
+{
+    // Simulates a health check for an hosted service that takes 15 seconds to initialize at app startup.
+    //
+    // StartupHostedServiceHealthCheck is part of the Liveness Probe Startup sample.
+
+    #region snippet1
+    public class StartupHostedServiceHealthCheck : IHealthCheck
+    {
+        private volatile bool _startupTaskCompleted = false;
+
+        public string Name => "slow_dependency_check";
+
+        public bool StartupTaskCompleted
+        {
+            get => _startupTaskCompleted;
+            set => _startupTaskCompleted = value;
+        }
+
+        public Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context, 
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (StartupTaskCompleted)
+            {
+                return Task.FromResult(
+                    HealthCheckResult.Healthy("The startup task is finished."));
+            }
+
+            return Task.FromResult(
+                HealthCheckResult.Unhealthy("The startup task is still running."));
+        }
+    }
+    #endregion
+}

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/appsettings.json
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/appsettings.json
@@ -1,0 +1,16 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\MSSQLLocalDB;Database=HealthCheckSample;Trusted_Connection=True;MultipleActiveResultSets=true;ConnectRetryCount=0"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    },
+    "Console": {
+      "IncludeScopes": "true"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Fixes #13340

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?view=aspnetcore-2.2&branch=pr-en-us-13946)

* Sample update to 3.0. Confirmed working.
* Lot's 'o updates here. Plz review me carefully :eyes:. We're not in a major rush, so review can wait if too busy right now to look. 🏃🏃🏃🏃😅 
* Whole topic versioning. You only need to review the top-half of the markdown file (the >=3.0 section).
* Goes with endpoint routing.
* `RequireHost`, `RequireAuthorization`, and `RequireCors` added.
* Let me know if we aren't going to stick with `MapWhen` to limit the HTTP verb: Is there an endpoint routing way to do it? (See the *Restrict health checks with MapWhen* section.)