### PR TITLE
Use RedirectToPage after SignOutAsync as per current Identity UI.

### DIFF
--- a/aspnetcore/security/authentication/identity.md
+++ b/aspnetcore/security/authentication/identity.md
@@ -207,7 +207,7 @@ The **Log out** link invokes the `LogoutModel.OnPost` action.
 
 [!code-csharp[](identity/sample/WebApp1/Areas/Identity/Pages/Account/Logout.cshtml.cs)]
 
-[SignOutAsync](/dotnet/api/microsoft.aspnetcore.identity.signinmanager-1.signoutasync#Microsoft_AspNetCore_Identity_SignInManager_1_SignOutAsync) clears the user's claims stored in a cookie. Don't redirect after calling `SignOutAsync` or the user will **not** be signed out.
+[SignOutAsync](/dotnet/api/microsoft.aspnetcore.identity.signinmanager-1.signoutasync#Microsoft_AspNetCore_Identity_SignInManager_1_SignOutAsync) clears the user's claims stored in a cookie.
 
 Post is specified in the *Pages/Shared/_LoginPartial.cshtml*:
 

--- a/aspnetcore/security/authentication/identity/sample/WebApp1/Areas/Identity/Pages/Account/Logout.cshtml.cs
+++ b/aspnetcore/security/authentication/identity/sample/WebApp1/Areas/Identity/Pages/Account/Logout.cshtml.cs
@@ -33,7 +33,9 @@ namespace WebApp1.Areas.Identity.Pages.Account
             }
             else
             {
-                return Page();
+                // This needs to be a redirect so that the browser performs a new
+                // request and the identity for the user gets updated.
+                return RedirectToPage();
             }
         }
     }


### PR DESCRIPTION
Fixes #14255.

The comment that comes in with the code update explains the need for a redirect, so I elected to remove the outdated line from the docs page.