### PR TITLE
SignalR Json instructions

### DIFF
--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -194,6 +194,8 @@ Apps and libraries targeting ASP.NET Core 2.1 or later should remove any direct 
 
 As part of the work to [improve the ASP.NET Core shared framework](https://blogs.msdn.microsoft.com/webdev/2018/10/29/a-first-look-at-changes-coming-in-asp-net-core-3-0/), [Json.NET](https://www.newtonsoft.com/json/help/html/Introduction.htm) has been removed from the ASP.NET Core shared framework. Your app may require this reference if it uses `Newtonsoft.Json`-specific feature such as JsonPatch or converters or if it [formats](xref:web-api/advanced/formatting) `Newtonsoft.Json`-specific types.
 
+To use Json.NET in an ASP.NET Core 3.0 SignalR project, see [SignalR and Json.NET](#srjn) in this document.
+
 To use Json.NET in an ASP.NET Core 3.0 project:
 
 * Add a package reference to [Microsoft.AspNetCore.Mvc.NewtonsoftJson](https://nuget.org/packages/Microsoft.AspNetCore.Mvc.NewtonsoftJson).
@@ -625,6 +627,32 @@ public void Configure(IApplicationBuilder app)
             "default", "{controller=Home}/{action=Index}/{id?}");
     });
 }
+```
+
+<a name="srjn"></a>
+
+### SignalR and Json.NET
+
+ASP.NET Core 3.0 SignalR uses `System.Text.Json` to implement the JSON Hub Protocol. There are some serialization scenarios supported by `Newtonsoft.Json` which are not currently supported in `System.Text.Json`. If your server app is affected by one of those scenarios:
+
+* Revert to the `Newtonsoft.Json` based protocol package. Add `Newtonsoft.Json` by including adding a reference to the `Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson` NuGet package.
+* Chain a call to `AddNewtonsoftJson` to the `AddSignalR` call in `ConfigureServices`:
+
+```csharp
+services.AddSignalR()
+    .AddNewtonsoftJsonProtocol() // Revert to Newtonsoft.Json protocol implementation.
+```
+
+To revert the .NET client to the `Newtonsoft.Json` based protocol implementation:
+
+* Add a reference to the `Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson` NuGet package.
+* Chain a call to `AddNewtonsoftJson()` to the `HubConnectionBuilder` calls:
+
+```csharp
+var connection = new HubConnectionBuilder()
+    .WithUrl("...")
+    .AddNewtonsoftJsonProtocol() // Revert to Newtonsoft.Json protocol implementation.
+    .Build();
 ```
 
 ### Razor Pages


### PR DESCRIPTION
@anurse your comments belong in the migration guide, not what's new. I did put a pointer to these instructions in the what's new. You'll see that soon :)