### PR TITLE
Add troubleshooting docs on untrusted cert with gRPC client

### DIFF
--- a/aspnetcore/grpc/troubleshoot.md
+++ b/aspnetcore/grpc/troubleshoot.md
@@ -52,7 +52,7 @@ The .NET gRPC client requires the service to have a trusted certificate. The fol
 
 You may see this error if you are testing your app locally and the ASP.NET Core HTTPS development certificate is not trusted. For instructions to fix this issue, see [Trust the ASP.NET Core HTTPS development certificate on Windows and macOS](xref:security/enforcing-ssl#trust-the-aspnet-core-https-development-certificate-on-windows-and-macos).
 
-If you are calling a gRPC service on another machine and are unable to trust the certificate then the gRPC client can be configured to ignore the invalid certificate. The following code shows how to configure the .NET gRPC client to allow calls without a trusted certificate using [HttpClientHandler.ServerCertificateCustomValidationCallback](/dotnet/api/system.net.http.httpclienthandler.servercertificatecustomvalidationcallback):
+If you are calling a gRPC service on another machine and are unable to trust the certificate then the gRPC client can be configured to ignore the invalid certificate. The following code uses [HttpClientHandler.ServerCertificateCustomValidationCallback](/dotnet/api/system.net.http.httpclienthandler.servercertificatecustomvalidationcallback) to allow calls without a trusted certificate:
 
 ```csharp
 var httpClientHandler = new HttpClientHandler();

--- a/aspnetcore/grpc/troubleshoot.md
+++ b/aspnetcore/grpc/troubleshoot.md
@@ -48,7 +48,7 @@ The .NET gRPC client requires the service to have a valid certificate for calls 
 > Unhandled exception. System.Net.Http.HttpRequestException: The SSL connection could not be established, see inner exception.
 > ---> System.Security.Authentication.AuthenticationException: The remote certificate is invalid according to the validation procedure.
 
-You may see this error if you are testing your app on your machine and the ASP.NET Core HTTPS development certificate is not trusted. To trust the HTTP development certificate on your local machine, see [Trust the ASP.NET Core HTTPS development certificate on Windows and macOS](xref:security/enforcing-ssl#trust-the-aspnet-core-https-development-certificate-on-windows-and-macos).
+You may see this error if you are testing your app locally and the ASP.NET Core HTTPS development certificate is not trusted. For instructions to fix this issue, see [Trust the ASP.NET Core HTTPS development certificate on Windows and macOS](xref:security/enforcing-ssl#trust-the-aspnet-core-https-development-certificate-on-windows-and-macos).
 
 Alternatively, you can configure the .NET gRPC client to allow calls with untrusted/invalid certificates using [HttpClientHandler.ServerCertificateCustomValidationCallback](/dotnet/api/system.net.http.httpclienthandler.servercertificatecustomvalidationcallback):
 

--- a/aspnetcore/grpc/troubleshoot.md
+++ b/aspnetcore/grpc/troubleshoot.md
@@ -12,7 +12,7 @@ uid: grpc/troubleshoot
 
 By [James Newton-King](https://twitter.com/jamesnk)
 
-This document provides solutions for commonly encountered problems when developing gRPC apps on .NET.
+This document discusses commonly encountered problems when developing gRPC apps on .NET.
 
 ## Mismatch between client and service SSL/TLS configuration
 

--- a/aspnetcore/grpc/troubleshoot.md
+++ b/aspnetcore/grpc/troubleshoot.md
@@ -5,7 +5,7 @@ description: Troubleshoot errors when using gRPC on .NET Core.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: jamesnk
 ms.custom: mvc
-ms.date: 08/17/2019
+ms.date: 08/26/2019
 uid: grpc/troubleshoot
 ---
 # Troubleshoot gRPC on .NET Core

--- a/aspnetcore/grpc/troubleshoot.md
+++ b/aspnetcore/grpc/troubleshoot.md
@@ -52,7 +52,7 @@ The .NET gRPC client requires the service to have a trusted certificate. The fol
 
 You may see this error if you are testing your app locally and the ASP.NET Core HTTPS development certificate is not trusted. For instructions to fix this issue, see [Trust the ASP.NET Core HTTPS development certificate on Windows and macOS](xref:security/enforcing-ssl#trust-the-aspnet-core-https-development-certificate-on-windows-and-macos).
 
-The following code shows how to configure the .NET gRPC client to allow calls without a trusted certificate using [HttpClientHandler.ServerCertificateCustomValidationCallback](/dotnet/api/system.net.http.httpclienthandler.servercertificatecustomvalidationcallback):
+If you are calling a gRPC service on another machine and are unable to trust the certificate then the gRPC client can be configured to ignore the invalid certificate. The following code shows how to configure the .NET gRPC client to allow calls without a trusted certificate using [HttpClientHandler.ServerCertificateCustomValidationCallback](/dotnet/api/system.net.http.httpclienthandler.servercertificatecustomvalidationcallback):
 
 ```csharp
 var httpClientHandler = new HttpClientHandler();
@@ -65,7 +65,7 @@ var client = GrpcClient.Create<Greeter.GreeterClient>(httpClient);
 ```
 
 > [!WARNING]
-> Hosting and calling gRPC services with untrusted certificates should only be done during app development. Production apps should always use valid certificates.
+> Untrusted certificates should only be used during app development. Production apps should always use valid certificates.
 
 ## Call insecure gRPC services with .NET Core client
 

--- a/aspnetcore/grpc/troubleshoot.md
+++ b/aspnetcore/grpc/troubleshoot.md
@@ -43,14 +43,14 @@ All gRPC client implementations support TLS. gRPC clients from other languages t
 
 ## Call a gRPC service with an untrusted/invalid certificate
 
-The .NET gRPC client requires the service to have a valid certificate by default. You'll see the following error message when you attempt to call a gRPC service with an untrusted/invalid certificate:
+The .NET gRPC client requires the service to have a valid certificate for calls to succeed. You'll see the following error message when you attempt to call a gRPC service with an untrusted/invalid certificate:
 
 > Unhandled exception. System.Net.Http.HttpRequestException: The SSL connection could not be established, see inner exception.
 > ---> System.Security.Authentication.AuthenticationException: The remote certificate is invalid according to the validation procedure.
 
-When developing your application locally, you may see this error if the ASP.NET Core HTTPS development certificate is not trusted. For instructions to trust the HTTP development certificate, see [Trust the ASP.NET Core HTTPS development certificate on Windows and macOS](xref:security/enforcing-ssl#trust-the-aspnet-core-https-development-certificate-on-windows-and-macos).
+You may see this error if you are testing your app on your machine and the ASP.NET Core HTTPS development certificate is not trusted. To trust the HTTP development certificate on your local machine, see [Trust the ASP.NET Core HTTPS development certificate on Windows and macOS](xref:security/enforcing-ssl#trust-the-aspnet-core-https-development-certificate-on-windows-and-macos).
 
-Alternatively, you can configure the .NET gRPC client to allow calls to services with untrusted/invalid certificates using [HttpClientHandler.ServerCertificateCustomValidationCallback](/dotnet/api/system.net.http.httpclienthandler.servercertificatecustomvalidationcallback):
+Alternatively, you can configure the .NET gRPC client to allow calls with untrusted/invalid certificates using [HttpClientHandler.ServerCertificateCustomValidationCallback](/dotnet/api/system.net.http.httpclienthandler.servercertificatecustomvalidationcallback):
 
 ```csharp
 var httpClientHandler = new HttpClientHandler();
@@ -58,7 +58,6 @@ var httpClientHandler = new HttpClientHandler();
 httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
 
 var httpClient = new HttpClient(httpClientHandler);
-// The port number(5001) must match the port of the gRPC server.
 httpClient.BaseAddress = new Uri("https://localhost:5001");
 var client = GrpcClient.Create<Greeter.GreeterClient>(httpClient);
 ```
@@ -72,7 +71,7 @@ Additional configuration is required to call insecure gRPC services with the .NE
 AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
 
 var httpClient = new HttpClient();
-// The port number(5000) must match the port of the gRPC server.
+// The address starts with "http://"
 httpClient.BaseAddress = new Uri("http://localhost:5000");
 var client = GrpcClient.Create<Greeter.GreeterClient>(httpClient);
 ```

--- a/aspnetcore/grpc/troubleshoot.md
+++ b/aspnetcore/grpc/troubleshoot.md
@@ -12,6 +12,8 @@ uid: grpc/troubleshoot
 
 By [James Newton-King](https://twitter.com/jamesnk)
 
+This document provides solutions for commonly encountered problems when developing gRPC apps on .NET.
+
 ## Mismatch between client and service SSL/TLS configuration
 
 The gRPC template and samples use [Transport Layer Security (TLS)](https://tools.ietf.org/html/rfc5246) to secure gRPC services by default. gRPC clients need to use a secure connection to call secured gRPC services successfully.
@@ -43,14 +45,14 @@ All gRPC client implementations support TLS. gRPC clients from other languages t
 
 ## Call a gRPC service with an untrusted/invalid certificate
 
-The .NET gRPC client requires the service to have a valid certificate for calls to succeed. You'll see the following error message when you attempt to call a gRPC service with an untrusted/invalid certificate:
+The .NET gRPC client requires the service to have a trusted certificate. The following error message is returned when calling a gRPC service without a trusted certificate:
 
 > Unhandled exception. System.Net.Http.HttpRequestException: The SSL connection could not be established, see inner exception.
 > ---> System.Security.Authentication.AuthenticationException: The remote certificate is invalid according to the validation procedure.
 
 You may see this error if you are testing your app locally and the ASP.NET Core HTTPS development certificate is not trusted. For instructions to fix this issue, see [Trust the ASP.NET Core HTTPS development certificate on Windows and macOS](xref:security/enforcing-ssl#trust-the-aspnet-core-https-development-certificate-on-windows-and-macos).
 
-Alternatively, you can configure the .NET gRPC client to allow calls with untrusted/invalid certificates using [HttpClientHandler.ServerCertificateCustomValidationCallback](/dotnet/api/system.net.http.httpclienthandler.servercertificatecustomvalidationcallback):
+The following code shows how to configure the .NET gRPC client to allow calls without a trusted certificate using [HttpClientHandler.ServerCertificateCustomValidationCallback](/dotnet/api/system.net.http.httpclienthandler.servercertificatecustomvalidationcallback):
 
 ```csharp
 var httpClientHandler = new HttpClientHandler();
@@ -61,6 +63,9 @@ var httpClient = new HttpClient(httpClientHandler);
 httpClient.BaseAddress = new Uri("https://localhost:5001");
 var client = GrpcClient.Create<Greeter.GreeterClient>(httpClient);
 ```
+
+> [!WARNING]
+> Hosting and calling gRPC services with untrusted certificates should only be done during app development. Production apps should always use valid certificates.
 
 ## Call insecure gRPC services with .NET Core client
 

--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -4,7 +4,7 @@ author: juntaoluo
 description: This tutorial shows how to create a gRPC Service and gRPC client on ASP.NET Core. Learn how to create a gRPC Service project, edit a proto file, and add a duplex streaming call.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: johluo
-ms.date: 8/23/2019
+ms.date: 8/26/2019
 uid: tutorials/grpc/grpc-start
 ---
 # Tutorial: Create a gRPC client and server in ASP.NET Core
@@ -305,6 +305,9 @@ info: Microsoft.AspNetCore.Routing.EndpointMiddleware[1]
 info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
       Request finished in 78.32260000000001ms 200 application/grpc
 ```
+
+> [!NOTE]
+> The template uses the ASP.NET Core HTTPS development certificate to secure the gRPC service. If the client fails with the message `The remote certificate is invalid according to the validation procedure.` then the development certificate is not trusted on your machine. For instructions to fix this issue, see [Trust the ASP.NET Core HTTPS development certificate on Windows and macOS](xref:security/enforcing-ssl#trust-the-aspnet-core-https-development-certificate-on-windows-and-macos).
 
 ### Next steps
 

--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -307,7 +307,7 @@ info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
 ```
 
 > [!NOTE]
-> The template uses the ASP.NET Core HTTPS development certificate to secure the gRPC service. If the client fails with the message `The remote certificate is invalid according to the validation procedure.` then the development certificate is not trusted on your machine. For instructions to fix this issue, see [Trust the ASP.NET Core HTTPS development certificate on Windows and macOS](xref:security/enforcing-ssl#trust-the-aspnet-core-https-development-certificate-on-windows-and-macos).
+> The code in this article requires the ASP.NET Core HTTPS development certificate to secure the gRPC service. If the client fails with the message `The remote certificate is invalid according to the validation procedure.`, the development certificate is not trusted. For instructions to fix this issue, see [Trust the ASP.NET Core HTTPS development certificate on Windows and macOS](xref:security/enforcing-ssl#trust-the-aspnet-core-https-development-certificate-on-windows-and-macos).
 
 ### Next steps
 


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore.Docs/issues/13552

Addresses https://github.com/grpc/grpc-dotnet/issues/476

[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/grpc/troubleshoot?view=aspnetcore-3.0&branch=pr-en-us-14010)
[Note:The template uses the ASP.NET Core HTTPS development certificat](https://review.docs.microsoft.com/en-us/aspnet/core/tutorials/grpc/grpc-start?view=aspnetcore-3.0&branch=pr-en-us-14010&tabs=visual-studio#next-steps)
