### PR TITLE
Call out the URL for Windows Service sample app

### DIFF
--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -5,7 +5,7 @@ description: Learn how to host an ASP.NET Core app in a Windows Service.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 06/03/2019
+ms.date: 09/09/2019
 uid: host-and-deploy/windows-service
 ---
 # Host ASP.NET Core in a Windows Service
@@ -306,15 +306,17 @@ To handle <xref:Microsoft.AspNetCore.Hosting.WindowsServices.WebHostService.OnSt
 
 Services that interact with requests from the Internet or a corporate network and are behind a proxy or load balancer might require additional configuration. For more information, see <xref:host-and-deploy/proxy-load-balancer>.
 
-## Configure HTTPS
+## Configure endpoints
 
-To configure a service with a secure endpoint:
+By default, ASP.NET Core binds to `http://localhost:5000`. Configure the URL and port by setting the `ASPNETCORE_URLS` environment variable.
 
-1. Create an X.509 certificate for the hosting system using your platform's certificate acquisition and deployment mechanisms.
+For additional URL and port configuration approaches, including support for HTTPS endpoints, see the following topics:
 
-1. Specify a [Kestrel server HTTPS endpoint configuration](xref:fundamentals/servers/kestrel#endpoint-configuration) to use the certificate.
+* <xref:fundamentals/servers/kestrel#endpoint-configuration> (Kestrel)
+* <xref:fundamentals/servers/httpsys#configure-windows-server> (HTTP.sys)
 
-Use of the ASP.NET Core HTTPS development certificate to secure a service endpoint isn't supported.
+> [!NOTE]
+> Use of the ASP.NET Core HTTPS development certificate to secure a service endpoint isn't supported.
 
 ## Current directory and content root
 

--- a/aspnetcore/host-and-deploy/windows-service/samples/2.x/AspNetCoreService/README.md
+++ b/aspnetcore/host-and-deploy/windows-service/samples/2.x/AspNetCoreService/README.md
@@ -1,3 +1,5 @@
-# ASP.NET Core Windows Service Sample (Framework-dependent Deployment)
+# ASP.NET Core Windows Service Sample
 
 This sample shows how to host an ASP.NET Core app as a Windows Service without using IIS. This sample demonstrates the scenario described in [Host ASP.NET Core in a Windows Service](https://docs.microsoft.com/aspnet/core/host-and-deploy/windows-service).
+
+After establishing and starting the service, access the app in a browser at `http://localhost:5000/`.

--- a/aspnetcore/host-and-deploy/windows-service/samples/3.x/AspNetCoreService/README.md
+++ b/aspnetcore/host-and-deploy/windows-service/samples/3.x/AspNetCoreService/README.md
@@ -1,3 +1,5 @@
-# ASP.NET Core Windows Service Sample (Framework-dependent Deployment)
+# ASP.NET Core Windows Service Sample
 
 This sample shows how to host an ASP.NET Core app as a Windows Service without using IIS. This sample demonstrates the scenario described in [Host ASP.NET Core in a Windows Service](https://docs.microsoft.com/aspnet/core/host-and-deploy/windows-service).
+
+After establishing and starting the service, access the app in a browser at `http://localhost:5000/`.

--- a/aspnetcore/host-and-deploy/windows-service/samples/3.x/AspNetCoreService/appsettings.json
+++ b/aspnetcore/host-and-deploy/windows-service/samples/3.x/AspNetCoreService/appsettings.json
@@ -1,7 +1,9 @@
 ﻿{
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
     }
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
Fixes #14193

* Calls out the default URL (http://localhost:5000) in the sample apps' *README.md* files.
* Slight touch to *appsettings.json* to mirror what the `worker` template app does.
* I suppose that `AllowedHosts` in the settings file is ok given that this is a web app service and Host Filtering Middleware would work here if added. Let me know if you'd like that 🔪 out of here.