### PR TITLE
Improve cascaded values/params content

### DIFF
--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -1080,7 +1080,7 @@ Cascading parameters also enable components to collaborate across the component 
 
 The sample app has an `ITab` interface that tabs implement:
 
-[!code-cs[](common/samples/3.x/BlazorSample/UIInterfaces/ITab.cs)]
+[!code-csharp[](common/samples/3.x/BlazorSample/UIInterfaces/ITab.cs)]
 
 The `CascadingValuesParametersTabSet` component uses the `TabSet` component, which contains several `Tab` components:
 

--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -5,7 +5,7 @@ description: Learn how to create and use Razor components, including how to bind
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 08/13/2019
+ms.date: 09/02/2019
 uid: blazor/components
 ---
 # Create and use ASP.NET Core Razor components
@@ -1000,18 +1000,7 @@ For example, the sample app specifies theme information (`ThemeInfo`) in one of 
 }
 ```
 
-To make use of cascading values, components declare cascading parameters using the `[CascadingParameter]` attribute or based on a string name value:
-
-```cshtml
-<CascadingValue Value=@PermInfo Name="UserPermissions">...</CascadingValue>
-
-[CascadingParameter(Name = "UserPermissions")]
-private PermInfo Permissions { get; set; }
-```
-
-Binding with a string name value is relevant if you have multiple cascading values of the same type and need to differentiate them within the same subtree.
-
-Cascading values are bound to cascading parameters by type.
+To make use of cascading values, components declare cascading parameters using the `[CascadingParameter]` attribute. Cascading values are bound to cascading parameters by type.
 
 In the sample app, the `CascadingValuesParametersTheme` component binds the `ThemeInfo` cascading value to a cascading parameter. The parameter is used to set the CSS class for one of the buttons displayed by the component.
 
@@ -1048,6 +1037,40 @@ In the sample app, the `CascadingValuesParametersTheme` component binds the `The
     {
         currentCount++;
     }
+}
+```
+
+To cascade multiple values of the same type within the same subtree, provide a unique `Name` string to each `CascadingValue` component and its corresponding `CascadingParameter`. In the following example, two `CascadingValue` components cascade different instances of `MyCascadingParameterType` by name:
+
+```cshtml
+<CascadingValue Value=@ParentCascadeParameter1 Name="CascadeParam1">
+    ...
+</CascadingValue>
+
+<CascadingValue Value=@ParentCascadeParameter2 Name="CascadeParam2">
+    ...
+</CascadingValue>
+
+@code {
+    [Parameter]
+    public MyCascadingType ParentCascadeParameter1 { get; set; }
+    
+    [Parameter]
+    public MyCascadingType ParentCascadeParameter2 { get; set; }
+}
+```
+
+In a decendent component, the cascaded parameters receive their values from the coorosponding cascaded values in the ancestor component by name:
+
+```cshtml
+...
+
+@code {
+    [CascadingParameter(Name = "CascadeParam1")]
+    protected MyCascadingType ChildCascadeParameter1 { get; set; }
+    
+    [CascadingParameter(Name = "CascadeParam2")]
+    protected MyCascadingType ChildCascadeParameter2 { get; set; }
 }
 ```
 

--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -1060,7 +1060,7 @@ To cascade multiple values of the same type within the same subtree, provide a u
 }
 ```
 
-In a decendent component, the cascaded parameters receive their values from the coorosponding cascaded values in the ancestor component by name:
+In a descendant component, the cascaded parameters receive their values from the coorosponding cascaded values in the ancestor component by name:
 
 ```cshtml
 ...

--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -1040,7 +1040,7 @@ In the sample app, the `CascadingValuesParametersTheme` component binds the `The
 }
 ```
 
-To cascade multiple values of the same type within the same subtree, provide a unique `Name` string to each `CascadingValue` component and its corresponding `CascadingParameter`. In the following example, two `CascadingValue` components cascade different instances of `MyCascadingParameterType` by name:
+To cascade multiple values of the same type within the same subtree, provide a unique `Name` string to each `CascadingValue` component and its corresponding `CascadingParameter`. In the following example, two `CascadingValue` components cascade different instances of `MyCascadingType` by name:
 
 ```cshtml
 <CascadingValue Value=@ParentCascadeParameter1 Name="CascadeParam1">


### PR DESCRIPTION
Fixes #14102

* Move coverage to the bottom of the section because the current content breaks right into the middle of the example without naming.
* Flesh out the code example with additional detail. For example, include both the ancestor and descendant components.
* @danroth27 , does SxS place the params 'within the same subtree,' or do they need to be nested? Which way should this example compose `CascadingValue` components? ...

  #### SxS
  ```cshtml
  <CascadingValue Value=@ParentCascadeParameter1 Name="CascadeParam1">
      ...
  </CascadingValue>
  <CascadingValue Value=@ParentCascadeParameter2 Name="CascadeParam2">
      ...
  </CascadingValue>
  ```

  #### Nested
  ```cshtml
  <CascadingValue Value=@ParentCascadeParameter1 Name="CascadeParam1">
      <CascadingValue Value=@ParentCascadeParameter2 Name="CascadeParam2">
          ...
      </CascadingValue>
  </CascadingValue>
  ```

Thanks @Legends