### PR TITLE
Revert OpenRegion/CloseRegion remarks

### DIFF
--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -1439,7 +1439,7 @@ This is a trivial example. In more realistic cases with complex and deeply neste
 
 * App performance suffers if sequence numbers are generated dynamically.
 * The framework can't create its own sequence numbers automatically at runtime because the necessary information doesn't exist unless it's captured at compile time.
-* Don't write long blocks of manually-implemented `RenderTreeBuilder` logic. Prefer `.razor` files and allow the compiler to deal with the sequence numbers.
+* Don't write long blocks of manually-implemented `RenderTreeBuilder` logic. Prefer `.razor` files and allow the compiler to deal with the sequence numbers. If you're unable to avoid manual `RenderTreeBuilder` logic, split long blocks of code into smaller pieces wrapped in `OpenRegion`/`CloseRegion` calls. Each region has its own separate space of sequence numbers, so you can restart from zero (or any other arbitrary number) inside each region.
 * If sequence numbers are hardcoded, the diff algorithm only requires that sequence numbers increase in value. The initial value and gaps are irrelevant. One legitimate option is to use the code line number as the sequence number, or start from zero and increase by ones or hundreds (or any preferred interval). 
 * Blazor uses sequence numbers, while other tree-diffing UI frameworks don't use them. Diffing is far faster when sequence numbers are used, and Blazor has the advantage of a compile step that deals with sequence numbers automatically for developers authoring `.razor` files.
 


### PR DESCRIPTION
Fixes #14277

Revert changes made on https://github.com/aspnet/AspNetCore.Docs/pull/12546, back when `OpenRegion`/`CloseRegion` were `private`.

https://github.com/aspnet/AspNetCore/blob/057ec9cfae1831f91f1a0e01397059b20431db7b/src/Components/Components/src/Rendering/RenderTreeBuilder.cs#L578-L597