### PR TITLE
constructing AuthorizationPolicyBuilder without parameters leads to exceptions

### DIFF
--- a/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
+++ b/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
@@ -86,6 +86,7 @@ When using `MinimumAgeAuthorizationAttribute`, the authorization policy names wi
 
 * Parsing the age from the policy name.
 * Using `AuthorizationPolicyBuilder` to create a new `AuthorizationPolicy`
+* In this and following examples it will be assumed that the user is authenticated via a cookie. The `AuthorizationPolicyBuilder` should either be constructed with at least one authorization scheme name or always succeed. Otherwise there is no information on how to provide a challenge to the user and an exception will be thrown.
 * Adding requirements to the policy based on the age with `AuthorizationPolicyBuilder.AddRequirements`. In other scenarios, you might use `RequireClaim`, `RequireRole`, or `RequireUserName` instead.
 
 ```csharp
@@ -102,7 +103,7 @@ internal class MinimumAgePolicyProvider : IAuthorizationPolicyProvider
         if (policyName.StartsWith(POLICY_PREFIX, StringComparison.OrdinalIgnoreCase) &&
             int.TryParse(policyName.Substring(POLICY_PREFIX.Length), out var age))
         {
-            var policy = new AuthorizationPolicyBuilder();
+            var policy = new AuthorizationPolicyBuilder(CookieAuthenticationDefaults.AuthenticationScheme);
             policy.AddRequirements(new MinimumAgeRequirement(age));
             return Task.FromResult(policy.Build());
         }
@@ -149,7 +150,7 @@ In many cases, this authorization attribute only requires an authenticated user,
 
 ```csharp
 public Task<AuthorizationPolicy> GetDefaultPolicyAsync() => 
-    Task.FromResult(new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build());
+    Task.FromResult(new AuthorizationPolicyBuilder(CookieAuthenticationDefaults.AuthenticationScheme).RequireAuthenticatedUser().Build());
 ```
 
 As with all aspects of a custom `IAuthorizationPolicyProvider`, you can customize this, as needed. In some cases, it may be desirable to retrieve the default policy from a fallback `IAuthorizationPolicyProvider`.


### PR DESCRIPTION

Fixes https://github.com/aspnet/AspNetCore.Docs/issues/14231
