### PR TITLE
Update gRPC sample package version to NuGet.org versions

### DIFF
--- a/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/GrpcGreeterClient.csproj
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/GrpcGreeterClient.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.8.0" />
-    <PackageReference Include="Grpc.Net.Client" Version="0.2.23-dev201908080701" />
-    <PackageReference Include="Grpc.Tools" Version="2.24.0-dev201908071006" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Net.Client" Version="0.2.23-pre1" />
+    <PackageReference Include="Grpc.Tools" Version="2.23.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Previous version numbers came from a private NuGet feed. Update sample to use publicly available versions.