### PR TITLE
RCL topic update for 3.0

### DIFF
--- a/aspnetcore/razor-pages/ui-class.md
+++ b/aspnetcore/razor-pages/ui-class.md
@@ -4,13 +4,15 @@ author: Rick-Anderson
 description: Explains how to create reusable Razor UI using partial views in a class library in ASP.NET Core.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
-ms.date: 08/22/2019
+ms.date: 09/21/2019
 ms.custom: "mvc, seodec18"
 uid: razor-pages/ui-class
 ---
 # Create reusable UI using the Razor class library project in ASP.NET Core
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT)
+
+::: moniker range=">= aspnetcore-3.0"
 
 Razor views, pages, controllers, page models, [Razor components](xref:blazor/class-libraries), [View components](xref:mvc/views/view-components), and data models can be built into a Razor class library (RCL). The RCL can be packaged and reused. Applications can include the RCL and override the views and pages it contains. When a view, partial view, or Razor Page is found in both the web app and the RCL, the Razor markup (*.cshtml* file) in the web app takes precedence.
 
@@ -28,9 +30,7 @@ This feature requires [!INCLUDE[](~/includes/2.1-SDK.md)]
 * Verify **ASP.NET Core 2.1** or later is selected.
 * Select **Razor Class Library** > **OK**.
 
-An RCL has the following project file:
-
-[!code-xml[Main](ui-class/samples/cli/RazorUIClassLib/RazorUIClassLib.csproj)]
+The Razor class library (RCL) template defaults to Razor component development by default. A template option in Visual Studio provides template support for pages and views.
 
 # [.NET Core CLI](#tab/netcore-cli)
 
