### PR TITLE
Kestrel updates for 3.0 migration topic

### DIFF
--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn how to migrate an ASP.NET Core 2.2 project to ASP.NET Core 3.0.
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/06/2019
+ms.date: 09/16/2019
 uid: migration/22-to-30
 ---
 # Migrate from ASP.NET Core 2.2 to 3.0
@@ -51,7 +51,7 @@ This article explains how to update an existing ASP.NET Core 2.2 project to ASP.
 
 * Update the `Version` attribute on remaining `<PackageReference>` elements for `Microsoft.AspNetCore.*` packages to the current preview (for example, `3.0.0-preview5-19227-01`).
 
-  If there's no 3.0 version of a package, the package might have been deprecated in 3.0. Many of these packages are part of `Microsoft.AspNetCore.App` and shouldn't be referenced individually. For a preliminary list of packages no longer produced in 3.0, see [Stop producing packages for shared framework assemblies in 3.0 (aspnet/AspNetCore #3756)](https://github.com/aspnet/AspNetCore/issues/3756). The *shared framework* is the set of assemblies (*.dll* files) that are installed on the machine and referenced by `Microsoft.AspNetCore.App`. For more information, see [The shared framework](https://natemcmaster.com/blog/2018/08/29/netcore-primitives-2/).
+  If there isn't a 3.0 version of a package, the package might have been deprecated in 3.0. Many of these packages are part of `Microsoft.AspNetCore.App` and shouldn't be referenced individually. For a preliminary list of packages no longer produced in 3.0, see [Stop producing packages for shared framework assemblies in 3.0 (aspnet/AspNetCore #3756)](https://github.com/aspnet/AspNetCore/issues/3756). The *shared framework* is the set of assemblies (*.dll* files) that are installed on the machine and referenced by `Microsoft.AspNetCore.App`. For more information, see [The shared framework](https://natemcmaster.com/blog/2018/08/29/netcore-primitives-2/).
 
 * The assemblies for several notable components were removed from `Microsoft.AspNetCore.App` in 3.0. Add `<PackageReference>` elements if you're using APIs from packages listed in [Assemblies being removed from Microsoft.AspNetCore.App 3.0 (aspnet/AspNetCore #3755)](https://github.com/aspnet/AspNetCore/issues/3755).
 
@@ -74,6 +74,108 @@ This article explains how to update an existing ASP.NET Core 2.2 project to ASP.
 * Add [Json.NET support](#jsonnet-support).
 
 * Projects default to the [in-process hosting model](xref:host-and-deploy/aspnet-core-module#in-process-hosting-model) in ASP.NET Core 3.0 or later. You may optionally remove the `<AspNetCoreHostingModel>` property in the project file if its value is `InProcess`.
+
+## Kestrel
+
+### Configuration
+
+Migrate Kestrel configuration to the web host builder provided by `ConfigureWebHostDefaults` (*Program.cs*):
+
+```csharp
+public static IHostBuilder CreateHostBuilder(string[] args) =>
+    Host.CreateDefaultBuilder(args)
+        .ConfigureWebHostDefaults(webBuilder =>
+        {
+            webBuilder.ConfigureKestrel(serverOptions =>
+            {
+                // Set properties and call methods on options
+            })
+            .UseStartup<Startup>();
+        });
+```
+
+If the app creates the host manually with `HostBuilder`, call `UseKestrel` on the web host builder in `ConfigureWebHostDefaults`:
+
+```csharp
+public static void Main(string[] args)
+{
+    var host = new HostBuilder()
+        .UseContentRoot(Directory.GetCurrentDirectory())
+        .ConfigureWebHostDefaults(webBuilder =>
+        {
+            webBuilder.UseKestrel(serverOptions =>
+            {
+                // Set properties and call methods on options
+            })
+            .UseIISIntegration()
+            .UseStartup<Startup>();
+        })
+        .Build();
+
+    host.Run();
+}
+```
+
+### Connection Middleware replaces Connection Adapters
+
+Connection Adapters (<xref:Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal.IConnectionAdapter>) has been removed from Kestrel. Replace Connection Adapters with Connection Middleware (similar to HTTP Middleware in the ASP.NET Core pipeline but for lower-level connections). HTTPS and connection logging have been moved from Connection Adapters to Connection Middleware, so those extension methods should continue to work as in previous versions of ASP.NET Core. For more information, see [the TlsFilterConnectionHandler example in the ListenOptions.Protocols section of the Kestrel article](/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-3.0#listenoptionsprotocols).
+
+### Transport abstractions moved and made public
+
+The Kestrel transport layer has been exposed as a public interface in `Connections.Abstractions`. As part of these updates:
+
+* `Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions` and associated types have been removed.
+* <xref:Microsoft.AspNetCore.Server.Kestrel.KestrelServerOptions.NoDelay> was moved from <xref:Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions> to the transport options.
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal.SchedulingMode> was removed from <xref:Microsoft.AspNetCore.Server.Kestrel.KestrelServerOptions>.
+
+For more information, see the following GitHub resources:
+
+* [Client/server networking abstractions (aspnet/AspNetCore #10308)](https://github.com/aspnet/AspNetCore/issues/10308)
+* [Implement new bedrock listener abstraction and re-plat Kestrel on top (aspnet/AspNetCore #10321)](https://github.com/aspnet/AspNetCore/pull/10321)
+
+### Kestrel Request trailer headers
+
+For apps that target earlier versions of ASP.NET Core, Kestrel adds HTTP/1.1 chunked trailer headers into the request headers collection when the request body is read to the end. This causes some concerns about ambiguity between headers and trailers, so the trailers have been moved to a new collection (`RequestTrailerExtensions`) in 3.0.
+
+HTTP/2 request trailers, which are unavailable in ASP.NET Core 2.2, are now available in 3.0 as `RequestTrailerExtensions`. New request extension methods are present to access these trailers. HTTP/2 trailers are available as soon as they're received from the client, but the client doesn't send the trailers until the entire request body has been at least buffered by the server. You may need to read the request body to free up buffer space. Trailers are always available if the request body is read to the end, as the trailers mark the end of the body.
+
+HTTP/1.1 trailers are available once the entire request body has been read.
+
+For the 3.0 release, the following `RequestTrailerExtensions` methods are available:
+
+* `GetDeclaredTrailers` &ndash; Gets the request `Trailer` header that lists which trailers to expect after the body.
+* `SupportsTrailers` &ndash; Indicates if the request supports receiving trailer headers.
+* `CheckTrailersAvailable` &ndash; Checks if the request supports trailers and if they're available to be read. This check doesn't assume that there are trailers to read; there might be no trailers to read even if `true` is returned by this method.
+* `GetTrailer` &ndash; Gets the requested trailing header from the response. Check `SupportsTrailers` before calling `GetTrailer`, or a <xref:System.NotSupportedException> may occur if the request doesn't support trailing headers.
+
+For more information, see [Put request trailers in a separate collection (aspnet/AspNetCore #10410)](https://github.com/aspnet/AspNetCore/pull/10410).
+
+### AllowSynchronousIO disabled
+
+`AllowSynchronousIO` enables or disables synchronous IO APIs, such as `HttpReqeuest.Body.Read`, `HttpResponse.Body.Write`, and `Stream.Flush`. These APIs are a source of thread starvation leading to app crashes. In 3.0, `AllowSynchronousIO` is disabled by default. For more information, see [the Synchronous IO section in the Kestrel article](/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-3.0#synchronous-io).
+
+In addition to enabling `AllowSynchronousIO` with `ConfigureKestrel`'s options, synchronous IO can also be overridden on a per-request basis as a temporary mitigation:
+
+```csharp
+var syncIOFeature = HttpContext.Features.Get<IHttpBodyControlFeature>();
+
+if (syncIOFeature != null)
+{
+    syncIOFeature.AllowSynchronousIO = true;
+}
+```
+
+If you have trouble with <xref:System.IO.TextWriter> implementations or other streams that call synchronous APIs in [Dispose](/dotnet/standard/garbage-collection/implementing-dispose), call the new <xref:System.IO.Stream.DisposeAsync*> API instead.
+
+For more information, see [[Announcement] AllowSynchronousIO disabled in all servers (aspnet/AspNetCore #7644)](https://github.com/aspnet/AspNetCore/issues/7644).
+
+### Microsoft.AspNetCore.Server.Kestrel.Https assembly removed
+
+In ASP.NET Core 2.1, the contents of *Microsoft.AspNetCore.Server.Kestrel.Https.dll* were moved to *Microsoft.AspNetCore.Server.Kestrel.Core.dll*. This was a non-breaking update using `TypeForwardedTo` attributes. For 3.0, the empty *Microsoft.AspNetCore.Server.Kestrel.Https.dll* assembly (and the NuGet package) have been removed.
+
+Libraries referencing [Microsoft.AspNetCore.Server.Kestrel.Https](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.Kestrel.Https) should update ASP.NET Core dependencies to 2.1 or later.
+
+Apps and libraries targeting ASP.NET Core 2.1 or later should remove any direct references to the [Microsoft.AspNetCore.Server.Kestrel.Https](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.Kestrel.Https) package.
 
 ## Json.NET support
 
@@ -152,7 +254,7 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
-## Update routing startup code
+## Routing startup code
 
 If an app calls `UseMvc` or `UseSignalR`, migrate the app to [Endpoint Routing](xref:fundamentals/routing) if possible. To improve Endpoint Routing compatibility with previous versions of MVC, we've reverted some of the changes in URL generation introduced in ASP.NET Core 2.2. If you experienced problems using Endpoint Routing in 2.2, expect improvements in ASP.NET Core 3.0 with the following exceptions:
 
@@ -364,6 +466,7 @@ The following example is the same as the preceding `DefaultPolicy` example but u
 public void ConfigureServices(IServiceCollection services)
 {
     ...
+
     services.AddAuthorization(options =>
     {
         options.FallbackPolicy = new AuthorizationPolicyBuilder()
@@ -420,7 +523,7 @@ public void Configure(IApplicationBuilder app)
 
 Protection is implemented for some scenarios. `UseEndpoint` middleware throws an exception if an authorization or CORS policy is skipped due to missing middleware. Analyzer support to provide additional feedback about misconfiguration is in progress.
 
-### Migrate SignalR
+### SignalR
 
 Mapping of SignalR hubs now takes place inside `UseEndpoints`.
 
@@ -453,7 +556,7 @@ services.AddSignalR(hubOptions =>
 
 In ASP.NET Core 2.2, you could set the `TransportMaxBufferSize` and that would effectively control the maximum message size. In ASP.NET Core 3.0, that option now only controls the maximum size before backpressure is observed.
 
-### Migrate MVC controllers
+### MVC controllers
 
 Mapping of controllers now takes place inside `UseEndpoints`.
 
@@ -492,7 +595,7 @@ public void Configure(IApplicationBuilder app)
 }
 ```
 
-### Migrate Razor Pages
+### Razor Pages
 
 Mapping Razor Pages now takes place inside `UseEndpoints`.
 
@@ -537,7 +640,7 @@ services.AddControllersWithViews(options => options.EnableEndpointRouting = fals
 services.AddRazorPages().AddMvcOptions(options => options.EnableEndpointRouting = false);
 ```
 
-### Migrate health checks
+### Health checks
 
 Health checks can be used as a *router-ware* with Endpoint Routing.
 
@@ -592,7 +695,7 @@ Apps that are not using *Microsoft.AspNetCore.Authorization.Policy.dll* should d
 
 For more information, see [Breaking change in `AddAuthorization(o =>`) overload lives in a different assembly #386](https://github.com/aspnet/Announcements/issues/386).
 
-## Update SignalR code
+## SignalR code
 
 `System.Text.Json` is now the default Hub Protocol used by both the client and server.
 

--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -139,8 +139,6 @@ For apps that target earlier versions of ASP.NET Core, Kestrel adds HTTP/1.1 chu
 
 HTTP/2 request trailers, which are unavailable in ASP.NET Core 2.2, are now available in 3.0 as `RequestTrailerExtensions`. New request extension methods are present to access these trailers. As with HTTP/1.1, trailers are available after the request body is read to the end.
 
-HTTP/1.1 trailers are available once the entire request body has been read.
-
 For the 3.0 release, the following `RequestTrailerExtensions` methods are available:
 
 * `GetDeclaredTrailers` &ndash; Gets the request `Trailer` header that lists which trailers to expect after the body.

--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -118,7 +118,12 @@ public static void Main(string[] args)
 
 ### Connection Middleware replaces Connection Adapters
 
-Connection Adapters (<xref:Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal.IConnectionAdapter>) has been removed from Kestrel. Replace Connection Adapters with Connection Middleware (similar to HTTP Middleware in the ASP.NET Core pipeline but for lower-level connections). HTTPS and connection logging have been moved from Connection Adapters to Connection Middleware, so those extension methods should continue to work as in previous versions of ASP.NET Core. For more information, see [the TlsFilterConnectionHandler example in the ListenOptions.Protocols section of the Kestrel article](/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-3.0#listenoptionsprotocols).
+Connection Adapters (<xref:Microsoft.AspNetCore.Server.Kestrel.Core.Adapter.Internal.IConnectionAdapter>) have been removed from Kestrel. Replace Connection Adapters with Connection Middleware. Connection Middleware is similar to HTTP Middleware in the ASP.NET Core pipeline but for lower-level connections. HTTPS and connection logging:
+
+* Have been moved from Connection Adapters to Connection Middleware.
+* These extension methods work as in previous versions of ASP.NET Core. 
+
+For more information, see [the TlsFilterConnectionHandler example in the ListenOptions.Protocols section of the Kestrel article](/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-3.0#listenoptionsprotocols).
 
 ### Transport abstractions moved and made public
 
@@ -135,15 +140,25 @@ For more information, see the following GitHub resources:
 
 ### Kestrel Request trailer headers
 
-For apps that target earlier versions of ASP.NET Core, Kestrel adds HTTP/1.1 chunked trailer headers into the request headers collection when the request body is read to the end. This causes some concerns about ambiguity between headers and trailers, so the trailers have been moved to a new collection (`RequestTrailerExtensions`) in 3.0.
+For apps that target earlier versions of ASP.NET Core:
 
-HTTP/2 request trailers, which are unavailable in ASP.NET Core 2.2, are now available in 3.0 as `RequestTrailerExtensions`. New request extension methods are present to access these trailers. As with HTTP/1.1, trailers are available after the request body is read to the end.
+* Kestrel adds HTTP/1.1 chunked trailer headers into the request headers collection.
+* Trailers are available after the request body is read to the end.
+
+This causes some concerns about ambiguity between headers and trailers, so the trailers have been moved to a new collection (`RequestTrailerExtensions`) in 3.0.
+
+HTTP/2 request trailers are:
+
+* Not available in ASP.NET Core 2.2.
+* Available in 3.0 as `RequestTrailerExtensions`.
+
+New request extension methods are present to access these trailers. As with HTTP/1.1, trailers are available after the request body is read to the end.
 
 For the 3.0 release, the following `RequestTrailerExtensions` methods are available:
 
 * `GetDeclaredTrailers` &ndash; Gets the request `Trailer` header that lists which trailers to expect after the body.
 * `SupportsTrailers` &ndash; Indicates if the request supports receiving trailer headers.
-* `CheckTrailersAvailable` &ndash; Checks if the request supports trailers and if they're available to be read. This check doesn't assume that there are trailers to read; there might be no trailers to read even if `true` is returned by this method.
+* `CheckTrailersAvailable` &ndash; Checks if the request supports trailers and if they're available to be read. This check doesn't assume that there are trailers to read. There might be no trailers to read even if `true` is returned by this method.
 * `GetTrailer` &ndash; Gets the requested trailing header from the response. Check `SupportsTrailers` before calling `GetTrailer`, or a <xref:System.NotSupportedException> may occur if the request doesn't support trailing headers.
 
 For more information, see [Put request trailers in a separate collection (aspnet/AspNetCore #10410)](https://github.com/aspnet/AspNetCore/pull/10410).

--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -137,7 +137,7 @@ For more information, see the following GitHub resources:
 
 For apps that target earlier versions of ASP.NET Core, Kestrel adds HTTP/1.1 chunked trailer headers into the request headers collection when the request body is read to the end. This causes some concerns about ambiguity between headers and trailers, so the trailers have been moved to a new collection (`RequestTrailerExtensions`) in 3.0.
 
-HTTP/2 request trailers, which are unavailable in ASP.NET Core 2.2, are now available in 3.0 as `RequestTrailerExtensions`. New request extension methods are present to access these trailers. HTTP/2 trailers are available as soon as they're received from the client, but the client doesn't send the trailers until the entire request body has been at least buffered by the server. You may need to read the request body to free up buffer space. Trailers are always available if the request body is read to the end, as the trailers mark the end of the body.
+HTTP/2 request trailers, which are unavailable in ASP.NET Core 2.2, are now available in 3.0 as `RequestTrailerExtensions`. New request extension methods are present to access these trailers. As with HTTP/1.1, trailers are available after the request body is read to the end.
 
 HTTP/1.1 trailers are available once the entire request body has been read.
 

--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -326,6 +326,25 @@ public void Configure(IApplicationBuilder app)
 }
 ```
 
+### Health Checks
+
+Health Checks use endpoint routing with the Generic Host. In `Startup.Configure`, call `MapHealthChecks` on the endpoint builder with the endpoint URL or relative path:
+
+```csharp
+app.UseEndpoints(endpoints =>
+{
+    endpoints.MapHealthChecks("/health");
+});
+```
+
+Health Checks endpoints can:
+
+* Specify one or more permitted hosts/ports.
+* Require authorization.
+* Require CORS.
+
+For more information, see <xref:host-and-deploy/health-checks>.
+
 ### Security middleware guidance
 
 Support for authorization and CORS is unified around the [middleware](xref:fundamentals/middleware/index) approach. This allows use of the same middleware and functionality across these scenarios. An updated authorization middleware is provided in this release, and CORS Middleware is enhanced so that it can understand the attributes used by MVC controllers.


### PR DESCRIPTION
Fixes #12923

[Internal Review Topic (direct link to Kestrel section)](https://review.docs.microsoft.com/en-us/aspnet/core/migration/22-to-30?view=aspnetcore-1.0&branch=pr-en-us-14331#kestrel)

* Removing a lot of "Migrate" and "Update" verb-y-ish-ness in headings ... a bit silly imo ... the whole topic is about *migration* and *updates*. These just cloud the heading subjects imo.
* Miss anything?
* Any :poop: coverage?
* Keep an :eye: on my namespace/package references. They're easy to :bomb:.