### PR TITLE
Change how the tool is launched

### DIFF
--- a/aspnetcore/web-api/http-repl.md
+++ b/aspnetcore/web-api/http-repl.md
@@ -49,24 +49,24 @@ A [.NET Core Global Tool](/dotnet/core/tools/global-tools#install-a-global-tool)
 After successful installation of the tool, run the following command to start the HTTP REPL:
 
 ```console
-dotnet httprepl
+httprepl
 ```
 
 To view the available HTTP REPL commands, run one of the following commands:
 
 ```console
-dotnet httprepl -h
+httprepl -h
 ```
 
 ```console
-dotnet httprepl --help
+httprepl --help
 ```
 
 The following output is displayed:
 
 ```console
 Usage:
-  dotnet httprepl [<BASE_ADDRESS>] [options]
+  httprepl [<BASE_ADDRESS>] [options]
 
 Arguments:
   <BASE_ADDRESS> - The initial base address for the REPL.
@@ -125,13 +125,13 @@ The HTTP REPL offers command completion. Pressing the <kbd>Tab</kbd> key iterate
 Connect to a web API by running the following command:
 
 ```console
-dotnet httprepl <ROOT URI>
+httprepl <ROOT URI>
 ```
 
 `<ROOT URI>` is the base URI for the web API. For example:
 
 ```console
-dotnet httprepl https://localhost:5001
+httprepl https://localhost:5001
 ```
 
 Alternatively, run the following command at any time while the HTTP REPL is running:
@@ -922,7 +922,7 @@ If you frequently execute the same set of HTTP REPL commands, consider storing t
 To remove all output written to the command shell by the HTTP REPL tool, run the `clear` or `cls` command. To illustrate, imagine the command shell contains the following output:
 
 ```console
-dotnet httprepl https://localhost:5001
+httprepl https://localhost:5001
 (Disconnected)~ set base "https://localhost:5001"
 Using swagger metadata from https://localhost:5001/swagger/v1/swagger.json
 


### PR DESCRIPTION
With https://github.com/dotnet/HttpRepl/pull/223, we changed the name of the tool from `dotnet-httprepl` to `httprepl`. This changes the way the tool is executed from `dotnet httprepl` (or `dotnet-httprepl`, though that wasn't used in the docs) to just `httprepl`.
This PR updates the docs to reflect that change.