@@ -40,160 +40,22 @@ From the command line, run `dotnet new razorclasslib`. For example:
 dotnet new razorclasslib -o RazorUIClassLib
 ```
 
+The Razor class library (RCL) template defaults to Razor component development by default. Pass the `-support-pages-and-views` option (`dotnet new razorclasslib -support-pages-and-views`) to provide support for pages and views.
+
 For more information, see [dotnet new](/dotnet/core/tools/dotnet-new). To avoid a file name collision with the generated view library, ensure the library name doesn't end in `.Views`.
 
 ---
 
 Add Razor files to the RCL.
 
-The ASP.NET Core templates assume the RCL content is in the *Areas* folder. See [RCL Pages layout](#afs) to create an RCL that exposes content in `~/Pages` rather than `~/Areas/Pages`.
+The ASP.NET Core templates assume the RCL content is in the *Areas* folder. See [RCL Pages layout](#rcl-pages-layout) to create an RCL that exposes content in `~/Pages` rather than `~/Areas/Pages`.
 
-## Referencing RCL content
+## Reference RCL content
 
 The RCL can be referenced by:
 
 * NuGet package. See [Creating NuGet packages](/nuget/create-packages/creating-a-package) and [dotnet add package](/dotnet/core/tools/dotnet-add-package) and [Create and publish a NuGet package](/nuget/quickstart/create-and-publish-a-package-using-visual-studio).
 * *{ProjectName}.csproj*. See [dotnet-add reference](/dotnet/core/tools/dotnet-add-reference).
-
-## Walkthrough: Create an RCL project and use from a Razor Pages project
-
-You can download the [complete project](https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/razor-pages/ui-class/samples) and test it rather than creating it. The sample download contains additional code and links that make the project easy to test. You can leave feedback in [this GitHub issue](https://github.com/aspnet/AspNetCore.Docs/issues/6098) with your comments on download samples versus step-by-step instructions.
-
-### Test the download app
-
-If you haven't downloaded the completed app and would rather create the walkthrough project, skip to the [next section](#create-an-rcl).
-
-# [Visual Studio](#tab/visual-studio)
-
-Open the *.sln* file in Visual Studio. Run the app.
-
-# [.NET Core CLI](#tab/netcore-cli)
-
-From a command prompt in the *cli* directory, build the RCL and web app.
-
-```dotnetcli
-dotnet build
-```
-
-Move to the *WebApp1* directory and run the app:
-
-```dotnetcli
-dotnet run
-```
-
----
-
-Follow the instructions in [Test WebApp1](#test)
-
-## Create an RCL
-
-In this section, an RCL is created. Razor files are added to the RCL.
-
-# [Visual Studio](#tab/visual-studio)
-
-Create the RCL project:
-
-* From the Visual Studio **File** menu, select **New** > **Project**.
-* Select **ASP.NET Core Web Application**.
-* Name the app **RazorUIClassLib** > **OK**.
-* Verify **ASP.NET Core 2.1** or later is selected.
-* Select **Razor Class Library** > **OK**.
-* Add a Razor partial view file named *RazorUIClassLib/Areas/MyFeature/Pages/Shared/_Message.cshtml*.
-
-# [.NET Core CLI](#tab/netcore-cli)
-
-From the command line, run the following:
-
-```dotnetcli
-dotnet new razorclasslib -o RazorUIClassLib
-dotnet new page -n _Message -np -o RazorUIClassLib/Areas/MyFeature/Pages/Shared
-dotnet new viewstart -o RazorUIClassLib/Areas/MyFeature/Pages
-```
-
-The preceding commands:
-
-* Creates the `RazorUIClassLib` RCL.
-* Creates a Razor _Message page, and adds it to the RCL. The `-np` parameter creates the page without a `PageModel`.
-* Creates a [_ViewStart.cshtml](xref:mvc/views/layout#running-code-before-each-view) file and adds it to the RCL.
-
-The *_ViewStart.cshtml* file is required to use the layout of the Razor Pages project (which is added in the next section).
-
----
-
-### Add Razor files and folders to the project
-
-* Replace the markup in *RazorUIClassLib/Areas/MyFeature/Pages/Shared/_Message.cshtml* with the following code:
-
-[!code-cshtml[Main](ui-class/samples/cli/RazorUIClassLib/Areas/MyFeature/Pages/Shared/_Message.cshtml)]
-
-* Replace the markup in *RazorUIClassLib/Areas/MyFeature/Pages/Page1.cshtml* with the following code:
-
-[!code-cshtml[Main](ui-class/samples/cli/RazorUIClassLib/Areas/MyFeature/Pages/Page1.cshtml)]
-
-`@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers` is required to use the partial view (`<partial name="_Message" />`). Rather than including the `@addTagHelper` directive, you can add a *_ViewImports.cshtml* file. For example:
-
-```dotnetcli
-dotnet new viewimports -o RazorUIClassLib/Areas/MyFeature/Pages
-```
-
-For more information on *_ViewImports.cshtml*, see [Importing Shared Directives](xref:mvc/views/layout#importing-shared-directives)
-
-* Build the class library to verify there are no compiler errors:
-
-```dotnetcli
-dotnet build RazorUIClassLib
-```
-
-The build output contains *RazorUIClassLib.dll* and *RazorUIClassLib.Views.dll*. *RazorUIClassLib.Views.dll* contains the compiled Razor content.
-
-### Use the Razor UI library from a Razor Pages project
-
-# [Visual Studio](#tab/visual-studio)
-
-Create the Razor Pages web app:
-
-* From **Solution Explorer**, right-click the solution > **Add** >  **New Project**.
-* Select **ASP.NET Core Web Application**.
-* Name the app **WebApp1**.
-* Verify **ASP.NET Core 2.1** or later is selected.
-* Select **Web Application** > **OK**.
-
-* From **Solution Explorer**, right-click on **WebApp1** and select **Set as StartUp Project**.
-* From **Solution Explorer**, right-click on **WebApp1** and select **Build Dependencies** > **Project Dependencies**.
-* Check **RazorUIClassLib** as a dependency of **WebApp1**.
-* From **Solution Explorer**, right-click on **WebApp1** and select **Add** > **Reference**.
-* In the **Reference Manager** dialog, check **RazorUIClassLib** > **OK**.
-
-Run the app.
-
-# [.NET Core CLI](#tab/netcore-cli)
-
-Create a Razor Pages web app and a solution file containing the Razor Pages app and the RCL:
-
-```dotnetcli
-dotnet new webapp -o WebApp1
-dotnet new sln
-dotnet sln add WebApp1
-dotnet sln add RazorUIClassLib
-dotnet add WebApp1 reference RazorUIClassLib
-```
-
-Build and run the web app:
-
-```dotnetcli
-cd WebApp1
-dotnet run
-```
-
----
-
-<a name="test"></a>
-
-### Test WebApp1
-
-Verify the Razor UI class library is in use:
-
-* Browse to `/MyFeature/Page1`.
 
 ## Override views, partial views, and pages
 
@@ -202,8 +64,6 @@ When a view, partial view, or Razor Page is found in both the web app and the RC
 In the sample download, rename *WebApp1/Areas/MyFeature2* to *WebApp1/Areas/MyFeature* to test precedence.
 
 Copy the *RazorUIClassLib/Areas/MyFeature/Pages/Shared/_Message.cshtml* partial view to *WebApp1/Areas/MyFeature/Pages/Shared/_Message.cshtml*. Update the markup to indicate the new location. Build and run the app to verify the app's version of the partial is being used.
-
-<a name="afs"></a>
 
 ### RCL Pages layout
 
@@ -221,8 +81,6 @@ Suppose *RazorUIClassLib/Pages/Shared* contains two partial files: *_Header.csht
   <partial name="_Footer">
 </body>
 ```
