### PR TITLE
Fix names of On init functions to correct names

### DIFF
--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -642,19 +642,19 @@ Ensure that values used for `@key` don't clash. If clashing values are detected 
 
 ## Lifecycle methods
 
-`OnInitializedAsync` and `OnInitialized` execute code to initialize the component. To perform an asynchronous operation, use `OnInitializedAsync` and the `await` keyword on the operation:
+`OnInitAsync` and `OnInit` execute code to initialize the component. To perform an asynchronous operation, use `OnInitAsync` and the `await` keyword on the operation:
 
 ```csharp
-protected override async Task OnInitializedAsync()
+protected override async Task OnInitAsync()
 {
     await ...
 }
 ```
 
-For a synchronous operation, use `OnInitialized`:
+For a synchronous operation, use `OnInit`:
 
 ```csharp
-protected override void OnInitialized()
+protected override void OnInit()
 {
     ...
 }


### PR DESCRIPTION
in the part of Lifecycle events I fixed the names of the functions.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->