### PR TITLE
Use dotnetcli dev lang to colorize .NET Core CLI commands

### DIFF
--- a/aspnetcore/azure/devops/deploying-to-app-service.md
+++ b/aspnetcore/azure/devops/deploying-to-app-service.md
@@ -45,13 +45,13 @@ From a command shell, download the code, build the project, and run it as follow
 
 3. Restore the packages, and build the solution.
 
-    ```console
+    ```dotnetcli
     dotnet build
     ```
 
 4. Run the app.
 
-    ```console
+    ```dotnetcli
     dotnet run
     ```
 

--- a/aspnetcore/azure/devops/tools-and-downloads.md
+++ b/aspnetcore/azure/devops/tools-and-downloads.md
@@ -26,7 +26,7 @@ The following tools are required:
 
     Verify your .NET Core SDK installation. Open a command shell, and run the following command:
 
-    ```console
+    ```dotnetcli
     dotnet --version
     ```
 

--- a/aspnetcore/blazor/class-libraries.md
+++ b/aspnetcore/blazor/class-libraries.md
@@ -42,13 +42,13 @@ Follow the guidance in the <xref:blazor/get-started> article to configure your e
 
 1. Use the **Razor Class Library** template (`razorclasslib`) with the [dotnet new](/dotnet/core/tools/dotnet-new) command in a command shell. In the following example, an RCL is created named `MyComponentLib1`. The folder that holds `MyComponentLib1` is created automatically when the command is executed:
 
-   ```console
+   ```dotnetcli
    dotnet new razorclasslib -o MyComponentLib1
    ```
 
 1. To add the library to an existing project, use the [dotnet add reference](/dotnet/core/tools/dotnet-add-reference) command in a command shell. In the following example, the RCL is added to the app. Execute the following command from the app's project folder with the path to the library:
 
-   ```console
+   ```dotnetcli
    dotnet add reference {PATH TO LIBRARY}
    ```
 
@@ -91,13 +91,13 @@ Include the `@using MyComponentLib1` directive in the top-level *_Import.razor* 
 
 Because component libraries are standard .NET libraries, packaging and shipping them to NuGet is no different from packaging and shipping any library to NuGet. Packaging is performed using the [dotnet pack](/dotnet/core/tools/dotnet-pack) command in a command shell:
 
-```console
+```dotnetcli
 dotnet pack
 ```
 
 Upload the package to NuGet using the [dotnet nuget publish](/dotnet/core/tools/dotnet-nuget-push) command in a command shell:
 
-```console
+```dotnetcli
 dotnet nuget publish
 ```
 

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -18,7 +18,7 @@ Get started with Blazor:
 
 1. Install the Blazor templates by running the following command in a command shell:
 
-   ```console
+   ```dotnetcli
    dotnet new -i Microsoft.AspNetCore.Blazor.Templates::3.0.0-preview9.19457.4
    ```
 
@@ -49,13 +49,13 @@ Get started with Blazor:
 
    3\. For a Blazor WebAssembly experience, execute the following command in a command shell:
 
-      ```console
+      ```dotnetcli
       dotnet new blazorwasm -o WebApplication1
       ```
 
       For a Blazor Server experience, execute the following command in a command shell:
 
-      ```console
+      ```dotnetcli
       dotnet new blazorserver -o WebApplication1
       ```
 
@@ -93,7 +93,7 @@ Get started with Blazor:
 
    For a Blazor WebAssembly experience, execute the following commands in a command shell:
 
-   ```console
+   ```dotnetcli
    dotnet new blazorwasm -o WebApplication1
    cd WebApplication1
    dotnet run
@@ -101,7 +101,7 @@ Get started with Blazor:
 
    For a Blazor Server experience, execute the following commands in a command shell:
 
-   ```console
+   ```dotnetcli
    dotnet new blazorserver -o WebApplication1
    cd WebApplication1
    dotnet run

--- a/aspnetcore/client-side/bundling-and-minification.md
+++ b/aspnetcore/client-side/bundling-and-minification.md
@@ -128,19 +128,19 @@ Clean the project. The following appears in the Output window:
 
 Add the *BuildBundlerMinifier* package to your project:
 
-```console
+```dotnetcli
 dotnet add package BuildBundlerMinifier
 ```
 
 If using ASP.NET Core 1.x, restore the newly added package:
 
-```console
+```dotnetcli
 dotnet restore
 ```
 
 Build the project:
 
-```console
+```dotnetcli
 dotnet build
 ```
 
@@ -158,7 +158,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
 Clean the project:
 
-```console
+```dotnetcli
 dotnet clean
 ```
 
@@ -186,7 +186,7 @@ It's possible to run the bundling and minification tasks on an ad hoc basis, wit
 
 This package extends the .NET Core CLI to include the *dotnet-bundle* tool. The following command can be executed in the Package Manager Console (PMC) window or in a command shell:
 
-```console
+```dotnetcli
 dotnet bundle
 ```
 

--- a/aspnetcore/client-side/libman/libman-cli.md
+++ b/aspnetcore/client-side/libman/libman-cli.md
@@ -21,7 +21,7 @@ The [LibMan](xref:client-side/libman/index) CLI is a cross-platform tool that's 
 
 To install the LibMan CLI:
 
-```console
+```dotnetcli
 dotnet tool install -g Microsoft.Web.LibraryManager.Cli
 ```
 
