### PR TITLE
Blazor chained bind

### DIFF
--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -513,17 +513,14 @@ Prefer the strongly typed `EventCallback<T>` over `EventCallback`. `EventCallbac
 
 ## Chained bind
 
-A common scenario when creating nested components is the desire to bind a property:
+A common scenario is chaining a data-bound parameter to a page element in the component's output. This scenario is called a *chained bind* because multiple levels of binding occur simultaneously.
 
-* To a page element in a component.
-* Across nested components.
-
-This scenario is called a *chained bind* because multiple levels of binding occur simultaneously.
+Chained bind can't be implemented with `@bind` syntax in the page's element. Chained bind is created using the property with an event handler. A parent component can use `@bind` syntax with the parameter.
 
 The following `PasswordField` component (*PasswordField.razor*):
 
-* Binds an `<input>` element to a `Password` property.
-* Exposes the `Password` property to a parent component with an [EventCallback](#eventcallback).
+* Sets an `<input>` element's value to a `Password` property.
+* Exposes changes of the `Password` property to a parent component with an [EventCallback](#eventcallback).
 
 ```cshtml
 Password: 

--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -515,7 +515,7 @@ Prefer the strongly typed `EventCallback<T>` over `EventCallback`. `EventCallbac
 
 A common scenario is chaining a data-bound parameter to a page element in the component's output. This scenario is called a *chained bind* because multiple levels of binding occur simultaneously.
 
-Chained bind can't be implemented with `@bind` syntax in the page's element. Chained bind is created using the property with an event handler. A parent component can use `@bind` syntax with the parameter.
+A chained bind can't be implemented with `@bind` syntax in the page's element. The event handler and value must be specified separately. A parent component, however, can use `@bind` syntax with the component's parameter.
 
 The following `PasswordField` component (*PasswordField.razor*):
 
@@ -567,12 +567,12 @@ The `PasswordField` component is used in another component:
 }
 ```
 
-If you need to perform checks or trap errors on the password in the preceding example:
+To perform checks or trap errors on the password in the preceding example:
 
 * Create a backing field for `Password` (`password` in the following example code).
 * Perform the checks or trap errors in the `Password` setter.
 
-The following example instantly provides feedback to the user if a space is provided anywhere in the password's value:
+The following example provides immediate feedback to the user if a space is used in the password's value:
 
 ```cshtml
 Password: 


### PR DESCRIPTION
Fixes #14144

[Internal Review Topic (direct link to the new *Chained bind* section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/components?view=aspnetcore-3.0&branch=pr-en-us-14215#chained-bind)

The *chained bind concept* and *checking values with the property's setter concept* seem to me to be *two different things*. One doesn't need to perform any checking if they're just binding to an element and binding across nested components. Therefore, what I do here is cover chained bind first. Get that basic idea out of the way. Then, I expand upon chained bind with a check for spaces in the password value in a second example. This 🤠 *Texas Two-step* 🤠 makes sense to me because it avoids complexity when explaining the basic concept while not losing the great example of checking values simultaneously in the child component.

I made a few (I hope simplifying) changes. Does anything fall into the *RexHacks*:tm: 🤦‍♂ category?

@epsitec, do you want to :eyes: this and comment on it? Also, I was curious about what sort of check(s) you performed on your password?

Note-to-self after chatting with @Legends: When this makes its way into the sample app (later), we might want to put a button in the parent that changes the value of the `password` field (just use a hardcoded value in a method) to show the two-way binding aspect. It could even be as simple as a **Clear password** button that does a `password = string.Empty()` in the parent.