### PR TITLE
Ensure VS Code doesn't trim significant whitespace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "omnisharp.autoStart": false
+    "omnisharp.autoStart": false,
+    "[markdown]": {
+        "files.trimTrailingWhitespace": false
+    },
 }


### PR DESCRIPTION
"files.trimTrailingWhitespace" already defaults to false in VS Code, but some people like me might have this configured to true in their user setting.

See https://github.com/aspnet/AspNetCore.Docs/pull/13844/files#r321423599