@@ -29,7 +29,7 @@ A [.NET Core Global Tool](/dotnet/core/tools/global-tools#install-a-global-tool)
 
 To install the LibMan CLI from a specific NuGet package source:
 
-```console
+```dotnetcli
 dotnet tool install -g Microsoft.Web.LibraryManager.Cli --version 1.0.94-g606058a278 --add-source C:\Temp\
 ```
 

--- a/aspnetcore/client-side/spa-services.md
+++ b/aspnetcore/client-side/spa-services.md
@@ -213,7 +213,7 @@ JavaScript Services provide pre-configured application templates. SpaServices is
 
 These templates can be installed via the .NET Core CLI by running the following command:
 
-```console
+```dotnetcli
 dotnet new --install Microsoft.AspNetCore.SpaTemplates::*
 ```
 
@@ -227,7 +227,7 @@ A list of available SPA templates is displayed:
 
 To create a new project using one of the SPA templates, include the **Short Name** of the template in the [dotnet new](/dotnet/core/tools/dotnet-new) command. The following command creates an Angular application with ASP.NET Core MVC configured for the server side:
 
-```console
+```dotnetcli
 dotnet new angular
 ```
 
@@ -248,13 +248,13 @@ ASP.NET Core uses an environment variable named `ASPNETCORE_ENVIRONMENT` to stor
 
 Restore the required NuGet and npm packages by running the following command at the project root:
 
-```console
+```dotnetcli
 dotnet restore && npm i
 ```
 
 Build and run the application:
 
-```console
+```dotnetcli
 dotnet run
 ```
 
@@ -297,7 +297,7 @@ The MSBuild target has the following responsibilities:
 
 The MSBuild target is invoked when running:
 
-```console
+```dotnetcli
 dotnet publish -c Release
 ```
 

--- a/aspnetcore/client-side/spa/angular.md
+++ b/aspnetcore/client-side/spa/angular.md
@@ -20,7 +20,7 @@ If you have ASP.NET Core 2.1 installed, there's no need to install the Angular p
 
 Create a new project from a command prompt using the command `dotnet new angular` in an empty directory. For example, the following commands create the app in a *my-new-app* directory and switch to that directory:
 
-```console
+```dotnetcli
 dotnet new angular -o my-new-app
 cd my-new-app
 ```

--- a/aspnetcore/client-side/spa/react.md
+++ b/aspnetcore/client-side/spa/react.md
@@ -20,7 +20,7 @@ If you have ASP.NET Core 2.1 installed, there's no need to install the React pro
 
 Create a new project from a command prompt using the command `dotnet new react` in an empty directory. For example, the following commands create the app in a *my-new-app* directory and switch to that directory:
 
-```console
+```dotnetcli
 dotnet new react -o my-new-app
 cd my-new-app
 ```

--- a/aspnetcore/data/ef-mvc/advanced.md
+++ b/aspnetcore/data/ef-mvc/advanced.md
@@ -230,7 +230,7 @@ To delete a database in SSOX, right-click the database, click **Delete**, and th
 
 To delete a database by using the CLI, run the `database drop` CLI command:
 
-```console
+```dotnetcli
 dotnet ef database drop
 ```
 

--- a/aspnetcore/data/ef-mvc/complex-data-model.md
+++ b/aspnetcore/data/ef-mvc/complex-data-model.md
@@ -93,11 +93,11 @@ The database model has now changed in a way that requires a change in the databa
 
 Save your changes and build the project. Then open the command window in the project folder and enter the following commands:
 
-```console
+```dotnetcli
 dotnet ef migrations add MaxLengthOnNames
 ```
 
-```console
+```dotnetcli
 dotnet ef database update
 ```
 
@@ -121,11 +121,11 @@ The addition of the `Column` attribute changes the model backing the `SchoolCont
 
 Save your changes and build the project. Then open the command window in the project folder and enter the following commands to create another migration:
 
-```console
+```dotnetcli
 dotnet ef migrations add ColumnFirstName
 ```
 
-```console
+```dotnetcli
 dotnet ef database update
 ```
 
@@ -429,7 +429,7 @@ As you saw in the first tutorial, most of this code simply creates new entity ob
 
 Save your changes and build the project. Then open the command window in the project folder and enter the `migrations add` command (don't do the update-database command yet):
 
-```console
+```dotnetcli
 dotnet ef migrations add ComplexDataModel
 ```
 
@@ -478,7 +478,7 @@ Save your change to *appsettings.json*.
 > [!NOTE]
 > As an alternative to changing the database name, you can delete the database. Use **SQL Server Object Explorer** (SSOX) or the `database drop` CLI command:
 >
-> ```console
+> ```dotnetcli
 > dotnet ef database drop
 > ```
 
@@ -486,7 +486,7 @@ Save your change to *appsettings.json*.
 
 After you have changed the database name or deleted the database, run the `database update` command in the command window to execute the migrations.
 
-```console
+```dotnetcli
 dotnet ef database update
 ```
 

--- a/aspnetcore/data/ef-mvc/concurrency.md
+++ b/aspnetcore/data/ef-mvc/concurrency.md
@@ -111,11 +111,11 @@ By adding a property you changed the database model, so you need to do another m
 
 Save your changes and build the project, and then enter the following commands in the command window:
 
-```console
+```dotnetcli
 dotnet ef migrations add RowVersion
 ```
 
-```console
+```dotnetcli
 dotnet ef database update
 ```
 

--- a/aspnetcore/data/ef-mvc/inheritance.md
+++ b/aspnetcore/data/ef-mvc/inheritance.md
@@ -88,7 +88,7 @@ This is all that the Entity Framework needs in order to configure table-per-hier
 
 Save your changes and build the project. Then open the command window in the project folder and enter the following command:
 
-```console
+```dotnetcli
 dotnet ef migrations add Inheritance
 ```
 
@@ -122,7 +122,7 @@ This code takes care of the following database update tasks:
 
 Run the `database update` command:
 
-```console
+```dotnetcli
 dotnet ef database update
 ```
 

--- a/aspnetcore/data/ef-mvc/migrations.md
+++ b/aspnetcore/data/ef-mvc/migrations.md
@@ -46,7 +46,7 @@ This change sets up the project so that the first migration will create a new da
 > [!NOTE]
 > As an alternative to changing the database name, you can delete the database. Use **SQL Server Object Explorer** (SSOX) or the `database drop` CLI command:
 >
-> ```console
+> ```dotnetcli
 > dotnet ef database drop
 > ```
 >
@@ -66,7 +66,7 @@ Save your changes and build the project. Then open a command window and navigate
 
 Enter the following command in the command window:
 
-```console
+```dotnetcli
 dotnet ef migrations add InitialCreate
 ```
 
@@ -107,7 +107,7 @@ See [EF Core Migrations in Team Environments](/ef/core/managing-schemas/migratio
 
 In the command window, enter the following command to create the database and tables in it.
 
-```console
+```dotnetcli
 dotnet ef database update
 ```
 

--- a/aspnetcore/data/ef-rp/complex-data-model.md
+++ b/aspnetcore/data/ef-rp/complex-data-model.md
@@ -192,7 +192,7 @@ SqliteException: SQLite Error 1: 'no such column: s.FirstName'.
 
 * Open a command window in the project folder. Enter the following commands to create a new migration and update the database:
 
-  ```console
+  ```dotnetcli
   dotnet ef migrations add ColumnFirstName
   dotnet ef database update
   ```
@@ -208,7 +208,7 @@ For this tutorial, the way to get past this error is to delete and re-create the
 * Delete the *Migrations* folder.
 * Run the following commands to drop the database, create a new initial migration, and apply the migration:
 
-  ```console
+  ```dotnetcli
   dotnet ef database drop --force
   dotnet ef migrations add InitialCreate
   dotnet ef database update
@@ -607,13 +607,13 @@ To force EF Core to create a new database, drop and update the database:
 
 * Run the following command:
 
-  ```console
+  ```dotnetcli
   dotnet ef database drop --force
   ```
 
 * Delete the *Migrations* folder, then run the following command:
 
-  ```console
+  ```dotnetcli
   dotnet ef migrations add InitialCreate
   dotnet ef database update
   ```
@@ -701,7 +701,7 @@ Because the `DbInitializer.Initialize` method is designed to work only with an e
 
 * If you're using SQL Server LocalDB with Visual Studio Code, run the following command:
 
-  ```console
+  ```dotnetcli
   dotnet ef database update
   ```
 
@@ -836,7 +836,7 @@ Update-Database
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
-```console
+```dotnetcli
 dotnet ef migrations add ColumnFirstName
 dotnet ef database update
 ```
@@ -1244,13 +1244,13 @@ Build the project.
 
 # [Visual Studio](#tab/visual-studio)
 
-```PMC
+```powershell
 Add-Migration ComplexDataModel
 ```
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
-```console
+```dotnetcli
 dotnet ef migrations add ComplexDataModel
 ```
 
@@ -1301,10 +1301,10 @@ Open a command window and navigate to the project folder. The project folder con
 
 Enter the following in the command window:
 
- ```console
- dotnet ef database drop
+```dotnetcli
+dotnet ef database drop
 dotnet ef database update
- ```
+```
 
 ---
 

--- a/aspnetcore/data/ef-rp/concurrency.md
+++ b/aspnetcore/data/ef-rp/concurrency.md
@@ -150,7 +150,7 @@ Build the project.
 
 * Run the following command in a terminal:
 
-  ```console
+  ```dotnetcli
   dotnet ef migrations add RowVersion
   ```
 
@@ -184,7 +184,7 @@ This command:
 
 * Run the following command in a terminal:
 
-  ```console
+  ```dotnetcli
   dotnet ef database update
   ```
 
@@ -210,13 +210,13 @@ This command:
 
   **On Windows:**
 
-  ```console
+  ```dotnetcli
   dotnet aspnet-codegenerator razorpage -m Department -dc SchoolContext -udl -outDir Pages\Departments --referenceScriptLibraries
   ```
 
   **On Linux or macOS:**
 
-  ```console
+  ```dotnetcli
   dotnet aspnet-codegenerator razorpage -m Department -dc SchoolContext -udl -outDir Pages/Departments --referenceScriptLibraries
   ```
 
@@ -488,7 +488,7 @@ Adding the `RowVersion` property changes the DB model, which requires a migratio
 
 Build the project. Enter the following in a command window:
 
-```console
+```dotnetcli
 dotnet ef migrations add RowVersion
 dotnet ef database update
 ```
@@ -514,7 +514,7 @@ Follow the instructions in [Scaffold the student model](xref:data/ef-rp/intro#sc
 
  Run the following command:
 
-  ```console
+  ```dotnetcli
   dotnet aspnet-codegenerator razorpage -m Department -dc SchoolContext -udl -outDir Pages\Departments --referenceScriptLibraries
   ```
 

--- a/aspnetcore/data/ef-rp/intro.md
+++ b/aspnetcore/data/ef-rp/intro.md
@@ -81,7 +81,7 @@ To run the app after downloading the completed project:
 * Build the project.
 * At a command prompt in the project folder, run the following commands:
 
-  ```console
+  ```dotnetcli
   dotnet tool install --global dotnet-ef --version 3.0.0-*
   dotnet ef database update
   ```
@@ -111,7 +111,7 @@ To run the app after downloading the completed project:
 
 * Run the following commands to create a Razor Pages project and `cd` into the new project folder:
 
-  ```console
+  ```dotnetcli
   dotnet new webapp -o ContosoUniversity
   cd ContosoUniversity
   ```
@@ -223,7 +223,7 @@ The following packages are automatically installed:
 
 * Run the following .NET Core CLI commands to install required NuGet packages:
 
-  ```console
+  ```dotnetcli
   dotnet add package Microsoft.EntityFrameworkCore.SQLite --version 3.0.0-*
   dotnet add package Microsoft.EntityFrameworkCore.SqlServer --version 3.0.0-*
   dotnet add package Microsoft.EntityFrameworkCore.Design --version 3.0.0-*
@@ -238,7 +238,7 @@ The following packages are automatically installed:
 
 * Run the following command to install the [aspnet-codegenerator scaffolding tool](xref:fundamentals/tools/dotnet-aspnet-codegenerator).
 
-  ```console
+  ```dotnetcli
   dotnet tool install --global dotnet-aspnet-codegenerator --version 3.0.0-*
   ```
 
@@ -246,13 +246,13 @@ The following packages are automatically installed:
 
   **On Windows**
 
-  ```console
+  ```dotnetcli
   dotnet aspnet-codegenerator razorpage -m Student -dc ContosoUniversity.Data.SchoolContext -udl -outDir Pages\Students --referenceScriptLibraries
   ```
 
   **On macOS or Linux**
 
-  ```console
+  ```dotnetcli
   dotnet aspnet-codegenerator razorpage -m Student -dc ContosoUniversity.Data.SchoolContext -udl -outDir Pages/Students --referenceScriptLibraries
   ```
 
@@ -495,7 +495,7 @@ Run the app.
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
-```CLI
+```dotnetcli
 dotnet new webapp -o ContosoUniversity
 cd ContosoUniversity
 dotnet run
@@ -600,7 +600,7 @@ See [Scaffold the movie model](xref:tutorials/razor-pages/model#scaffold-the-mov
 
 Run the following commands to scaffold the student model.
 
-```console
+```dotnetcli
 dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design --version 2.1.0
 dotnet tool install --global dotnet-aspnet-codegenerator
 dotnet aspnet-codegenerator razorpage -m Student -dc ContosoUniversity.Models.SchoolContext -udl -outDir Pages/Students --referenceScriptLibraries

--- a/aspnetcore/data/ef-rp/migrations.md
+++ b/aspnetcore/data/ef-rp/migrations.md
@@ -39,7 +39,7 @@ Drop-Database
 
 * Run the following command at a command prompt to install the EF CLI tools:
 
-  ```console
+  ```dotnetcli
   dotnet tool install --global dotnet-ef --version 3.0.0-*
   ```
 
@@ -47,7 +47,7 @@ Drop-Database
 
 * Delete the *CU.db* file, or run the following command:
 
-  ```console
+  ```dotnetcli
   dotnet ef database drop --force
   ```
 
@@ -68,7 +68,7 @@ Update-Database
 
 Make sure the command prompt is in the project folder, and run the following commands:
 
-```console
+```dotnetcli
 dotnet ef migrations add InitialCreate
 dotnet ef database update
 ```
@@ -187,7 +187,7 @@ Open a command window and navigate to the project folder. The project folder con
 
 Enter the following in the command window:
 
- ```console
+ ```dotnetcli
  dotnet ef database drop
  ```
 
@@ -206,7 +206,7 @@ Update-Database
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
-```console
+```dotnetcli
 dotnet ef migrations add InitialCreate
 dotnet ef database update
 ```
@@ -244,11 +244,11 @@ Remove-Migration
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
-```console
+```dotnetcli
 dotnet ef migrations remove
 ```
 
-For more information, see  [dotnet ef migrations remove](/ef/core/miscellaneous/cli/dotnet#dotnet-ef-migrations-remove).
+For more information, see [dotnet ef migrations remove](/ef/core/miscellaneous/cli/dotnet#dotnet-ef-migrations-remove).
 
 ---
 

--- a/aspnetcore/data/ef-rp/read-related-data.md
+++ b/aspnetcore/data/ef-rp/read-related-data.md
@@ -80,13 +80,13 @@ To display the name of the assigned department for a course:
 
   **On Windows:**
 
-  ```console
+  ```dotnetcli
   dotnet aspnet-codegenerator razorpage -m Course -dc SchoolContext -udl -outDir Pages\Courses --referenceScriptLibraries
   ```
 
   **On Linux or macOS:**
 
-  ```console
+  ```dotnetcli
   dotnet aspnet-codegenerator razorpage -m Course -dc SchoolContext -udl -outDir Pages/Courses --referenceScriptLibraries
   ```
 
@@ -177,13 +177,13 @@ Create *SchoolViewModels/InstructorIndexData.cs* with the following code:
 
   **On Windows:**
 
-  ```console
+  ```dotnetcli
   dotnet aspnet-codegenerator razorpage -m Instructor -dc SchoolContext -udl -outDir Pages\Instructors --referenceScriptLibraries
   ```
 
   **On Linux or macOS:**
 
-  ```console
+  ```dotnetcli
   dotnet aspnet-codegenerator razorpage -m Instructor -dc SchoolContext -udl -outDir Pages/Instructors --referenceScriptLibraries
   ```
 
@@ -385,7 +385,7 @@ Follow the instructions in [Scaffold the student model](xref:data/ef-rp/intro#sc
 
  Run the following command:
 
-  ```console
+  ```dotnetcli
   dotnet aspnet-codegenerator razorpage -m Course -dc SchoolContext -udl -outDir Pages\Courses --referenceScriptLibraries
   ```
 
@@ -472,7 +472,7 @@ Follow the instructions in [Scaffold the student model](xref:data/ef-rp/intro#sc
 
  Run the following command:
 
-  ```console
+  ```dotnetcli
   dotnet aspnet-codegenerator razorpage -m Instructor -dc SchoolContext -udl -outDir Pages\Instructors --referenceScriptLibraries
   ```
 

--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -348,7 +348,7 @@ Within the same command, don't mix command-line argument key-value pairs that us
 
 Example commands:
 
-```console
+```dotnetcli
 dotnet run CommandLineKey1=value1 --CommandLineKey2=value2 /CommandLineKey3=value3
 dotnet run --CommandLineKey1 value1 /CommandLineKey2 value2
 dotnet run CommandLineKey1= CommandLineKey2=value2
@@ -396,7 +396,7 @@ After the switch mappings dictionary is created, it contains the data shown in t
 
 If the switch-mapped keys are used when starting the app, configuration receives the configuration value on the key supplied by the dictionary:
 
-```console
+```dotnetcli
 dotnet run -CLKey1=value1 -CLKey2=value2
 ```
 

--- a/aspnetcore/fundamentals/host/hosted-services.md
+++ b/aspnetcore/fundamentals/host/hosted-services.md
@@ -43,7 +43,7 @@ The ASP.NET Core Worker Service template provides a starting point for writing l
 
 Use the Worker Service (`worker`) template with the [dotnet new](/dotnet/core/tools/dotnet-new) command from a command shell. In the following example, a Worker Service app is created named `ContosoWorkerService`. A folder for the `ContosoWorkerService` app is created automatically when the command is executed.
 
-```console
+```dotnetcli
 dotnet new worker -o ContosoWorkerService
 ```
 

--- a/aspnetcore/fundamentals/host/platform-specific-configuration.md
+++ b/aspnetcore/fundamentals/host/platform-specific-configuration.md
@@ -197,13 +197,13 @@ The hosting startup implementation is placed in the [runtime store](/dotnet/core
 
 After the hosting startup is built, a runtime store is generated using the manifest project file and the [dotnet store](/dotnet/core/tools/dotnet-store) command.
 
-```console
+```dotnetcli
 dotnet store --manifest {MANIFEST FILE} --runtime {RUNTIME IDENTIFIER} --output {OUTPUT LOCATION} --skip-optimization
 ```
 
 In the sample app (*RuntimeStore* project) the following command is used:
 
-``` console
+```dotnetcli
 dotnet store --manifest store.manifest.csproj --runtime win7-x64 --output ./deployment/store --skip-optimization
 ```
 
@@ -355,7 +355,7 @@ To run the sample:
 
 If you make changes to the *HostingStartupPackage* project and recompile it, clear the local NuGet package caches to ensure that the *HostingStartupApp* receives the updated package and not a stale package from the local cache. To clear the local NuGet caches, execute the following [dotnet nuget locals](/dotnet/core/tools/dotnet-nuget-locals) command:
 
-```console
+```dotnetcli
 dotnet nuget locals all --clear
 ```
 

--- a/aspnetcore/fundamentals/host/web-host.md
+++ b/aspnetcore/fundamentals/host/web-host.md
@@ -426,7 +426,7 @@ public class Program
 
 To specify the host run on a particular URL, the desired value can be passed in from a command prompt when executing [dotnet run](/dotnet/core/tools/dotnet-run). The command-line argument overrides the `urls` value from the *hostsettings.json* file, and the server listens on port 8080:
 
-```console
+```dotnetcli
 dotnet run --urls "http://*:8080"
 ```
 

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -778,7 +778,7 @@ logging.AddConsole();
 
 To see console logging output, open a command prompt in the project folder and run the following command:
 
-```console
+```dotnetcli
 dotnet run
 ```
 

--- a/aspnetcore/fundamentals/tools/dotnet-aspnet-codegenerator.md
+++ b/aspnetcore/fundamentals/tools/dotnet-aspnet-codegenerator.md
@@ -20,13 +20,13 @@ This article applies to [.NET Core 2.1 SDK](https://dotnet.microsoft.com/downloa
 
 `dotnet-aspnet-codegenerator` is a [global tool](/dotnet/core/tools/global-tools) that must be installed. The following command installs the latest stable version of the `dotnet-aspnet-codegenerator` tool:
 
-```console
+```dotnetcli
 dotnet tool install -g dotnet-aspnet-codegenerator
 ```
 
 The following command updates `dotnet-aspnet-codegenerator` to the latest stable version available from the installed .NET Core SDKs:
 
-```console
+```dotnetcli
 dotnet tool update -g dotnet-aspnet-codegenerator
 ```
 
@@ -132,7 +132,7 @@ The following table lists options unique to  `aspnet-codegenerator controller`:
 
 Use the `-h` switch for help on the `aspnet-codegenerator controller` command:
 
-```console
+```dotnetcli
 dotnet aspnet-codegenerator controller -h
 ```
 
@@ -153,7 +153,7 @@ Razor Pages can be individually scaffolded by specifying the name of the new pag
 
 For example, the following command uses the Edit template to generate *MyEdit.cshtml* and *MyEdit.cshtml.cs*:
 
-```console
+```dotnetcli
 dotnet aspnet-codegenerator razorpage MyEdit Edit -m Movie -dc RazorPagesMovieContext -outDir Pages/Movies
 ```
 
@@ -179,7 +179,7 @@ The following table lists options unique to  `aspnet-codegenerator razorpage`:
 
 Use the `-h` switch for help on the `aspnet-codegenerator razorpage` command:
 
-```console
+```dotnetcli
 dotnet aspnet-codegenerator razorpage -h
 ```
 

--- a/aspnetcore/getting-started/index.md
+++ b/aspnetcore/getting-started/index.md
@@ -31,7 +31,7 @@ At the end, you'll have a working web app running on your local machine.
 
 Open a command shell, and enter the following command:
 
-```console
+```dotnetcli
 dotnet new webapp -o aspnetcoreapp
 ```
 
@@ -41,7 +41,7 @@ Trust the HTTPS development certificate:
 
 # [Windows](#tab/windows)
 
-```console
+```dotnetcli
 dotnet dev-certs https --trust
 ```
 
@@ -53,7 +53,7 @@ Select **Yes** if you agree to trust the development certificate.
 
 # [macOS](#tab/macos)
 
-```console
+```dotnetcli
 dotnet dev-certs https --trust
 ```
 
@@ -77,7 +77,7 @@ For more information, see [Trust the ASP.NET Core HTTPS development certificate]
 
 Run the following commands:
 
-```console
+```dotnetcli
 cd aspnetcoreapp
 dotnet run
 ```

--- a/aspnetcore/host-and-deploy/azure-apps/index.md
+++ b/aspnetcore/host-and-deploy/azure-apps/index.md
@@ -224,7 +224,7 @@ For a 64-bit [framework-dependent deployment](/dotnet/core/deploying/#framework-
 
 1. From a command shell, publish the app in Release configuration with the [dotnet publish](/dotnet/core/tools/dotnet-publish) command. In the following example, the app is published as a framework-dependent app:
 
-   ```console
+   ```dotnetcli
    dotnet publish --configuration Release
    ```
 
@@ -262,7 +262,7 @@ Use Visual Studio or the command-line interface (CLI) tools for a [self-containe
 
 1. From a command shell, publish the app in Release configuration for the host's runtime with the [dotnet publish](/dotnet/core/tools/dotnet-publish) command. In the following example, the app is published for the `win-x86` RID. The RID supplied to the `--runtime` option must be provided in the `<RuntimeIdentifier>` (or `<RuntimeIdentifiers>`) property in the project file.
 
-   ```console
+   ```dotnetcli
    dotnet publish --configuration Release --runtime win-x86
    ```
 

--- a/aspnetcore/host-and-deploy/blazor/index.md
+++ b/aspnetcore/host-and-deploy/blazor/index.md
@@ -26,7 +26,7 @@ Apps are published for deployment in Release configuration.
 
 Use the [dotnet publish](/dotnet/core/tools/dotnet-publish) command to publish the app with a Release configuration:
 
-```console
+```dotnetcli
 dotnet publish -c Release
 ```
 
@@ -65,13 +65,13 @@ To set the app's base path, update the `<base>` tag within the `<head>` tag elem
 
 For an app with a non-root relative URL path (for example, `<base href="/CoolApp/">`), the app fails to find its resources *when run locally*. To overcome this problem during local development and testing, you can supply a *path base* argument that matches the `href` value of the `<base>` tag at runtime. To pass the path base argument when running the app locally, execute the `dotnet run` command from the app's directory with the `--pathbase` option:
 
-```console
+```dotnetcli
 dotnet run --pathbase=/{RELATIVE URL PATH (no trailing slash)}
 ```
 
 For an app with a relative URL path of `/CoolApp/` (`<base href="/CoolApp/">`), the command is:
 
-```console
+```dotnetcli
 dotnet run --pathbase=/CoolApp
 ```
 

--- a/aspnetcore/host-and-deploy/blazor/webassembly.md
+++ b/aspnetcore/host-and-deploy/blazor/webassembly.md
@@ -194,7 +194,7 @@ The `--contentroot` argument sets the absolute path to the directory that contai
 
 * Pass the argument when running the app locally at a command prompt. From the app's directory, execute:
 
-  ```console
+  ```dotnetcli
   dotnet run --contentroot=/content-root-path
   ```
 
@@ -219,7 +219,7 @@ The `--pathbase` argument sets the app base path for an app run locally with a n
 
 * Pass the argument when running the app locally at a command prompt. From the app's directory, execute:
 
-  ```console
+  ```dotnetcli
   dotnet run --pathbase=/relative-URL-path
   ```
 
@@ -241,7 +241,7 @@ The `--urls` argument sets the IP addresses or host addresses with ports and pro
 
 * Pass the argument when running the app locally at a command prompt. From the app's directory, execute:
 
-  ```console
+  ```dotnetcli
   dotnet run --urls=http://127.0.0.1:0
   ```
 

--- a/aspnetcore/host-and-deploy/docker/building-net-docker-images.md
+++ b/aspnetcore/host-and-deploy/docker/building-net-docker-images.md
@@ -65,7 +65,7 @@ The sample Dockerfile uses the [Docker multi-stage build feature](https://docs.d
 
 * Run the following command to build and run the app locally:
 
-  ```console
+  ```dotnetcli
   dotnet run
   ```
 
@@ -137,7 +137,7 @@ In some scenarios, you might want to deploy an app to a container by copying to 
 
 * Run the [dotnet publish](/dotnet/core/tools/dotnet-publish) command:
 
-  ```console
+  ```dotnetcli
   dotnet publish -c Release -o published
   ```
 
@@ -149,13 +149,13 @@ In some scenarios, you might want to deploy an app to a container by copying to 
 
   * Windows:
 
-    ```console
+    ```dotnetcli
     dotnet published\aspnetapp.dll
     ```
 
   * Linux:
 
-    ```bash
+    ```dotnetcli
     dotnet published/aspnetapp.dll
     ```
 
@@ -172,9 +172,9 @@ ENTRYPOINT ["dotnet", "aspnetapp.dll"]
 
 ### The Dockerfile
 
-Here's the Dockerfile used by the `docker build` command you ran earlier.  It uses `dotnet publish` the same way you did in this section to build and deploy.  
+Here's the *Dockerfile* used by the `docker build` command you ran earlier.  It uses `dotnet publish` the same way you did in this section to build and deploy.  
 
-```console
+```dockerfile
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
 WORKDIR /app
 

--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -76,7 +76,7 @@ public class BasicStartup
 
 To run the basic configuration scenario using the sample app, execute the following command from the project's folder in a command shell:
 
-```console
+```dotnetcli
 dotnet run --scenario basic
 ```
 
@@ -326,7 +326,7 @@ app.UseEndpoints(endpoints =>
 
 To run the database probe scenario using the sample app, execute the following command from the project's folder in a command shell:
 
-```console
+```dotnetcli
 dotnet run --scenario db
 ```
 
@@ -364,7 +364,7 @@ To run the `DbContext` probe scenario using the sample app, confirm that the dat
 
 Execute the following command from the project's folder in a command shell:
 
-```console
+```dotnetcli
 dotnet run --scenario dbcontext
 ```
 
@@ -450,7 +450,7 @@ app.UseEndpoints(endpoints =>
 
 To run the readiness/liveness configuration scenario using the sample app, execute the following command from the project's folder in a command shell:
 
-```console
+```dotnetcli
 dotnet run --scenario liveness
 ```
 
@@ -513,7 +513,7 @@ The `WriteResponse` method formats the `CompositeHealthCheckResult` into a JSON 
 
 To run the metric-based probe with custom response writer output using the sample app, execute the following command from the project's folder in a command shell:
 
-```console
+```dotnetcli
 dotnet run --scenario writer
 ```
 
@@ -609,7 +609,7 @@ app.UseEndpoints(endpoints =>
 
 To run the management port configuration scenario using the sample app, execute the following command from the project's folder in a command shell:
 
-```console
+```dotnetcli
 dotnet run --scenario port
 ```
 
@@ -815,7 +815,7 @@ public class BasicStartup
 
 To run the basic configuration scenario using the sample app, execute the following command from the project's folder in a command shell:
 
-```console
+```dotnetcli
 dotnet run --scenario basic
 ```
 
@@ -1041,7 +1041,7 @@ app.UseHealthChecks("/health");
 
 To run the database probe scenario using the sample app, execute the following command from the project's folder in a command shell:
 
-```console
+```dotnetcli
 dotnet run --scenario db
 ```
 
@@ -1076,7 +1076,7 @@ To run the `DbContext` probe scenario using the sample app, confirm that the dat
 
 Execute the following command from the project's folder in a command shell:
 
-```console
+```dotnetcli
 dotnet run --scenario dbcontext
 ```
 
@@ -1151,7 +1151,7 @@ app.UseHealthChecks("/health/live", new HealthCheckOptions()
 
 To run the readiness/liveness configuration scenario using the sample app, execute the following command from the project's folder in a command shell:
 
-```console
+```dotnetcli
 dotnet run --scenario liveness
 ```
 
@@ -1215,7 +1215,7 @@ The `WriteResponse` method formats the `CompositeHealthCheckResult` into a JSON 
 
 To run the metric-based probe with custom response writer output using the sample app, execute the following command from the project's folder in a command shell:
 
-```console
+```dotnetcli
 dotnet run --scenario writer
 ```
 
@@ -1284,7 +1284,7 @@ Register health check services with <xref:Microsoft.Extensions.DependencyInjecti
 
 To run the management port configuration scenario using the sample app, execute the following command from the project's folder in a command shell:
 
-```console
+```dotnetcli
 dotnet run --scenario port
 ```
 

--- a/aspnetcore/host-and-deploy/iis/transform-webconfig.md
+++ b/aspnetcore/host-and-deploy/iis/transform-webconfig.md
@@ -52,7 +52,7 @@ In the following example, a configuration-specific environment variable is set i
 
 The transform is applied when the configuration is set to *Release*:
 
-```console
+```dotnetcli
 dotnet publish --configuration Release
 ```
 
@@ -86,7 +86,7 @@ In the following example, a profile-specific environment variable is set in *web
 
 The transform is applied when the profile is *FolderProfile*:
 
-```console
+```dotnetcli
 dotnet publish --configuration Release /p:PublishProfile=FolderProfile
 ```
 
@@ -122,7 +122,7 @@ In the following example, a environment-specific environment variable is set in 
 
 The transform is applied when the environment is *Production*:
 
-```console
+```dotnetcli
 dotnet publish --configuration Release /p:EnvironmentName=Production
 ```
 
@@ -160,7 +160,7 @@ In the following example, a custom transform environment variable is set in *cus
 
 The transform is applied when the `CustomTransformFileName` property is passed to the [dotnet publish](/dotnet/core/tools/dotnet-publish) command:
 
-```console
+```dotnetcli
 dotnet publish --configuration Release /p:CustomTransformFileName=custom.transform
 ```
 
@@ -170,7 +170,7 @@ The MSBuild property for the profile name is `$(CustomTransformFileName)`.
 
 To prevent transformations of the *web.config* file, set the MSBuild property `$(IsWebConfigTransformDisabled)`:
 
-```console
+```dotnetcli
 dotnet publish /p:IsWebConfigTransformDisabled=true
 ```
 

--- a/aspnetcore/host-and-deploy/linux-apache.md
+++ b/aspnetcore/host-and-deploy/linux-apache.md
@@ -34,7 +34,7 @@ If the app is run locally and isn't configured to make secure connections (HTTPS
 
 Run [dotnet publish](/dotnet/core/tools/dotnet-publish) from the development environment to package an app into a directory (for example, *bin/Release/&lt;target_framework_moniker&gt;/publish*) that can run on the server:
 
-```console
+```dotnetcli
 dotnet publish --configuration Release
 ```
 

--- a/aspnetcore/host-and-deploy/linux-nginx.md
+++ b/aspnetcore/host-and-deploy/linux-nginx.md
@@ -46,7 +46,7 @@ If the app is run locally and isn't configured to make secure connections (HTTPS
 
 Run [dotnet publish](/dotnet/core/tools/dotnet-publish) from the development environment to package an app into a directory (for example, *bin/Release/&lt;target_framework_moniker&gt;/publish*) that can run on the server:
 
-```console
+```dotnetcli
 dotnet publish --configuration Release
 ```
 

--- a/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
+++ b/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
@@ -66,13 +66,13 @@ When an ASP.NET Core project references `Microsoft.NET.Sdk.Web` in the project f
 
 Command-line publishing works on all .NET Core-supported platforms and doesn't require Visual Studio. In the following examples, the .NET Core CLI's [dotnet publish](/dotnet/core/tools/dotnet-publish) command is run from the project directory (which contains the *.csproj* file). If the project folder isn't the current working directory, explicitly pass in the project file path. For example:
 
-```console
+```dotnetcli
 dotnet publish C:\Webs\Web1
 ```
 
 Run the following commands to create and publish a web app:
 
-```console
+```dotnetcli
 dotnet new mvc
 dotnet publish
 ```
@@ -94,7 +94,7 @@ The default publish folder format is *bin\Debug\\{TARGET FRAMEWORK MONIKER}\publ
 
 The following command specifies a `Release` build and the publishing directory:
 
-```console
+```dotnetcli
 dotnet publish -c Release -o C:\MyWebs\test
 ```
 
@@ -107,7 +107,9 @@ MSBuild properties can be passed using either of the following formats:
 
 For example, the following command publishes a `Release` build to a network share. The network share is specified with forward slashes (*//r8/*) and works on all .NET Core supported platforms.
 
-`dotnet publish -c Release /p:PublishDir=//r8/release/AdminWeb`
+```dotnetcli
+dotnet publish -c Release /p:PublishDir=//r8/release/AdminWeb
+```
 
 Confirm that the published app for deployment isn't running. Files in the *publish* folder are locked when the app is running. Deployment can't occur because locked files can't be copied.
 
@@ -150,19 +152,19 @@ The `dotnet publish` command can use folder, MSDeploy, and [Kudu](https://github
 
 **Folder (works cross-platform):**
 
-```console
+```dotnetcli
 dotnet publish WebApplication.csproj /p:PublishProfile=<FolderProfileName>
 ```
 
 **MSDeploy:**
 
-```console
+```dotnetcli
 dotnet publish WebApplication.csproj /p:PublishProfile=<MsDeployProfileName> /p:Password=<DeploymentPassword>
 ```
 
 **MSDeploy package:**
 
-```console
+```dotnetcli
 dotnet publish WebApplication.csproj /p:PublishProfile=<MsDeployPackageProfileName>
 ```
 
@@ -187,7 +189,7 @@ Add a publish profile to the project's *Properties/PublishProfiles* folder with 
 
 Run the following command to zip up the publish contents and publish it to Azure using the Kudu APIs:
 
-```console
+```dotnetcli
 dotnet publish /p:PublishProfile=Azure /p:Configuration=Release
 ```
 
@@ -239,7 +241,7 @@ In the preceding example:
 * The `<LastUsedBuildConfiguration>` property is set to `Release`. When publishing from Visual Studio, the value of `<LastUsedBuildConfiguration>` is set using the value when the publish process is started. `<LastUsedBuildConfiguration>` is special and shouldn't be overridden in an imported MSBuild file. This property can, however, be overridden from the command line using one of the following approaches.
   * Using the .NET Core CLI:
 
-    ```console
+    ```dotnetcli
     dotnet build -c Release /p:DeployOnBuild=true /p:PublishProfile=FolderProfile
     ```
 
@@ -286,7 +288,7 @@ msbuild "AzureWebApp.csproj"
 
 A publish profile can also be used with the .NET Core CLI's [dotnet msbuild](/dotnet/core/tools/dotnet-msbuild) command from a Windows command shell:
 
-```console
+```dotnetcli
 dotnet msbuild "AzureWebApp.csproj"
     /p:DeployOnBuild=true 
     /p:PublishProfile="AzureWebApp - Web Deploy" 

--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -42,7 +42,7 @@ The ASP.NET Core Worker Service template provides a starting point for writing l
 
 Use the Worker Service (`worker`) template with the [dotnet new](/dotnet/core/tools/dotnet-new) command from a command shell. In the following example, a Worker Service app is created named `ContosoWorkerService`. A folder for the `ContosoWorkerService` app is created automatically when the command is executed.
 
-```console
+```dotnetcli
 dotnet new worker -o ContosoWorkerService
 ```
 

--- a/aspnetcore/includes/RP/model2.md
+++ b/aspnetcore/includes/RP/model2.md
@@ -23,7 +23,7 @@ Add a connection string to the *appsettings.json* file as shown in the following
 
 Open a terminal for the RazorPagesMovie project.  Right click the project name in the design/layout bar and go to **Tools > Open** in Terminal. Run the following .NET Core CLI commands in the Termial:
 
-```console
+```dotnetcli
 dotnet tool install --global dotnet-ef --version 3.0.0-*
 dotnet add package Microsoft.EntityFrameworkCore.SQLite --version 3.0.0-*
 dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design --version 3.0.0-*
@@ -58,11 +58,10 @@ Register the database context with the [dependency injection](xref:fundamentals/
 
 Run the following .NET Core CLI command to add SQLite and CodeGeneration.Design  to the project:
 
-```console
+```dotnetcli
 dotnet add package Microsoft.EntityFrameworkCore.SQLite
 dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
 dotnet add package Microsoft.EntityFrameworkCore.Design
-
 ```
 
 The `Microsoft.VisualStudio.Web.CodeGeneration.Design` package is required for scaffolding.

--- a/aspnetcore/includes/RP/model3.md
+++ b/aspnetcore/includes/RP/model3.md
@@ -1,7 +1,7 @@
 
 Run the following .NET Core CLI commands:
 
-```console
+```dotnetcli
 dotnet ef migrations add InitialCreate
 dotnet ef database update
 ```

--- a/aspnetcore/includes/RP/model4.md
+++ b/aspnetcore/includes/RP/model4.md
@@ -11,7 +11,7 @@ The following table details the ASP.NET Core code generator parameters:
 
 Use the `h` switch to get help on the `aspnet-codegenerator razorpage` command:
 
-```console
+```dotnetcli
 dotnet aspnet-codegenerator razorpage -h
 ```
 

--- a/aspnetcore/includes/RP/model4Win.md
+++ b/aspnetcore/includes/RP/model4Win.md
@@ -4,7 +4,7 @@
 
 * Run the following from the command line (in the project directory that contains the *Program.cs*, *Startup.cs*, and *.csproj* files):
 
-  ```console
+  ```dotnetcli
   dotnet restore
   dotnet aspnet-codegenerator razorpage -m Movie -dc MovieContext -udl -outDir Pages\Movies --referenceScriptLibraries
   ```

--- a/aspnetcore/includes/RP/model4tbl.md
+++ b/aspnetcore/includes/RP/model4tbl.md
@@ -11,6 +11,6 @@ The following table details the ASP.NET Core code generators` parameters:
 
 Use the `h` switch to get help on the `aspnet-codegenerator razorpage` command:
 
-```console
+```dotnetcli
 dotnet aspnet-codegenerator razorpage -h
 ```

--- a/aspnetcore/includes/RP/model4x.md
+++ b/aspnetcore/includes/RP/model4x.md
@@ -4,7 +4,7 @@
 
 * Run the following from the command line (in the project directory that contains the *Program.cs*, *Startup.cs*, and *.csproj* files):
 
-  ```console
+  ```dotnetcli
   dotnet aspnet-codegenerator razorpage -m Movie -dc MovieContext -udl -outDir Pages/Movies --referenceScriptLibraries
   ```
 

--- a/aspnetcore/includes/mvc-intro/adding-model2.md
+++ b/aspnetcore/includes/mvc-intro/adding-model2.md
@@ -4,7 +4,7 @@
 
 * Run the following commands in the command prompt:
 
-  ```console
+  ```dotnetcli
   dotnet restore
   dotnet ef migrations add Initial
   dotnet ef database update

--- a/aspnetcore/includes/mvc-intro/adding-model2xp.md
+++ b/aspnetcore/includes/mvc-intro/adding-model2xp.md
@@ -4,7 +4,7 @@
 
 From the command line, run the following .NET Core CLI commands:
 
-```console
+```dotnetcli
 dotnet ef migrations add InitialCreate
 dotnet ef database update
 ```

--- a/aspnetcore/includes/mvc-intro/model2.md
+++ b/aspnetcore/includes/mvc-intro/model2.md
@@ -22,7 +22,7 @@ Add a connection string to the *appsettings.json* file:
 
 Run the following .NET Core CLI commands:
 
-```console
+```dotnetcli
 dotnet tool install --global dotnet-ef --version 3.0.0-*
 dotnet add package Microsoft.EntityFrameworkCore.SQLite --version 3.0.0-*
 dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design --version 3.0.0-*
@@ -71,7 +71,7 @@ Add a connection string to the *appsettings.json* file:
 
 Run the following .NET Core CLI command to add SQLite and CodeGeneration.Design  to the project:
 
-```console
+```dotnetcli
 dotnet add package Microsoft.EntityFrameworkCore.SQLite
 dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
 ```

--- a/aspnetcore/includes/mvc-intro/model4.md
+++ b/aspnetcore/includes/mvc-intro/model4.md
@@ -11,7 +11,7 @@ The following table details the ASP.NET Core code generator parameters:
 
 Use the `h` switch to get help on the `aspnet-codegenerator controller` command:
 
-```console
+```dotnetcli
 dotnet aspnet-codegenerator controller -h
 ```
 

--- a/aspnetcore/includes/mvc-intro/new-field.md
+++ b/aspnetcore/includes/mvc-intro/new-field.md
@@ -56,7 +56,9 @@ There are a few approaches to resolving the error:
 
 For this tutorial, we'll drop and re-create the database when the schema changes. Run the following command from a terminal to drop the db:
 
-`dotnet ef database drop`
+```dotnetcli
+dotnet ef database drop
+```
 
 Update the `SeedData` class so that it provides a value for the new column. A sample change is shown below, but you'll want to make this change for each `new Movie`.
 

--- a/aspnetcore/includes/scaffold-identity/id-scaffold-dlg-auth.md
+++ b/aspnetcore/includes/scaffold-identity/id-scaffold-dlg-auth.md
@@ -23,32 +23,32 @@ Note: If you're creating a new user context, you don't have to select a file to 
 
 If you have not previously installed the ASP.NET Core scaffolder, install it now:
 
-```console
+```dotnetcli
 dotnet tool install -g dotnet-aspnet-codegenerator
 ```
 
 Add a package reference to [Microsoft.VisualStudio.Web.CodeGeneration.Design](https://www.nuget.org/packages/Microsoft.VisualStudio.Web.CodeGeneration.Design/) to the project (\*.csproj) file. Run the following command in the project directory:
 
-```console
+```dotnetcli
 dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
 dotnet restore
 ```
 
 Run the following command to list the Identity scaffolder options:
 
-```console
+```dotnetcli
 dotnet aspnet-codegenerator identity -h
 ```
 
 In the project folder, run the Identity scaffolder with the options you want. For example, to setup identity with the default UI and the minimum number of files, run the following command. Use the correct fully qualified name for your DB context:
 
-```console
+```dotnetcli
 dotnet aspnet-codegenerator identity -dc MyWeb.Data.ApplicationDbContext --files Account.Register
 ```
 
 PowerShell uses semicolon as a command separator. When using PowerShell, escape the semi-colons in the file list or put the file list in double quotes. For example:
 
-```console
+```dotnetcli
 dotnet aspnet-codegenerator identity -dc MyWeb.Data.ApplicationDbContext --files "Account.Register;Account.Login;Account.Logout"
 ```
 

--- a/aspnetcore/includes/scaffold-identity/id-scaffold-dlg.md
+++ b/aspnetcore/includes/scaffold-identity/id-scaffold-dlg.md
@@ -15,26 +15,26 @@ Run the Identity scaffolder:
 
 If you have not previously installed the ASP.NET Core scaffolder, install it now:
 
-```cli
+```dotnetcli
 dotnet tool install -g dotnet-aspnet-codegenerator
 ```
 
 Add a package reference to [Microsoft.VisualStudio.Web.CodeGeneration.Design](https://www.nuget.org/packages/Microsoft.VisualStudio.Web.CodeGeneration.Design/) to the project (\*.csproj) file. Run the following command in the project directory:
 
-```cli
+```dotnetcli
 dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
 dotnet restore
 ```
 
 Run the following command to list the Identity scaffolder options:
 
-```cli
+```dotnetcli
 dotnet aspnet-codegenerator identity -h
 ```
 
 In the project folder, run the Identity scaffolder with the options you want. For example, to setup identity with the default UI and the minimum number of files, run the following command:
 
-```cli
+```dotnetcli
 dotnet aspnet-codegenerator identity --useDefaultUI
 ```
 

--- a/aspnetcore/includes/scaffold-identity/migrations.md
+++ b/aspnetcore/includes/scaffold-identity/migrations.md
@@ -4,14 +4,14 @@ The generated Identity database code requires [Entity Framework Core Migrations]
 
 In the Visual Studio **Package Manager Console**:
 
-```PMC
+```powershell
 Add-Migration CreateIdentitySchema
 Update-Database
 ```
 
 # [.NET Core CLI](#tab/netcore-cli)
 
-```cli
+```dotnetcli
 dotnet ef migrations add CreateIdentitySchema
 dotnet ef database update
 ```

--- a/aspnetcore/includes/trustCertMac.md
+++ b/aspnetcore/includes/trustCertMac.md
@@ -1,6 +1,6 @@
 * Trust the HTTPS development certificate by running the following command:
 
-    ```console
+    ```dotnetcli
     dotnet dev-certs https --trust
     ```
 

--- a/aspnetcore/includes/trustCertVSC.md
+++ b/aspnetcore/includes/trustCertVSC.md
@@ -1,6 +1,6 @@
 * Trust the HTTPS development certificate by running the following command:
 
-  ```console
+  ```dotnetcli
   dotnet dev-certs https --trust
   ```
   

--- a/aspnetcore/mvc/views/view-compilation.md
+++ b/aspnetcore/mvc/views/view-compilation.md
@@ -83,7 +83,7 @@ Set the `MvcRazorCompileOnPublish` property to `true`, and install the [Microsof
 
 Prepare the app for a [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd) with the [.NET Core CLI publish command](/dotnet/core/tools/dotnet-publish). For example, execute the following command at the project root:
 
-```console
+```dotnetcli
 dotnet publish -c Release
 ```
 

--- a/aspnetcore/performance/caching/distributed.md
+++ b/aspnetcore/performance/caching/distributed.md
@@ -98,7 +98,7 @@ The Distributed SQL Server Cache implementation (<xref:Microsoft.Extensions.Depe
 
 Create a table in SQL Server by running the `sql-cache create` command. Provide the SQL Server instance (`Data Source`), database (`Initial Catalog`), schema (for example, `dbo`), and table name (for example, `TestCache`):
 
-```console
+```dotnetcli
 dotnet sql-cache create "Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=DistCache;Integrated Security=True;" dbo TestCache
 ```
 

--- a/aspnetcore/razor-pages/ui-class.md
+++ b/aspnetcore/razor-pages/ui-class.md
@@ -36,7 +36,7 @@ An RCL has the following project file:
 
 From the command line, run `dotnet new razorclasslib`. For example:
 
-```console
+```dotnetcli
 dotnet new razorclasslib -o RazorUIClassLib
 ```
 
@@ -71,13 +71,13 @@ Open the *.sln* file in Visual Studio. Run the app.
 
 From a command prompt in the *cli* directory, build the RCL and web app.
 
-```console
+```dotnetcli
 dotnet build
 ```
 
 Move to the *WebApp1* directory and run the app:
 
-```console
+```dotnetcli
 dotnet run
 ```
 
@@ -104,7 +104,7 @@ Create the RCL project:
 
 From the command line, run the following:
 
-```console
+```dotnetcli
 dotnet new razorclasslib -o RazorUIClassLib
 dotnet new page -n _Message -np -o RazorUIClassLib/Areas/MyFeature/Pages/Shared
 dotnet new viewstart -o RazorUIClassLib/Areas/MyFeature/Pages
@@ -132,7 +132,7 @@ The *_ViewStart.cshtml* file is required to use the layout of the Razor Pages pr
 
 `@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers` is required to use the partial view (`<partial name="_Message" />`). Rather than including the `@addTagHelper` directive, you can add a *_ViewImports.cshtml* file. For example:
 
-```console
+```dotnetcli
 dotnet new viewimports -o RazorUIClassLib/Areas/MyFeature/Pages
 ```
 
@@ -140,7 +140,7 @@ For more information on *_ViewImports.cshtml*, see [Importing Shared Directives]
 
 * Build the class library to verify there are no compiler errors:
 
-```console
+```dotnetcli
 dotnet build RazorUIClassLib
 ```
 
@@ -170,7 +170,7 @@ Run the app.
 
 Create a Razor Pages web app and a solution file containing the Razor Pages app and the RCL:
 
-```console
+```dotnetcli
 dotnet new webapp -o WebApp1
 dotnet new sln
 dotnet sln add WebApp1
@@ -180,7 +180,7 @@ dotnet add WebApp1 reference RazorUIClassLib
 
 Build and run the web app:
 
-```console
+```dotnetcli
 cd WebApp1
 dotnet run
 ```

--- a/aspnetcore/security/app-secrets.md
+++ b/aspnetcore/security/app-secrets.md
@@ -84,7 +84,7 @@ Install the [Microsoft.Extensions.SecretManager.Tools](https://www.nuget.org/pac
 
 Execute the following command in a command shell to validate the tool installation:
 
-```console
+```dotnetcli
 dotnet user-secrets -h
 ```
 
@@ -123,7 +123,7 @@ The Secret Manager tool operates on project-specific configuration settings stor
 
 The Secret Manager tool includes an `init` command in .NET Core SDK 3.0.100 or later. To use user secrets, run the following command in the project directory:
 
-```console
+```dotnetcli
 dotnet user-secrets init
 ```
 
@@ -156,7 +156,7 @@ To use user secrets, define a `UserSecretsId` element within a `PropertyGroup` o
 
 Define an app secret consisting of a key and its value. The secret is associated with the project's `UserSecretsId` value. For example, run the following command from the directory in which the *.csproj* file exists:
 
-```console
+```dotnetcli
 dotnet user-secrets set "Movies:ServiceApiKey" "12345"
 ```
 
@@ -164,7 +164,7 @@ In the preceding example, the colon denotes that `Movies` is an object literal w
 
 The Secret Manager tool can be used from other directories too. Use the `--project` option to supply the file system path at which the *.csproj* file exists. For example:
 
-```console
+```dotnetcli
 dotnet user-secrets set "Movies:ServiceApiKey" "12345" --project "C:\apps\WebApp1\src\WebApp1"
 ```
 
@@ -197,7 +197,7 @@ A batch of secrets can be set by piping JSON to the `set` command. In the follow
 
 Open a command shell, and execute the following command:
 
-  ```console
+  ```dotnetcli
   type .\input.json | dotnet user-secrets set
   ```
 
@@ -205,7 +205,7 @@ Open a command shell, and execute the following command:
 
 Open a command shell, and execute the following command:
 
-  ```console
+  ```dotnetcli
   cat ./input.json | dotnet user-secrets set
   ```
 
@@ -289,7 +289,7 @@ Storing passwords in plain text is insecure. For example, a database connection 
 
 A more secure approach is to store the password as a secret. For example:
 
-```console
+```dotnetcli
 dotnet user-secrets set "DbPassword" "pass123"
 ```
 
@@ -317,7 +317,7 @@ The secret's value can be set on a <xref:System.Data.SqlClient.SqlConnectionStri
 
 Run the following command from the directory in which the *.csproj* file exists:
 
-```console
+```dotnetcli
 dotnet user-secrets list
 ```
 
@@ -336,7 +336,7 @@ In the preceding example, a colon in the key names denotes the object hierarchy 
 
 Run the following command from the directory in which the *.csproj* file exists:
 
-```console
+```dotnetcli
 dotnet user-secrets remove "Movies:ConnectionString"
 ```
 
@@ -362,7 +362,7 @@ Movies:ServiceApiKey = 12345
 
 Run the following command from the directory in which the *.csproj* file exists:
 
-```console
+```dotnetcli
 dotnet user-secrets clear
 ```
 

--- a/aspnetcore/security/authentication/accconfirm.md
+++ b/aspnetcore/security/authentication/accconfirm.md
@@ -35,7 +35,7 @@ See [this PDF file](https://webpifeed.blob.core.windows.net/webpifeed/Partners/a
 
 Run the following commands to create a web app with authentication.
 
-```console
+```dotnetcli
 dotnet new webapp -au Individual -uld -o WebPWrecover
 cd WebPWrecover
 dotnet run
@@ -60,7 +60,7 @@ Create a class to fetch the secure email key. For this sample, create *Services/
 
 Set the `SendGridUser` and `SendGridKey` with the [secret-manager tool](xref:security/app-secrets). For example:
 
-```console
+```dotnetcli
 dotnet user-secrets set SendGridUser RickAndMSFT
 dotnet user-secrets set SendGridKey <key>
 
@@ -90,7 +90,7 @@ Install the `SendGrid` NuGet package:
 
 From the Package Manager Console, enter the following command:
 
-``` PMC
+```powershell
 Install-Package SendGrid
 ```
 
@@ -98,7 +98,7 @@ Install-Package SendGrid
 
 From the console, enter the following command:
 
-```cli
+```dotnetcli
 dotnet add package SendGrid
 ```
 
@@ -220,7 +220,7 @@ Enabling account confirmation on a site with users locks out all the existing us
 
 Run the following commands to create a web app with authentication.
 
-```console
+```dotnetcli
 dotnet new webapp -au Individual -uld -o WebPWrecover
 cd WebPWrecover
 dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
@@ -296,7 +296,7 @@ Install the `SendGrid` NuGet package:
 
 From the Package Manager Console, enter the following command:
 
-``` PMC
+```powershell
 Install-Package SendGrid
 ```
 
@@ -304,7 +304,7 @@ Install-Package SendGrid
 
 From the console, enter the following command:
 
-```cli
+```dotnetcli
 dotnet add package SendGrid
 ```
 

--- a/aspnetcore/security/authentication/add-user-data.md
+++ b/aspnetcore/security/authentication/add-user-data.md
@@ -36,7 +36,7 @@ The project sample is created from a Razor Pages web app, but the instructions a
 
 # [.NET Core CLI](#tab/netcore-cli)
 
-```cli
+```dotnetcli
 dotnet new webapp -o WebApp1
 ```
 
@@ -61,26 +61,26 @@ dotnet new webapp -o WebApp1
 
 If you have not previously installed the ASP.NET Core scaffolder, install it now:
 
-```cli
+```dotnetcli
 dotnet tool install -g dotnet-aspnet-codegenerator
 ```
 
 Add a package reference to [Microsoft.VisualStudio.Web.CodeGeneration.Design](https://www.nuget.org/packages/Microsoft.VisualStudio.Web.CodeGeneration.Design/) to the project (.csproj) file. Run the following command in the project directory:
 
-```cli
+```dotnetcli
 dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
 dotnet restore
 ```
 
 Run the following command to list the Identity scaffolder options:
 
-```cli
+```dotnetcli
 dotnet aspnet-codegenerator identity -h
 ```
 
 In the project folder, run the Identity scaffolder:
 
-```cli
+```dotnetcli
 dotnet aspnet-codegenerator identity -u WebApp1User -fi Account.Register;Account.Manage.Index
 ```
 
@@ -137,14 +137,14 @@ Build the project.
 
 In the Visual Studio **Package Manager Console**:
 
-```PMC
+```powershell
 Add-Migration CustomUserData
 Update-Database
 ```
 
 # [.NET Core CLI](#tab/netcore-cli)
 
-```cli
+```dotnetcli
 dotnet ef migrations add CustomUserData
 dotnet ef database update
 ```

--- a/aspnetcore/security/authentication/identity-api-authorization.md
+++ b/aspnetcore/security/authentication/identity-api-authorization.md
@@ -20,13 +20,13 @@ User authentication and authorization can be used with both Angular and React SP
 
 **Angular**:
 
-```console
+```dotnetcli
 dotnet new angular -o <output_directory_name> -au Individual
 ```
 
 **React**:
 
-```console
+```dotnetcli
 dotnet new react -o <output_directory_name> -au Individual
 ```
 

--- a/aspnetcore/security/authentication/identity-custom-storage-providers.md
+++ b/aspnetcore/security/authentication/identity-custom-storage-providers.md
@@ -29,7 +29,7 @@ ASP.NET Core Identity is included in project templates in Visual Studio with the
 
 When using the .NET Core CLI, add `-au Individual`:
 
-```console
+```dotnetcli
 dotnet new mvc -au Individual
 ```
 

--- a/aspnetcore/security/authentication/identity.md
+++ b/aspnetcore/security/authentication/identity.md
@@ -47,7 +47,7 @@ Create an ASP.NET Core Web Application project with Individual User Accounts.
 
 # [.NET Core CLI](#tab/netcore-cli)
 
-```cli
+```dotnetcli
 dotnet new webapp --auth Individual -o WebApp1
 ```
 
@@ -71,7 +71,7 @@ Run the following command in the Package Manager Console (PMC):
 
 # [.NET Core CLI](#tab/netcore-cli)
 
-```cli
+```dotnetcli
 dotnet ef database update
 ```
 
@@ -139,7 +139,7 @@ Add the Register, Login, and LogOut files.
 
 If you created the project with name **WebApp1**, run the following commands. Otherwise, use the correct namespace for the `ApplicationDbContext`:
 
-```cli
+```dotnetcli
 dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
 dotnet aspnet-codegenerator identity -dc WebApp1.Data.ApplicationDbContext --files "Account.Register;Account.Login;Account.Logout"
 ```

--- a/aspnetcore/security/authentication/individual.md
+++ b/aspnetcore/security/authentication/individual.md
@@ -14,7 +14,7 @@ The authentication templates are available in .NET Core CLI with `-au Individual
 
 ::: moniker range=">= aspnetcore-2.1"
 
-```console
+```dotnetcli
 dotnet new mvc -au Individual
 dotnet new webapp -au Individual
 ```
@@ -23,7 +23,7 @@ dotnet new webapp -au Individual
 
 ::: moniker range="= aspnetcore-2.0"
 
-```console
+```dotnetcli
 dotnet new mvc -au Individual
 dotnet new razor -au Individual
 ```

--- a/aspnetcore/security/authentication/social/facebook-logins.md
+++ b/aspnetcore/security/authentication/social/facebook-logins.md
@@ -58,7 +58,7 @@ Link sensitive settings like Facebook `App ID` and `App Secret` to your applicat
 
 Execute the following commands to securely store `App ID` and `App Secret` using Secret Manager:
 
-```console
+```dotnetcli
 dotnet user-secrets set Authentication:Facebook:AppId <app-id>
 dotnet user-secrets set Authentication:Facebook:AppSecret <app-secret>
 ```

--- a/aspnetcore/security/authentication/social/google-logins.md
+++ b/aspnetcore/security/authentication/social/google-logins.md
@@ -27,7 +27,7 @@ This tutorial shows you how to enable users to sign in with their Google account
 
 Store sensitive settings such as the Google `Client ID` and `Client Secret` with the [Secret Manager](xref:security/app-secrets). For the purposes of this tutorial, name the tokens `Authentication:Google:ClientId` and `Authentication:Google:ClientSecret`:
 
-```console
+```dotnetcli
 dotnet user-secrets set "Authentication:Google:ClientId" "X.apps.googleusercontent.com"
 dotnet user-secrets set "Authentication:Google:ClientSecret" "<client secret>"
 ```

--- a/aspnetcore/security/authentication/social/index.md
+++ b/aspnetcore/security/authentication/social/index.md
@@ -42,7 +42,7 @@ For examples of how social logins can drive traffic and customer conversions, se
 
 * Run the following commands:
 
-  ```console
+  ```dotnetcli
   dotnet new webapp -o WebApp1 -au Individual -uld
   code -r WebApp1
   ```

--- a/aspnetcore/security/authentication/social/microsoft-logins.md
+++ b/aspnetcore/security/authentication/social/microsoft-logins.md
@@ -42,7 +42,7 @@ If you don't have a Microsoft account, select **Create one**. After signing in y
 
 Run the following commands to securely store `ClientId` and `ClientSecret` using [Secret Manager](xref:security/app-secrets):
 
-```console
+```dotnetcli
 dotnet user-secrets set Authentication:Microsoft:ClientId <Client-Id>
 dotnet user-secrets set Authentication:Microsoft:ClientSecret <Client-Secret>
 ```

--- a/aspnetcore/security/authentication/social/twitter-logins.md
+++ b/aspnetcore/security/authentication/social/twitter-logins.md
@@ -30,7 +30,7 @@ This sample shows how to enable users to [sign in with their Twitter account](ht
 
 Run the following commands to securely store `ClientId` and `ClientSecret` using [Secret Manager](xref:security/app-secrets):
 
-```console
+```dotnetcli
 dotnet user-secrets set Authentication:Twitter:ConsumerAPIKey <Key>
 dotnet user-secrets set Authentication:Twitter:ConsumerSecret <Secret>
 ```

--- a/aspnetcore/security/authentication/windowsauth.md
+++ b/aspnetcore/security/authentication/windowsauth.md
@@ -86,7 +86,7 @@ Alternatively, the properties can be configured in the `iisSettings` node of the
 
 Execute the [dotnet new](/dotnet/core/tools/dotnet-new) command with the `webapp` argument (ASP.NET Core Web App) and `--auth Windows` switch:
 
-```console
+```dotnetcli
 dotnet new webapp --auth Windows
 ```
 

--- a/aspnetcore/security/authorization/secure-data.md
+++ b/aspnetcore/security/authorization/secure-data.md
@@ -98,7 +98,7 @@ Use the ASP.NET [Identity](xref:security/authentication/identity) user ID to ens
 
 Create a new migration and update the database:
 
-```console
+```dotnetcli
 dotnet ef migrations add userID_Status
 dotnet ef database update
 ```
@@ -125,7 +125,7 @@ Add [AllowAnonymous](/dotnet/api/microsoft.aspnetcore.authorization.allowanonymo
 
 The `SeedData` class creates two accounts: administrator and manager. Use the [Secret Manager tool](xref:security/app-secrets) to set a password for these accounts. Set the password from the project directory (the directory containing *Program.cs*):
 
-```console
+```dotnetcli
 dotnet user-secrets set SeedUserPW <PW>
 ```
 
@@ -274,7 +274,7 @@ If you haven't already set a password for seeded user accounts, use the [Secret 
 * Choose a strong password: Use eight or more characters and at least one upper-case character, number, and symbol. For example, `Passw0rd!` meets the strong password requirements.
 * Execute the following command from the project's folder, where `<PW>` is the password:
 
-  ```console
+  ```dotnetcli
   dotnet user-secrets set SeedUserPW <PW>
   ```
 
@@ -305,7 +305,7 @@ Create a contact in the administrator's browser. Copy the URL for delete and edi
   * Name it "ContactManager" so the namespace matches the namespace used in the sample.
   * `-uld` specifies LocalDB instead of SQLite
 
-  ```console
+  ```dotnetcli
   dotnet new webapp -o ContactManager -au Individual -uld
   ```
 
@@ -316,14 +316,14 @@ Create a contact in the administrator's browser. Copy the URL for delete and edi
 * Scaffold the `Contact` model.
 * Create initial migration and update the database:
 
-```console
+```dotnetcli
 dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
 dotnet tool install -g dotnet-aspnet-codegenerator
 dotnet aspnet-codegenerator razorpage -m Contact -udl -dc ApplicationDbContext -outDir Pages\Contacts --referenceScriptLibraries
 dotnet ef database drop -f
 dotnet ef migrations add initial
 dotnet ef database update
-  ```
+```
 
 If you experience a bug with the `dotnet aspnet-codegenerator razorpage` command, see [this GitHub issue](https://github.com/aspnet/Scaffolding/issues/984).
 
@@ -421,7 +421,7 @@ Use the ASP.NET [Identity](xref:security/authentication/identity) user ID to ens
 
 Create a new migration and update the database:
 
-```console
+```dotnetcli
 dotnet ef migrations add userID_Status
 dotnet ef database update
 ```
@@ -448,7 +448,7 @@ Add [AllowAnonymous](/dotnet/api/microsoft.aspnetcore.authorization.allowanonymo
 
 The `SeedData` class creates two accounts: administrator and manager. Use the [Secret Manager tool](xref:security/app-secrets) to set a password for these accounts. Set the password from the project directory (the directory containing *Program.cs*):
 
-```console
+```dotnetcli
 dotnet user-secrets set SeedUserPW <PW>
 ```
 
@@ -597,16 +597,16 @@ If you haven't already set a password for seeded user accounts, use the [Secret 
 * Choose a strong password: Use eight or more characters and at least one upper-case character, number, and symbol. For example, `Passw0rd!` meets the strong password requirements.
 * Execute the following command from the project's folder, where `<PW>` is the password:
 
-  ```console
+  ```dotnetcli
   dotnet user-secrets set SeedUserPW <PW>
   ```
 
 * Drop and update the Database
 
-    ```console
-     dotnet ef database drop -f
-     dotnet ef database update  
-     ```
+  ```dotnetcli
+  dotnet ef database drop -f
+  dotnet ef database update  
+  ```
 
 * Restart the app to seed the database.
 
@@ -632,7 +632,7 @@ Create a contact in the administrator's browser. Copy the URL for delete and edi
   * Name it "ContactManager" so the namespace matches the namespace used in the sample.
   * `-uld` specifies LocalDB instead of SQLite
 
-  ```console
+  ```dotnetcli
   dotnet new webapp -o ContactManager -au Individual -uld
   ```
 
@@ -643,7 +643,7 @@ Create a contact in the administrator's browser. Copy the URL for delete and edi
 * Scaffold the `Contact` model.
 * Create initial migration and update the database:
 
-  ```console
+  ```dotnetcli
   dotnet aspnet-codegenerator razorpage -m Contact -udl -dc ApplicationDbContext -outDir Pages\Contacts --referenceScriptLibraries
   dotnet ef database drop -f
   dotnet ef migrations add initial

--- a/aspnetcore/security/blazor/index.md
+++ b/aspnetcore/security/blazor/index.md
@@ -50,7 +50,7 @@ A dialog opens to offer the same set of authentication mechanisms available for 
 
 Follow the Visual Studio Code guidance in the <xref:blazor/get-started> article to create a new Blazor Server project with an authentication mechanism:
 
-```console
+```dotnetcli
 dotnet new blazorserver -o {APP NAME} -au {AUTHENTICATION}
 ```
 
@@ -84,7 +84,7 @@ The command creates a folder named with the value provided for the `{APP NAME}` 
 
 Follow the .NET Core CLI guidance in the <xref:blazor/get-started> article to create a new Blazor Server project with an authentication mechanism:
 
-```console
+```dotnetcli
 dotnet new blazorserver -o {APP NAME} -au {AUTHENTICATION}
 ```
 

--- a/aspnetcore/security/data-protection/implementation/key-storage-providers.md
+++ b/aspnetcore/security/data-protection/implementation/key-storage-providers.md
@@ -158,7 +158,7 @@ Update-Database -Context MyKeysContext
 
 Execute the following commands in a command shell:
 
-```console
+```dotnetcli
 dotnet ef migrations add AddDataProtectionKeys --context MyKeysContext
 dotnet ef database update --context MyKeysContext
 ```

--- a/aspnetcore/security/docker-https.md
+++ b/aspnetcore/security/docker-https.md
@@ -49,7 +49,7 @@ Use the following instructions for your operating system configuration.
 
 Generate certificate and configure local machine:
 
-```console
+```dotnetcli
 dotnet dev-certs https -ep %USERPROFILE%\.aspnet\https\aspnetapp.pfx -p { password here }
 dotnet dev-certs https --trust
 ```
@@ -69,7 +69,7 @@ The password must match the password used for the certificate.
 
 Generate certificate and configure local machine:
 
-```console
+```dotnetcli
 dotnet dev-certs https -ep ${HOME}/.aspnet/https/aspnetapp.pfx -p { password here }
 dotnet dev-certs https --trust
 ```
@@ -91,7 +91,7 @@ The password must match the password used for the certificate.
 
 Generate certificate and configure local machine:
 
-```console
+```dotnetcli
 dotnet dev-certs https -ep %USERPROFILE%\.aspnet\https\aspnetapp.pfx -p { password here }
 dotnet dev-certs https --trust
 ```

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -309,7 +309,7 @@ Uncheck the **Configure for HTTPS** check box.
 
 Use the `--no-https` option. For example
 
-```console
+```dotnetcli
 dotnet new webapp --no-https
 ```
 
@@ -332,13 +332,13 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
 
 Installing the .NET Core SDK installs the ASP.NET Core HTTPS development certificate to the local user certificate store. The certificate has been installed, but it's not trusted. To trust the certificate perform the one-time step to run the dotnet `dev-certs` tool:
 
-```console
+```dotnetcli
 dotnet dev-certs https --trust
 ```
 
 The following command provides help on the `dev-certs` tool:
 
-```console
+```dotnetcli
 dotnet dev-certs https --help
 ```
 

--- a/aspnetcore/security/key-vault-configuration.md
+++ b/aspnetcore/security/key-vault-configuration.md
@@ -55,13 +55,13 @@ Secrets are created as name-value pairs. Hierarchical values (configuration sect
 
 The Secret Manager is used from a command shell opened to the project's content root, where `{SECRET NAME}` is the name and `{SECRET VALUE}` is the value:
 
-```console
+```dotnetcli
 dotnet user-secrets set "{SECRET NAME}" "{SECRET VALUE}"
 ```
 
 Execute the following commands in a command shell from the project's content root to set the secrets for the sample app:
 
-```console
+```dotnetcli
 dotnet user-secrets set "SecretName" "secret_value_1_dev"
 dotnet user-secrets set "Section:SecretName" "secret_value_2_dev"
 ```
@@ -227,7 +227,7 @@ When this approach is implemented:
 
    Save the following secrets locally with the [Secret Manager tool](xref:security/app-secrets):
 
-   ```console
+   ```dotnetcli
    dotnet user-secrets set "5000-AppSecret" "5.0.0.0_secret_value_dev"
    dotnet user-secrets set "5100-AppSecret" "5.1.0.0_secret_value_dev"
    ```

--- a/aspnetcore/signalr/dotnet-client.md
+++ b/aspnetcore/signalr/dotnet-client.md
@@ -33,7 +33,7 @@ Install-Package Microsoft.AspNetCore.SignalR.Client
 
 To install the client library, run the following command in a command shell:
 
-```console
+```dotnetcli
 dotnet add package Microsoft.AspNetCore.SignalR.Client
 ```
 

--- a/aspnetcore/test/integration-tests.md
+++ b/aspnetcore/test/integration-tests.md
@@ -305,7 +305,7 @@ The [sample app](https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcor
 
 The tests can be run using the built-in test features of an IDE, such as [Visual Studio](https://visualstudio.microsoft.com). If using [Visual Studio Code](https://code.visualstudio.com/) or the command line, execute the following command at a command prompt in the *tests/RazorPagesProject.Tests* directory:
 
-```console
+```dotnetcli
 dotnet test
 ```
 

--- a/aspnetcore/test/integration-tests/samples/2.x/IntegrationTestsSample/src/RazorPagesProject/README.md
+++ b/aspnetcore/test/integration-tests/samples/2.x/IntegrationTestsSample/src/RazorPagesProject/README.md
@@ -4,6 +4,6 @@ This sample illustrates integration testing of an [ASP.NET Core Razor Pages](htt
 
 If you aren't using an IDE with built-in testing features, execute the following command at a command prompt in the *tests/RazorPagesProject.Tests* folder:
 
-```console
+```dotnetcli
 dotnet test
 ```

--- a/aspnetcore/test/integration-tests/samples/2.x/IntegrationTestsSample/tests/RazorPagesProject.Tests/README.md
+++ b/aspnetcore/test/integration-tests/samples/2.x/IntegrationTestsSample/tests/RazorPagesProject.Tests/README.md
@@ -4,6 +4,6 @@ This sample illustrates integration testing of an [ASP.NET Core Razor Pages](htt
 
 If you aren't using an IDE with built-in testing features, execute the following command at a command prompt in the *tests/RazorPagesProject.Tests* folder:
 
-```console
+```dotnetcli
 dotnet test
 ```

--- a/aspnetcore/test/razor-pages-tests.md
+++ b/aspnetcore/test/razor-pages-tests.md
@@ -38,7 +38,7 @@ The sample project is composed of two apps:
 
 The tests can be run using the built-in test features of an IDE, such as [Visual Studio](/visualstudio/test/unit-test-your-code) or [Visual Studio for Mac](/dotnet/core/tutorials/using-on-mac-vs-full-solution). If using [Visual Studio Code](https://code.visualstudio.com/) or the command line, execute the following command at a command prompt in the *tests/RazorPagesTestSample.Tests* folder:
 
-```console
+```dotnetcli
 dotnet test
 ```
 
@@ -222,7 +222,7 @@ The sample project is composed of two apps:
 
 The tests can be run using the built-in test features of an IDE, such as [Visual Studio](/visualstudio/test/unit-test-your-code) or [Visual Studio for Mac](/dotnet/core/tutorials/using-on-mac-vs-full-solution). If using [Visual Studio Code](https://code.visualstudio.com/) or the command line, execute the following command at a command prompt in the *tests/RazorPagesTestSample.Tests* folder:
 
-```console
+```dotnetcli
 dotnet test
 ```
 

--- a/aspnetcore/test/troubleshoot-azure-iis.md
+++ b/aspnetcore/test/troubleshoot-azure-iis.md
@@ -259,7 +259,7 @@ Many startup errors don't produce useful information in the Application Event Lo
 1. Run the app:
    * If the app is a [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd):
 
-     ```console
+     ```dotnetcli
      dotnet .\{ASSEMBLY NAME}.dll
      ```
 

--- a/aspnetcore/tutorials/dotnet-watch.md
+++ b/aspnetcore/tutorials/dotnet-watch.md
@@ -18,7 +18,7 @@ Download the [sample app](https://github.com/aspnet/AspNetCore.Docs/tree/master/
 
 In a command shell, navigate to the *WebApp* folder. Run the following command:
 
-```console
+```dotnetcli
 dotnet run
 ```
 
@@ -55,7 +55,7 @@ The `dotnet watch` file watcher tool is included with version 2.1.300 of the .NE
 
 1. Install the `Microsoft.DotNet.Watcher.Tools` package by running the following command:
 
-    ```console
+    ```dotnetcli
     dotnet restore
     ```
 
@@ -171,7 +171,7 @@ If the goal is to watch both projects, create a custom project file configured t
 
 To start file watching on both projects, change to the *test* folder. Execute the following command:
 
-```console
+```dotnetcli
 dotnet watch msbuild /t:Test
 ```
 

--- a/aspnetcore/tutorials/first-mongo-app.md
+++ b/aspnetcore/tutorials/first-mongo-app.md
@@ -157,7 +157,7 @@ The database is ready. You can start creating the ASP.NET Core web API.
 
 1. Run the following commands in a command shell:
 
-   ```console
+   ```dotnetcli
    dotnet new webapi -o BooksApi
    code BooksApi
    ```
@@ -167,7 +167,7 @@ The database is ready. You can start creating the ASP.NET Core web API.
 1. After the status bar's OmniSharp flame icon turns green, a dialog asks **Required assets to build and debug are missing from 'BooksApi'. Add them?**. Select **Yes**.
 1. Visit the [NuGet Gallery: MongoDB.Driver](https://www.nuget.org/packages/MongoDB.Driver/) to determine the latest stable version of the .NET driver for MongoDB. Open **Integrated Terminal** and navigate to the project root. Run the following command to install the .NET driver for MongoDB:
 
-   ```console
+   ```dotnetcli
    dotnet add BooksApi.csproj package MongoDB.Driver -v {VERSION}
    ```
 
@@ -507,7 +507,7 @@ The database is ready. You can start creating the ASP.NET Core web API.
 
 1. Run the following commands in a command shell:
 
-   ```console
+   ```dotnetcli
    dotnet new webapi -o BooksApi
    code BooksApi
    ```
@@ -517,7 +517,7 @@ The database is ready. You can start creating the ASP.NET Core web API.
 1. After the status bar's OmniSharp flame icon turns green, a dialog asks **Required assets to build and debug are missing from 'BooksApi'. Add them?**. Select **Yes**.
 1. Visit the [NuGet Gallery: MongoDB.Driver](https://www.nuget.org/packages/MongoDB.Driver/) to determine the latest stable version of the .NET driver for MongoDB. Open **Integrated Terminal** and navigate to the project root. Run the following command to install the .NET driver for MongoDB:
 
-   ```console
+   ```dotnetcli
    dotnet add BooksApi.csproj package MongoDB.Driver -v {VERSION}
    ```
 

--- a/aspnetcore/tutorials/first-mvc-app/adding-model.md
+++ b/aspnetcore/tutorials/first-mvc-app/adding-model.md
@@ -66,7 +66,7 @@ The preceding command adds the EF Core SQL Server provider. The provider package
 
 Run the following .NET Core CLI commands:
 
-```console
+```dotnetcli
 dotnet tool install --global dotnet-ef --version 3.0.0-*
 dotnet add package Microsoft.EntityFrameworkCore.SQLite --version 3.0.0-*
 dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design --version 3.0.0-*
@@ -185,8 +185,8 @@ The automatic creation of these files is known as *scaffolding*.
 
 * Run the following command:
 
-  ```console
-     dotnet aspnet-codegenerator controller -name MoviesController -m Movie -dc MvcMovieContext --relativeFolderPath Controllers --useDefaultLayout --referenceScriptLibraries
+  ```dotnetcli
+   dotnet aspnet-codegenerator controller -name MoviesController -m Movie -dc MvcMovieContext --relativeFolderPath Controllers --useDefaultLayout --referenceScriptLibraries
   ```
 
   [!INCLUDE [explains scaffold generated params](~/includes/mvc-intro/model4.md)]
@@ -197,8 +197,8 @@ The automatic creation of these files is known as *scaffolding*.
 
 * Run the following command:
 
-  ```console
-     dotnet aspnet-codegenerator controller -name MoviesController -m Movie -dc MvcMovieContext --relativeFolderPath Controllers --useDefaultLayout --referenceScriptLibraries
+  ```dotnetcli
+   dotnet aspnet-codegenerator controller -name MoviesController -m Movie -dc MvcMovieContext --relativeFolderPath Controllers --useDefaultLayout --referenceScriptLibraries
   ```
 
   [!INCLUDE [explains scaffold generated params](~/includes/mvc-intro/model4.md)]
@@ -242,7 +242,7 @@ Update-Database
 
 Run the following .NET Core CLI commands:
 
-```console
+```dotnetcli
 dotnet ef migrations add InitialCreate
 dotnet ef database update
 ```
@@ -442,7 +442,7 @@ The automatic creation of the database context and [CRUD](https://wikipedia.org/
 * Open a command window in the project directory (The directory that contains the *Program.cs*, *Startup.cs*, and *.csproj* files).
 * Install the scaffolding tool:
 
-  ```console
+  ```dotnetcli
    dotnet tool install --global dotnet-aspnet-codegenerator
    ```
 
@@ -454,8 +454,8 @@ The automatic creation of the database context and [CRUD](https://wikipedia.org/
 
 * Run the following command:
 
-  ```console
-     dotnet aspnet-codegenerator controller -name MoviesController -m Movie -dc MvcMovieContext --relativeFolderPath Controllers --useDefaultLayout --referenceScriptLibraries
+  ```dotnetcli
+   dotnet aspnet-codegenerator controller -name MoviesController -m Movie -dc MvcMovieContext --relativeFolderPath Controllers --useDefaultLayout --referenceScriptLibraries
   ```
 
 [!INCLUDE [explains scaffold generated params](~/includes/mvc-intro/model4.md)]
@@ -467,14 +467,14 @@ The automatic creation of the database context and [CRUD](https://wikipedia.org/
 * Open a command window in the project directory (The directory that contains the *Program.cs*, *Startup.cs*, and *.csproj* files).
 * Install the scaffolding tool:
 
-  ```console
+  ```dotnetcli
    dotnet tool install --global dotnet-aspnet-codegenerator
    ```
 
 * Run the following command:
 
-  ```console
-     dotnet aspnet-codegenerator controller -name MoviesController -m Movie -dc MvcMovieContext --relativeFolderPath Controllers --useDefaultLayout --referenceScriptLibraries
+  ```dotnetcli
+   dotnet aspnet-codegenerator controller -name MoviesController -m Movie -dc MvcMovieContext --relativeFolderPath Controllers --useDefaultLayout --referenceScriptLibraries
   ```
 
 [!INCLUDE [explains scaffold generated params](~/includes/mvc-intro/model4.md)]

--- a/aspnetcore/tutorials/first-mvc-app/new-field.md
+++ b/aspnetcore/tutorials/first-mvc-app/new-field.md
@@ -35,7 +35,9 @@ Build the app
 
 ### [Visual Studio Code](#tab/visual-studio-code)
 
-`dotnet build`
+```dotnetcli
+dotnet build
+```
 
 ### [Visual Studio for Mac](#tab/visual-studio-mac)
 
@@ -116,7 +118,7 @@ If all the records in the DB are deleted, the initialize method will seed the DB
 
 Delete the database and use migrations to re-create the database. To delete the database, delete the database file (*MvcMovie.db*). Then run the `ef database update` command:
 
-```console
+```dotnetcli
 dotnet ef database update
 ```
 

--- a/aspnetcore/tutorials/first-mvc-app/start-mvc.md
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc.md
@@ -72,7 +72,7 @@ The tutorial assumes familarity with VS Code. See [Getting started with VS Code]
 * Change directories (`cd`) to a folder which will contain the project.
 * Run the following command:
 
-   ```console
+   ```dotnetcli
    dotnet new mvc -o MvcMovie
    code -r MvcMovie
    ```
@@ -222,7 +222,7 @@ The tutorial assumes familarity with VS Code. See [Getting started with VS Code]
 * Change directories (`cd`) to a folder which will contain the project.
 * Run the following command:
 
-   ```console
+   ```dotnetcli
    dotnet new mvc -o MvcMovie
    code -r MvcMovie
    ```

--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -76,7 +76,7 @@ The following diagram shows the design of the app.
 * Change directories (`cd`) to the folder that will contain the project folder.
 * Run the following commands:
 
-   ```console
+   ```dotnetcli
    dotnet new webapi -o TodoApi
    cd TodoAPI
    dotnet add package Microsoft.EntityFrameworkCore.SqlServer --version 3.0.0-*
@@ -111,7 +111,7 @@ The following diagram shows the design of the app.
 
 Open a command terminal in the project folder and run the following commands:
 
-   ```console
+   ```dotnetcli
    dotnet add package Microsoft.EntityFrameworkCore.SqlServer --version 3.0.0-*
    dotnet add package Microsoft.EntityFrameworkCore.InMemory --version 3.0.0-*
    ```
@@ -275,7 +275,7 @@ The preceding code:
 
 Run the following commands:
 
-```console
+```dotnetcli
 dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design --version 3.0.0-*
 dotnet add package Microsoft.EntityFrameworkCore.Design --version 3.0.0-*
 dotnet tool install --global dotnet-aspnet-codegenerator
@@ -528,7 +528,7 @@ The following diagram shows the design of the app.
 * Change directories (`cd`) to the folder that will contain the project folder.
 * Run the following commands:
 
-   ```console
+   ```dotnetcli
    dotnet new webapi -o TodoApi
    code -r TodoApi
    ```

--- a/aspnetcore/tutorials/getting-started-with-NSwag.md
+++ b/aspnetcore/tutorials/getting-started-with-NSwag.md
@@ -69,7 +69,7 @@ Use one of the following approaches to install the NSwag NuGet package:
 
 Run the following command:
 
-```console
+```dotnetcli
 dotnet add TodoApi.csproj package NSwag.AspNetCore
 ```
 

--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -55,7 +55,7 @@ Swashbuckle can be added with the following approaches:
 
 Run the following command from the **Integrated Terminal**:
 
-```console
+```dotnetcli
 dotnet add TodoApi.csproj package Swashbuckle.AspNetCore -v 5.0.0-rc2
 ```
 
@@ -63,7 +63,7 @@ dotnet add TodoApi.csproj package Swashbuckle.AspNetCore -v 5.0.0-rc2
 
 Run the following command:
 
-```console
+```dotnetcli
 dotnet add TodoApi.csproj package Swashbuckle.AspNetCore -v 5.0.0-rc2
 ```
 

--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -61,7 +61,7 @@ In this tutorial, you:
 * Change directories (`cd`) to a folder which will contain the project.
 * Run the following commands:
 
-  ```console
+  ```dotnetcli
   dotnet new grpc -o GrpcGreeter
   code -r GrpcGreeter
   ```
@@ -76,9 +76,9 @@ In this tutorial, you:
 
 From a terminal, run the following commands:
 
-```console
-  dotnet new grpc -o GrpcGreeter
-  cd GrpcGreeter
+```dotnetcli
+dotnet new grpc -o GrpcGreeter
+cd GrpcGreeter
 ```
 
 The preceding commands use the [.NET Core CLI](/dotnet/core/tools/dotnet) to create a gRPC service.
@@ -147,7 +147,7 @@ info: Microsoft.Hosting.Lifetime[0]
 * Change directories (`cd`) to a folder which will contain the project.
 * Run the following commands:
 
-  ```console
+  ```dotnetcli
   dotnet new console -o GrpcGreeterClient
   code -r GrpcGreeterClient
   ```
@@ -194,7 +194,7 @@ Install the packages using either the Package Manager Console (PMC) or Manage Nu
 
 Run the following commands from the **Integrated Terminal**:
 
-```console
+```dotnetcli
 dotnet add GrpcGreeterClient.csproj package Grpc.Net.Client
 dotnet add GrpcGreeterClient.csproj package Google.Protobuf
 dotnet add GrpcGreeterClient.csproj package Grpc.Tools

--- a/aspnetcore/tutorials/publish-to-azure-webapp-using-vscode.md
+++ b/aspnetcore/tutorials/publish-to-azure-webapp-using-vscode.md
@@ -35,8 +35,8 @@ and deploy it within Visual Studio Code.
 Using a terminal, navigate to the folder you want the project to be created on
 and use the following command:
 
-```cmd
-> dotnet new mvc
+```dotnetcli
+dotnet new mvc
 ```
 
 You'll have a folder structure similar to the following:

--- a/aspnetcore/tutorials/publish-to-iis.md
+++ b/aspnetcore/tutorials/publish-to-iis.md
@@ -78,7 +78,7 @@ Follow the <xref:getting-started> tutorial to create a Razor Pages app.
 
 1. In a command shell, publish the app in Release configuration with the [dotnet publish](/dotnet/core/tools/dotnet-publish) command:
 
-   ```console
+   ```dotnetcli
    dotnet publish --configuration Release
    ```
 

--- a/aspnetcore/tutorials/razor-pages/model.md
+++ b/aspnetcore/tutorials/razor-pages/model.md
@@ -92,19 +92,19 @@ The *appsettings.json* file is updated with the connection string used to connec
 * Open a command window in the project directory (The directory that contains the *Program.cs*, *Startup.cs*, and *.csproj* files).
 * Install the scaffolding tool:
 
-  ```console
+  ```dotnetcli
    dotnet tool install --global dotnet-aspnet-codegenerator --version 3.0.0-*
    ```
 
 * **For Windows**: Run the following command:
 
-  ```console
+  ```dotnetcli
   dotnet aspnet-codegenerator razorpage -m Movie -dc RazorPagesMovieContext -udl -outDir Pages\Movies --referenceScriptLibraries
   ```
 
 * **For macOS and Linux**: Run the following command:
 
-  ```console
+  ```dotnetcli
   dotnet aspnet-codegenerator razorpage -m Movie -dc RazorPagesMovieContext -udl -outDir Pages/Movies --referenceScriptLibraries
   ```
 
@@ -115,13 +115,13 @@ The *appsettings.json* file is updated with the connection string used to connec
 * Open a command window in the project directory (The directory that contains the *Program.cs*, *Startup.cs*, and *.csproj* files).
 * Install the scaffolding tool:
 
-  ```console
+  ```dotnetcli
    dotnet tool install --global dotnet-aspnet-codegenerator --version 3.0.0-*
    ```
 
 * Run the following command:
 
-  ```console
+  ```dotnetcli
   dotnet aspnet-codegenerator razorpage -m Movie -dc RazorPagesMovieContext -udl -outDir Pages/Movies --referenceScriptLibraries
   ```
 
@@ -349,19 +349,19 @@ The *appsettings.json* file is updated with the connection string used to connec
 * Open a command window in the project directory (The directory that contains the *Program.cs*, *Startup.cs*, and *.csproj* files).
 * Install the scaffolding tool:
 
-  ```console
+  ```dotnetcli
    dotnet tool install --global dotnet-aspnet-codegenerator
    ```
 
 * **For Windows**: Run the following command:
 
-  ```console
+  ```dotnetcli
   dotnet aspnet-codegenerator razorpage -m Movie -dc RazorPagesMovieContext -udl -outDir Pages\Movies --referenceScriptLibraries
   ```
 
 * **For macOS and Linux**: Run the following command:
 
-  ```console
+  ```dotnetcli
   dotnet aspnet-codegenerator razorpage -m Movie -dc RazorPagesMovieContext -udl -outDir Pages/Movies --referenceScriptLibraries
   ```
 
@@ -372,13 +372,13 @@ The *appsettings.json* file is updated with the connection string used to connec
 * Open a command window in the project directory (The directory that contains the *Program.cs*, *Startup.cs*, and *.csproj* files).
 * Install the scaffolding tool:
 
-  ```console
+  ```dotnetcli
    dotnet tool install --global dotnet-aspnet-codegenerator
    ```
 
 * Run the following command:
 
-  ```console
+  ```dotnetcli
   dotnet aspnet-codegenerator razorpage -m Movie -dc RazorPagesMovieContext -udl -outDir Pages/Movies --referenceScriptLibraries
   ```
 

--- a/aspnetcore/tutorials/razor-pages/new-field.md
+++ b/aspnetcore/tutorials/razor-pages/new-field.md
@@ -116,7 +116,7 @@ Another option is to delete the database and use migrations to re-create the dat
 
 Delete the migration folder.  Use the following commands to recreate the database.
 
-```console
+```dotnetcli
 dotnet ef database drop
 dotnet ef migrations add InitialCreate
 dotnet ef database update
@@ -241,7 +241,7 @@ Another option is to delete the database and use migrations to re-create the dat
 
 Delete the database and use migrations to re-create the database. To delete the database, delete the database file (*MvcMovie.db*). Then run the `ef database update` command:
 
-```console
+```dotnetcli
 dotnet ef database update
 ```
 

--- a/aspnetcore/tutorials/razor-pages/razor-pages-start.md
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start.md
@@ -73,7 +73,7 @@ At the end of this tutorial, you'll have a working Razor Pages web app that you'
 
 * Run the following commands:
 
-  ```console
+  ```dotnetcli
   dotnet new webapp -o RazorPagesMovie
   code -r RazorPagesMovie
   ```
@@ -250,7 +250,7 @@ At the end of this tutorial, you'll have a working Razor Pages web app that you'
 
 * Run the following commands:
 
-  ```console
+  ```dotnetcli
   dotnet new webapp -o RazorPagesMovie
   code -r RazorPagesMovie
   ```
@@ -268,7 +268,7 @@ From a terminal, run the following command:
 
 <!-- TODO: update these instruction once mac support 2.2 projects -->
 
-```console
+```dotnetcli
 dotnet new webapp -o RazorPagesMovie
 ```
 

--- a/aspnetcore/tutorials/signalr-typescript-webpack.md
+++ b/aspnetcore/tutorials/signalr-typescript-webpack.md
@@ -64,7 +64,7 @@ Visual Studio configuration is completed. It's time to create the project.
 
 Run the following command in the **Integrated Terminal**:
 
-```console
+```dotnetcli
 dotnet new web -o SignalRWebPack
 ```
 
@@ -243,7 +243,7 @@ Confirm that the app works with the following steps.
 
 1. Build and run the app by executing the following command in the project root:
 
-    ```console
+    ```dotnetcli
     dotnet run
     ```
 
@@ -299,7 +299,7 @@ Visual Studio configuration is completed. It's time to create the project.
 
 Run the following command in the **Integrated Terminal**:
 
-```console
+```dotnetcli
 dotnet new web -o SignalRWebPack
 ```
 
@@ -478,7 +478,7 @@ Confirm that the app works with the following steps.
 
 1. Build and run the app by executing the following command in the project root:
 
-    ```console
+    ```dotnetcli
     dotnet run
     ```
 

--- a/aspnetcore/tutorials/signalr.md
+++ b/aspnetcore/tutorials/signalr.md
@@ -65,7 +65,7 @@ At the end, you'll have a working chat app:
 
 * Run the following commands:
 
-   ```console
+   ```dotnetcli
    dotnet new webapp -o SignalRChat
    code -r SignalRChat
    ```
@@ -107,7 +107,7 @@ The SignalR server library is included in the ASP.NET Core 3.0 shared framework.
 
 * In the integrated terminal, run the following command to install LibMan.
 
-  ```console
+  ```dotnetcli
   dotnet tool install -g Microsoft.Web.LibraryManager.Cli
   ```
 
@@ -134,7 +134,7 @@ The SignalR server library is included in the ASP.NET Core 3.0 shared framework.
 
 * In the **Terminal**, run the following command to install LibMan.
 
-  ```console
+  ```dotnetcli
   dotnet tool install -g Microsoft.Web.LibraryManager.Cli
   ```
 
@@ -217,7 +217,7 @@ The SignalR server must be configured to pass SignalR requests to SignalR.
 
 * In the integrated terminal, run the following command:
 
-  ```console
+  ```dotnetcli
   dotnet run -p SignalRChat.csproj
   ```
 
@@ -239,7 +239,8 @@ The SignalR server must be configured to pass SignalR requests to SignalR.
 > * If the app doesn't work, open your browser developer tools (F12) and go to the console. You might see errors related to your HTML and JavaScript code. For example, suppose you put *signalr.js* in a different folder than directed. In that case the reference to that file won't work and you'll see a 404 error in the console.
 >   ![signalr.js not found error](signalr/_static/3.x/f12-console.png)
 > * If you get the error ERR_SPDY_INADEQUATE_TRANSPORT_SECURITY in Chrome or NS_ERROR_NET_INADEQUATE_SECURITY in Firefox, run these commands to update your development certificate:
->   ```
+>
+>   ```dotnetcli
 >   dotnet dev-certs https --clean
 >   dotnet dev-certs https --trust
 >   ```
@@ -306,7 +307,7 @@ At the end, you'll have a working chat app:
 
 * Run the following commands:
 
-   ```console
+   ```dotnetcli
    dotnet new webapp -o SignalRChat
    code -r SignalRChat
    ```
@@ -349,7 +350,7 @@ The SignalR server library is included in the `Microsoft.AspNetCore.App` metapac
 
 * In the integrated terminal, run the following command to install LibMan.
 
-  ```console
+  ```dotnetcli
   dotnet tool install -g Microsoft.Web.LibraryManager.Cli
   ```
 
@@ -376,7 +377,7 @@ The SignalR server library is included in the `Microsoft.AspNetCore.App` metapac
 
 * In the **Terminal**, run the following command to install LibMan.
 
-  ```console
+  ```dotnetcli
   dotnet tool install -g Microsoft.Web.LibraryManager.Cli
   ```
 
@@ -459,7 +460,7 @@ The SignalR server must be configured to pass SignalR requests to SignalR.
 
 * In the integrated terminal, run the following command:
 
-  ```console
+  ```dotnetcli
   dotnet run -p SignalRChat.csproj
   ```
 

--- a/aspnetcore/web-api/advanced/analyzers.md
+++ b/aspnetcore/web-api/advanced/analyzers.md
@@ -61,7 +61,7 @@ From the **Package Manager Console** window:
 
 Run the following command from the **Integrated Terminal**:
 
-```console
+```dotnetcli
 dotnet add ApiConventions.csproj package Microsoft.AspNetCore.Mvc.Api.Analyzers
 ```
 
@@ -69,7 +69,7 @@ dotnet add ApiConventions.csproj package Microsoft.AspNetCore.Mvc.Api.Analyzers
 
 Run the following command:
 
-```console
+```dotnetcli
 dotnet add ApiConventions.csproj package Microsoft.AspNetCore.Mvc.Api.Analyzers
 ```
 

--- a/aspnetcore/web-api/http-repl.md
+++ b/aspnetcore/web-api/http-repl.md
@@ -38,7 +38,7 @@ To follow along, [view or download the sample ASP.NET Core web API](https://gith
 
 To install the HTTP REPL, run the following command:
 
-```console
+```dotnetcli
 dotnet tool install -g Microsoft.dotnet-httprepl --version "3.0.0-*"
 ```
 


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore.Docs/issues/14360

Improves the readability of the .NET Core CLI commands used throughout the doc set. For example:

![image](https://user-images.githubusercontent.com/10702007/65076997-a5e6d600-d95f-11e9-9591-0d02561a82d7.png)

FYI, @guardrex, @wadepickett