-
-::: moniker range=">= aspnetcore-3.0"
 
 ## Create an RCL with static assets
 
@@ -319,5 +177,213 @@ When the RCL is built, a manifest is produced that describes the static web asse
 ### Publish
 
 When the app is published, the companion assets from all referenced projects and packages are copied into the *wwwroot* folder of the published app under `_content/{LIBRARY NAME}/`.
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-3.0"
+
+Razor views, pages, controllers, page models, [Razor components](xref:blazor/class-libraries), [View components](xref:mvc/views/view-components), and data models can be built into a Razor class library (RCL). The RCL can be packaged and reused. Applications can include the RCL and override the views and pages it contains. When a view, partial view, or Razor Page is found in both the web app and the RCL, the Razor markup (*.cshtml* file) in the web app takes precedence.
+
+This feature requires [!INCLUDE[](~/includes/2.1-SDK.md)]
+
+[View or download sample code](https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/razor-pages/ui-class/samples) ([how to download](xref:index#how-to-download-a-sample))
+
+## Create a class library containing Razor UI
+
+# [Visual Studio](#tab/visual-studio)
+
+* From the Visual Studio **File** menu, select **New** > **Project**.
+* Select **ASP.NET Core Web Application**.
+* Name the library (for example, "RazorClassLib") > **OK**. To avoid a file name collision with the generated view library, ensure the library name doesn't end in `.Views`.
+* Verify **ASP.NET Core 2.1** or later is selected.
+* Select **Razor Class Library** > **OK**.
+
+An RCL has the following project file:
+
+[!code-xml[](ui-class/samples/cli/RazorUIClassLib/RazorUIClassLib.csproj)]
+
+# [.NET Core CLI](#tab/netcore-cli)
+
+From the command line, run `dotnet new razorclasslib`. For example:
+
+```dotnetcli
+dotnet new razorclasslib -o RazorUIClassLib
+```
+
+For more information, see [dotnet new](/dotnet/core/tools/dotnet-new). To avoid a file name collision with the generated view library, ensure the library name doesn't end in `.Views`.
+
+---
+
+Add Razor files to the RCL.
+
+The ASP.NET Core templates assume the RCL content is in the *Areas* folder. See [RCL Pages layout](#rcl-pages-layout) to create an RCL that exposes content in `~/Pages` rather than `~/Areas/Pages`.
+
+## Reference RCL content
+
+The RCL can be referenced by:
+
+* NuGet package. See [Creating NuGet packages](/nuget/create-packages/creating-a-package) and [dotnet add package](/dotnet/core/tools/dotnet-add-package) and [Create and publish a NuGet package](/nuget/quickstart/create-and-publish-a-package-using-visual-studio).
+* *{ProjectName}.csproj*. See [dotnet-add reference](/dotnet/core/tools/dotnet-add-reference).
+
+## Walkthrough: Create an RCL project and use from a Razor Pages project
+
+You can download the [complete project](https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/razor-pages/ui-class/samples) and test it rather than creating it. The sample download contains additional code and links that make the project easy to test. You can leave feedback in [this GitHub issue](https://github.com/aspnet/AspNetCore.Docs/issues/6098) with your comments on download samples versus step-by-step instructions.
+
+### Test the download app
+
+If you haven't downloaded the completed app and would rather create the walkthrough project, skip to the [next section](#create-an-rcl).
+
+# [Visual Studio](#tab/visual-studio)
+
+Open the *.sln* file in Visual Studio. Run the app.
+
+# [.NET Core CLI](#tab/netcore-cli)
+
+From a command prompt in the *cli* directory, build the RCL and web app.
+
+```dotnetcli
+dotnet build
+```
+
+Move to the *WebApp1* directory and run the app:
+
+```dotnetcli
+dotnet run
+```
+
+---
+
+Follow the instructions in [Test WebApp1](#test-webapp1)
+
+## Create an RCL
+
+In this section, an RCL is created. Razor files are added to the RCL.
+
+# [Visual Studio](#tab/visual-studio)
+
+Create the RCL project:
+
+* From the Visual Studio **File** menu, select **New** > **Project**.
+* Select **ASP.NET Core Web Application**.
+* Name the app **RazorUIClassLib** > **OK**.
+* Verify **ASP.NET Core 2.1** or later is selected.
+* Select **Razor Class Library** > **OK**.
+* Add a Razor partial view file named *RazorUIClassLib/Areas/MyFeature/Pages/Shared/_Message.cshtml*.
+
+# [.NET Core CLI](#tab/netcore-cli)
+
+From the command line, run the following:
+
+```dotnetcli
+dotnet new razorclasslib -o RazorUIClassLib
+dotnet new page -n _Message -np -o RazorUIClassLib/Areas/MyFeature/Pages/Shared
+dotnet new viewstart -o RazorUIClassLib/Areas/MyFeature/Pages
+```
+
+The preceding commands:
+
+* Creates the `RazorUIClassLib` RCL.
+* Creates a Razor _Message page, and adds it to the RCL. The `-np` parameter creates the page without a `PageModel`.
+* Creates a [_ViewStart.cshtml](xref:mvc/views/layout#running-code-before-each-view) file and adds it to the RCL.
+
+The *_ViewStart.cshtml* file is required to use the layout of the Razor Pages project (which is added in the next section).
+
+---
+
+### Add Razor files and folders to the project
+
+* Replace the markup in *RazorUIClassLib/Areas/MyFeature/Pages/Shared/_Message.cshtml* with the following code:
+
+  [!code-cshtml[](ui-class/samples/cli/RazorUIClassLib/Areas/MyFeature/Pages/Shared/_Message.cshtml)]
+
+* Replace the markup in *RazorUIClassLib/Areas/MyFeature/Pages/Page1.cshtml* with the following code:
+
+  [!code-cshtml[](ui-class/samples/cli/RazorUIClassLib/Areas/MyFeature/Pages/Page1.cshtml)]
+
+  `@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers` is required to use the partial view (`<partial name="_Message" />`). Rather than including the `@addTagHelper` directive, you can add a *_ViewImports.cshtml* file. For example:
+
+  ```dotnetcli
+  dotnet new viewimports -o RazorUIClassLib/Areas/MyFeature/Pages
+  ```
+
+  For more information on *_ViewImports.cshtml*, see [Importing Shared Directives](xref:mvc/views/layout#importing-shared-directives)
+
+* Build the class library to verify there are no compiler errors:
+
+  ```dotnetcli
+  dotnet build RazorUIClassLib
+  ```
+
+The build output contains *RazorUIClassLib.dll* and *RazorUIClassLib.Views.dll*. *RazorUIClassLib.Views.dll* contains the compiled Razor content.
+
+### Use the Razor UI library from a Razor Pages project
+
+# [Visual Studio](#tab/visual-studio)
+
+Create the Razor Pages web app:
+
+* From **Solution Explorer**, right-click the solution > **Add** >  **New Project**.
+* Select **ASP.NET Core Web Application**.
+* Name the app **WebApp1**.
+* Verify **ASP.NET Core 2.1** or later is selected.
+* Select **Web Application** > **OK**.
+
+* From **Solution Explorer**, right-click on **WebApp1** and select **Set as StartUp Project**.
+* From **Solution Explorer**, right-click on **WebApp1** and select **Build Dependencies** > **Project Dependencies**.
+* Check **RazorUIClassLib** as a dependency of **WebApp1**.
+* From **Solution Explorer**, right-click on **WebApp1** and select **Add** > **Reference**.
+* In the **Reference Manager** dialog, check **RazorUIClassLib** > **OK**.
+
+Run the app.
+
+# [.NET Core CLI](#tab/netcore-cli)
+
+Create a Razor Pages web app and a solution file containing the Razor Pages app and the RCL:
+
+```dotnetcli
+dotnet new webapp -o WebApp1
+dotnet new sln
+dotnet sln add WebApp1
+dotnet sln add RazorUIClassLib
+dotnet add WebApp1 reference RazorUIClassLib
+```
+
+Build and run the web app:
+
+```dotnetcli
+cd WebApp1
+dotnet run
+```
+
+---
+
+### Test WebApp1
+
+Browse to `/MyFeature/Page1` to verify that the Razor UI class library is in use.
+
+## Override views, partial views, and pages
+
+When a view, partial view, or Razor Page is found in both the web app and the RCL, the Razor markup (*.cshtml* file) in the web app takes precedence. For example, add *WebApp1/Areas/MyFeature/Pages/Page1.cshtml* to WebApp1, and Page1 in the WebApp1 will take precedence over Page1 in the RCL.
+
+In the sample download, rename *WebApp1/Areas/MyFeature2* to *WebApp1/Areas/MyFeature* to test precedence.
+
+Copy the *RazorUIClassLib/Areas/MyFeature/Pages/Shared/_Message.cshtml* partial view to *WebApp1/Areas/MyFeature/Pages/Shared/_Message.cshtml*. Update the markup to indicate the new location. Build and run the app to verify the app's version of the partial is being used.
+
+### RCL Pages layout
+
+To reference RCL content as though it is part of the web app's *Pages* folder, create the RCL project with the following file structure:
+
+* *RazorUIClassLib/Pages*
+* *RazorUIClassLib/Pages/Shared*
+
+Suppose *RazorUIClassLib/Pages/Shared* contains two partial files: *_Header.cshtml* and *_Footer.cshtml*. The `<partial>` tags could be added to *_Layout.cshtml* file:
+
+```cshtml
+<body>
+  <partial name="_Header">
+  @RenderBody()
+  <partial name="_Footer">
+</body>
+```
 
 ::: moniker-end

--- a/aspnetcore/razor-pages/ui-class.md
+++ b/aspnetcore/razor-pages/ui-class.md
@@ -16,8 +16,6 @@ By [Rick Anderson](https://twitter.com/RickAndMSFT)
 
 Razor views, pages, controllers, page models, [Razor components](xref:blazor/class-libraries), [View components](xref:mvc/views/view-components), and data models can be built into a Razor class library (RCL). The RCL can be packaged and reused. Applications can include the RCL and override the views and pages it contains. When a view, partial view, or Razor Page is found in both the web app and the RCL, the Razor markup (*.cshtml* file) in the web app takes precedence.
 
-This feature requires [!INCLUDE[](~/includes/2.1-SDK.md)]
-
 [View or download sample code](https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/razor-pages/ui-class/samples) ([how to download](xref:index#how-to-download-a-sample))
 
 ## Create a class library containing Razor UI
@@ -27,7 +25,7 @@ This feature requires [!INCLUDE[](~/includes/2.1-SDK.md)]
 * From the Visual Studio **File** menu, select **New** > **Project**.
 * Select **ASP.NET Core Web Application**.
 * Name the library (for example, "RazorClassLib") > **OK**. To avoid a file name collision with the generated view library, ensure the library name doesn't end in `.Views`.
-* Verify **ASP.NET Core 2.1** or later is selected.
+* Verify **ASP.NET Core 3.0** or later is selected.
 * Select **Razor Class Library** > **OK**.
 
 The Razor class library (RCL) template defaults to Razor component development by default. A template option in Visual Studio provides template support for pages and views.
@@ -183,8 +181,6 @@ When the app is published, the companion assets from all referenced projects and
 ::: moniker range="< aspnetcore-3.0"
 
 Razor views, pages, controllers, page models, [Razor components](xref:blazor/class-libraries), [View components](xref:mvc/views/view-components), and data models can be built into a Razor class library (RCL). The RCL can be packaged and reused. Applications can include the RCL and override the views and pages it contains. When a view, partial view, or Razor Page is found in both the web app and the RCL, the Razor markup (*.cshtml* file) in the web app takes precedence.
-
-This feature requires [!INCLUDE[](~/includes/2.1-SDK.md)]
 
 [View or download sample code](https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/razor-pages/ui-class/samples) ([how to download](xref:index#how-to-download-a-sample))
 

--- a/aspnetcore/razor-pages/ui-class/samples/cli/RazorUIClassLib/RazorUIClassLib.csproj
+++ b/aspnetcore/razor-pages/ui-class/samples/cli/RazorUIClassLib/RazorUIClassLib.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/razor-pages/ui-class/samples/cli/WebApp1/WebApp1.csproj
+++ b/aspnetcore/razor-pages/ui-class/samples/cli/WebApp1/WebApp1.csproj
@@ -1,25 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
-
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-
   <ItemGroup>
     <ProjectReference Include="..\RazorUIClassLib\RazorUIClassLib.csproj" />
   </ItemGroup>
-
 
   <ItemGroup>
     <Content Update="Areas\MyFeature2\Pages\_ViewStart.cshtml">
       <Pack>$(IncludeRazorContentInPack)</Pack>
     </Content>
   </ItemGroup>
-
 
 </Project>


### PR DESCRIPTION
Fixes #14408

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/razor-pages/ui-class?view=aspnetcore-2.1&branch=pr-en-us-14461)

* Whole-topic versioning.
* Add info on "Pages and Views" via VS and `-support-pages-and-views` option.&dagger;
* Update sample code for 2.x to 2.2 from 2.1.

&dagger;I won't get a look at the VS screens locally until RTM (I can't support preview VS).

Options:

* Let me know how to phrase the VS UI content ... How and where does VS show 'pages and views support'? Send me a screenshot perhaps.
* Let's hold this PR until RTM ... My VS will update that day ... I'll see and react to it myself. I'll just mark this PR with `[HOLD]` in the title for now.

Also note: I thought that I would arrive to find this topic+sample code addressed for 3.0. *Not that lucky.* Some 3.0 content for RCL is here, but the walkthrough is 2.x. Therefore, I take that walkthrough out for the 3.0 version of the topic (recommended anyway btw ... would be better in a proper tutorial imo). I wasn't anticipating this scenario. I'm 🏃😅 right now; so if you prefer a 3.0 walkthrough, I recommend that we open a new issue for this topic (or for a separate tutorial) and I or someone else can work it later. I need to get back to my 3.0 high priority issues. 🏃🏃🏃