### PR TITLE
Added missing word in sentence

### DIFF
--- a/aspnetcore/security/authentication/add-user-data/sample-2.2/ScaffoldingReadme.txt
+++ b/aspnetcore/security/authentication/add-user-data/sample-2.2/ScaffoldingReadme.txt
@@ -8,7 +8,7 @@ If your app was previously configured to use Identity, then you should remove th
 The generated UI requires support for static files. To add static files to your app:
 1. Call app.UseStaticFiles() from your Configure method
 
-To use ASP.NET Core Identity you also need to enable authentication. To authentication to your app:
+To use ASP.NET Core Identity you also need to enable authentication. To add authentication to your app:
 1. Call app.UseAuthentication() from your Configure method (after static files)
 
 The generated UI requires MVC. To add MVC to your app:


### PR DESCRIPTION
The word "add" was missing from a sentence in the ScaffoldingReadme.txt file.
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->