### PR TITLE
DI topic updates for 3.0

### DIFF
--- a/aspnetcore/fundamentals/dependency-injection.md
+++ b/aspnetcore/fundamentals/dependency-injection.md
@@ -153,6 +153,25 @@ In the sample app, the `IMyDependency` instance is requested and used to call th
 
 ::: moniker-end
 
+## Services injected into Startup
+
+Only the following service types can be injected into the `Startup` constructor when using the Generic Host (<xref:Microsoft.Extensions.Hosting.IHostBuilder>):
+
+* `IWebHostEnvironment`
+* <xref:Microsoft.Extensions.Hosting.IHostEnvironment>
+* <xref:Microsoft.Extensions.Configuration.IConfiguration>
+
+Services can be injected into `Startup.Configure`:
+
+```csharp
+public void Configure(IApplicationBuilder app, IOptions<MyOptions> options)
+{
+    ...
+}
+```
+
+For more information, see <xref:fundamentals/startup>.
+
 ## Framework-provided services
 
 The `Startup.ConfigureServices` method is responsible for defining the services that the app uses, including platform features, such as Entity Framework Core and ASP.NET Core MVC. Initially, the `IServiceCollection` provided to `ConfigureServices` has services defined by the framework depending on [how the host was configured](xref:fundamentals/index#host). It's not uncommon for an app based on an ASP.NET Core template to have hundreds of services registered by the framework. A small sample of framework-registered services is listed in the following table.

--- a/aspnetcore/fundamentals/dependency-injection.md
+++ b/aspnetcore/fundamentals/dependency-injection.md
@@ -5,7 +5,7 @@ description: Learn how ASP.NET Core implements dependency injection and how to u
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/22/2019
+ms.date: 09/24/2019
 uid: fundamentals/dependency-injection
 ---
 # Dependency injection in ASP.NET Core
@@ -581,7 +581,7 @@ public void ConfigureServices(IServiceCollection services)
 
 ## Default service container replacement
 
-The built-in service container is meant to serve the needs of the framework and most consumer apps. We recommend using the built-in container unless you need a specific feature that it doesn't support. Some of the features supported in 3rd party containers not found in the built-in container:
+The built-in service container is designed to serve the needs of the framework and most consumer apps. We recommend using the built-in container unless you need a specific feature that the built-in container doesn't support, such as:
 
 * Property injection
 * Injection based on name
@@ -589,74 +589,15 @@ The built-in service container is meant to serve the needs of the framework and 
 * Custom lifetime management
 * `Func<T>` support for lazy initialization
 
-See the [Dependency Injection readme.md file](https://github.com/aspnet/Extensions/tree/master/src/DependencyInjection) for a list of some of the containers that support adapters.
+The following 3rd party containers can be used with ASP.NET Core apps:
 
-The following sample replaces the built-in container with [Autofac](https://autofac.org/):
-
-* Install the appropriate container package(s):
-
-  * [Autofac](https://www.nuget.org/packages/Autofac/)
-  * [Autofac.Extensions.DependencyInjection](https://www.nuget.org/packages/Autofac.Extensions.DependencyInjection/)
-
-::: moniker range=">= aspnetcore-3.0"
-
-* Configure the container in `Startup.ConfigureServices` and return an `IServiceProvider`:
-
-   ```csharp
-   public IServiceProvider ConfigureServices(IServiceCollection services)
-   {
-       services.AddControllersWithViews();
-       // Add other framework services
-
-       // Add Autofac
-       var containerBuilder = new ContainerBuilder();
-       containerBuilder.RegisterModule<DefaultModule>();
-       containerBuilder.Populate(services);
-       var container = containerBuilder.Build();
-       return new AutofacServiceProvider(container);
-   }
-   ```
-
-   To use a 3rd party container, `Startup.ConfigureServices` must return `IServiceProvider`.
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-3.0"
-
-* Configure the container in `Startup.ConfigureServices` and return an `IServiceProvider`:
-
-   ```csharp
-   public IServiceProvider ConfigureServices(IServiceCollection services)
-   {
-       services.AddMvc();
-       // Add other framework services
-
-       // Add Autofac
-       var containerBuilder = new ContainerBuilder();
-       containerBuilder.RegisterModule<DefaultModule>();
-       containerBuilder.Populate(services);
-       var container = containerBuilder.Build();
-       return new AutofacServiceProvider(container);
-   }
-   ```
-
-   To use a 3rd party container, `Startup.ConfigureServices` must return `IServiceProvider`.
-
-::: moniker-end
-
-* Configure Autofac in `DefaultModule`:
-
-   ```csharp
-   public class DefaultModule : Module
-   {
-       protected override void Load(ContainerBuilder builder)
-       {
-           builder.RegisterType<CharacterRepository>().As<ICharacterRepository>();
-       }
-   }
-   ```
-
-At runtime, Autofac is used to resolve types and inject dependencies. To learn more about using Autofac with ASP.NET Core, see the [Autofac documentation](https://docs.autofac.org/en/latest/integration/aspnetcore.html).
+* [Autofac](https://autofac.readthedocs.io/en/latest/integration/aspnetcore.html)
+* [DryIoc](https://www.nuget.org/packages/DryIoc.Microsoft.DependencyInjection)
+* [Grace](https://www.nuget.org/packages/Grace.DependencyInjection.Extensions)
+* [LightInject](https://github.com/seesharper/LightInject.Microsoft.DependencyInjection)
+* [Lamar](https://jasperfx.github.io/lamar/)
+* [Stashbox](https://github.com/z4kn4fein/stashbox-extensions-dependencyinjection)
+* [Unity](https://www.nuget.org/packages/Unity.Microsoft.DependencyInjection)
 
 ### Thread safety
 

--- a/aspnetcore/fundamentals/dependency-injection.md
+++ b/aspnetcore/fundamentals/dependency-injection.md
@@ -5,7 +5,7 @@ description: Learn how ASP.NET Core implements dependency injection and how to u
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 08/14/2019
+ms.date: 09/22/2019
 uid: fundamentals/dependency-injection
 ---
 # Dependency injection in ASP.NET Core
@@ -68,11 +68,31 @@ Dependency injection addresses these problems through:
 
 In the [sample app](https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/fundamentals/dependency-injection/samples), the `IMyDependency` interface defines a method that the service provides to the app:
 
+::: moniker range=">= aspnetcore-3.0"
+
+[!code-csharp[](dependency-injection/samples/3.x/DependencyInjectionSample/Interfaces/IMyDependency.cs?name=snippet1)]
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-3.0"
+
 [!code-csharp[](dependency-injection/samples/2.x/DependencyInjectionSample/Interfaces/IMyDependency.cs?name=snippet1)]
+
+::: moniker-end
 
 This interface is implemented by a concrete type, `MyDependency`:
 
+::: moniker range=">= aspnetcore-3.0"
+
+[!code-csharp[](dependency-injection/samples/3.x/DependencyInjectionSample/Services/MyDependency.cs?name=snippet1)]
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-3.0"
+
 [!code-csharp[](dependency-injection/samples/2.x/DependencyInjectionSample/Services/MyDependency.cs?name=snippet1)]
+
+::: moniker-end
 
 `MyDependency` requests an <xref:Microsoft.Extensions.Logging.ILogger`1> in its constructor. It's not unusual to use dependency injection in a chained fashion. Each requested dependency in turn requests its own dependencies. The container resolves the dependencies in the graph and returns the fully resolved service. The collective set of dependencies that must be resolved is typically referred to as a *dependency tree*, *dependency graph*, or *object graph*.
 
@@ -86,7 +106,17 @@ services.AddSingleton(typeof(ILogger<T>), typeof(Logger<T>));
 
 In the sample app, the `IMyDependency` service is registered with the concrete type `MyDependency`. The registration scopes the service lifetime to the lifetime of a single request. [Service lifetimes](#service-lifetimes) are described later in this topic.
 
+::: moniker range=">= aspnetcore-3.0"
+
+[!code-csharp[](dependency-injection/samples/3.x/DependencyInjectionSample/Startup.cs?name=snippet1&highlight=5)]
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-3.0"
+
 [!code-csharp[](dependency-injection/samples/2.x/DependencyInjectionSample/Startup.cs?name=snippet1&highlight=5)]
+
+::: moniker-end
 
 > [!NOTE]
 > Each `services.Add{SERVICE_NAME}` extension method adds (and potentially configures) services. For example, `services.AddMvc()` adds the services Razor Pages and MVC require. We recommended that apps follow this convention. Place extension methods in the [Microsoft.Extensions.DependencyInjection](/dotnet/api/microsoft.extensions.dependencyinjection) namespace to encapsulate groups of service registrations.
@@ -111,11 +141,44 @@ An instance of the service is requested via the constructor of a class where the
 
 In the sample app, the `IMyDependency` instance is requested and used to call the service's `WriteMessage` method:
 
+::: moniker range=">= aspnetcore-3.0"
+
+[!code-csharp[](dependency-injection/samples/3.x/DependencyInjectionSample/Pages/Index.cshtml.cs?name=snippet1&highlight=3,6,13,29-30)]
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-3.0"
+
 [!code-csharp[](dependency-injection/samples/2.x/DependencyInjectionSample/Pages/Index.cshtml.cs?name=snippet1&highlight=3,6,13,29-30)]
+
+::: moniker-end
 
 ## Framework-provided services
 
-The `Startup.ConfigureServices` method is responsible for defining the services the app uses, including platform features, such as Entity Framework Core and ASP.NET Core MVC. Initially, the `IServiceCollection` provided to `ConfigureServices` has the following services defined (depending on [how the host was configured](xref:fundamentals/index#host)):
+The `Startup.ConfigureServices` method is responsible for defining the services that the app uses, including platform features, such as Entity Framework Core and ASP.NET Core MVC. Initially, the `IServiceCollection` provided to `ConfigureServices` has services defined by the framework depending on [how the host was configured](xref:fundamentals/index#host). It's not uncommon for an app based on an ASP.NET Core template to have hundreds of services registered by the framework. A small sample of framework-registered services is listed in the following table.
+
+::: moniker range=">= aspnetcore-3.0"
+
+| Service Type | Lifetime |
+| ------------ | -------- |
+| <xref:Microsoft.AspNetCore.Hosting.Builder.IApplicationBuilderFactory?displayProperty=fullName> | Transient |
+| `IHostApplicationLifetime` | Singleton |
+| `IWebHostEnvironment` | Singleton |
+| <xref:Microsoft.AspNetCore.Hosting.IStartup?displayProperty=fullName> | Singleton |
+| <xref:Microsoft.AspNetCore.Hosting.IStartupFilter?displayProperty=fullName> | Transient |
+| <xref:Microsoft.AspNetCore.Hosting.Server.IServer?displayProperty=fullName> | Singleton |
+| <xref:Microsoft.AspNetCore.Http.IHttpContextFactory?displayProperty=fullName> | Transient |
+| <xref:Microsoft.Extensions.Logging.ILogger`1?displayProperty=fullName> | Singleton |
+| <xref:Microsoft.Extensions.Logging.ILoggerFactory?displayProperty=fullName> | Singleton |
+| <xref:Microsoft.Extensions.ObjectPool.ObjectPoolProvider?displayProperty=fullName> | Singleton |
+| <xref:Microsoft.Extensions.Options.IConfigureOptions`1?displayProperty=fullName> | Transient |
+| <xref:Microsoft.Extensions.Options.IOptions`1?displayProperty=fullName> | Singleton |
+| <xref:System.Diagnostics.DiagnosticSource?displayProperty=fullName> | Singleton |
+| <xref:System.Diagnostics.DiagnosticListener?displayProperty=fullName> | Singleton |
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-3.0"
 
 | Service Type | Lifetime |
 | ------------ | -------- |
@@ -134,11 +197,17 @@ The `Startup.ConfigureServices` method is responsible for defining the services 
 | <xref:System.Diagnostics.DiagnosticSource?displayProperty=fullName> | Singleton |
 | <xref:System.Diagnostics.DiagnosticListener?displayProperty=fullName> | Singleton |
 
-When a service collection extension method is available to register a service (and its dependent services, if required), the convention is to use a single `Add{SERVICE_NAME}` extension method to register all of the services required by that service. The following code is an example of how to add additional services to the container using the extension methods [AddDbContext\<TContext>](/dotnet/api/microsoft.extensions.dependencyinjection.entityframeworkservicecollectionextensions.adddbcontext), <xref:Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionExtensions.AddIdentityCore*>, and <xref:Microsoft.Extensions.DependencyInjection.MvcServiceCollectionExtensions.AddMvc*>:
+::: moniker-end
+
+## Register additional services with extension methods
+
+When a service collection extension method is available to register a service (and its dependent services, if required), the convention is to use a single `Add{SERVICE_NAME}` extension method to register all of the services required by that service. The following code is an example of how to add additional services to the container using the extension methods [AddDbContext\<TContext>](/dotnet/api/microsoft.extensions.dependencyinjection.entityframeworkservicecollectionextensions.adddbcontext) and <xref:Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionExtensions.AddIdentityCore*>:
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
+    ...
+
     services.AddDbContext<ApplicationDbContext>(options =>
         options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection")));
 
@@ -146,7 +215,7 @@ public void ConfigureServices(IServiceCollection services)
         .AddEntityFrameworkStores<ApplicationDbContext>()
         .AddDefaultTokenProviders();
 
-    services.AddMvc();
+    ...
 }
 ```
 
@@ -242,11 +311,31 @@ Entity Framework contexts are usually added to the service container using the [
 
 To demonstrate the difference between the lifetime and registration options, consider the following interfaces that represent tasks as an operation with a unique identifier, `OperationId`. Depending on how the lifetime of an operations service is configured for the following interfaces, the container provides either the same or a different instance of the service when requested by a class:
 
+::: moniker range=">= aspnetcore-3.0"
+
+[!code-csharp[](dependency-injection/samples/3.x/DependencyInjectionSample/Interfaces/IOperation.cs?name=snippet1)]
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-3.0"
+
 [!code-csharp[](dependency-injection/samples/2.x/DependencyInjectionSample/Interfaces/IOperation.cs?name=snippet1)]
+
+::: moniker-end
 
 The interfaces are implemented in the `Operation` class. The `Operation` constructor generates a GUID if one isn't supplied:
 
+::: moniker range=">= aspnetcore-3.0"
+
+[!code-csharp[](dependency-injection/samples/3.x/DependencyInjectionSample/Models/Operation.cs?name=snippet1)]
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-3.0"
+
 [!code-csharp[](dependency-injection/samples/2.x/DependencyInjectionSample/Models/Operation.cs?name=snippet1)]
+
+::: moniker-end
 
 An `OperationService` is registered that depends on each of the other `Operation` types. When `OperationService` is requested via dependency injection, it receives either a new instance of each service or an existing instance based on the lifetime of the dependent service.
 
@@ -254,17 +343,47 @@ An `OperationService` is registered that depends on each of the other `Operation
 * When scoped services are created per client request, the `OperationId` of the `IOperationScoped` service is the same as that of `OperationService` within a client request. Across client requests, both services share a different `OperationId` value.
 * When singleton and singleton-instance services are created once and used across all client requests and all services, the `OperationId` is constant across all service requests.
 
+::: moniker range=">= aspnetcore-3.0"
+
+[!code-csharp[](dependency-injection/samples/3.x/DependencyInjectionSample/Services/OperationService.cs?name=snippet1)]
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-3.0"
+
 [!code-csharp[](dependency-injection/samples/2.x/DependencyInjectionSample/Services/OperationService.cs?name=snippet1)]
+
+::: moniker-end
 
 In `Startup.ConfigureServices`, each type is added to the container according to its named lifetime:
 
+::: moniker range=">= aspnetcore-3.0"
+
+[!code-csharp[](dependency-injection/samples/3.x/DependencyInjectionSample/Startup.cs?name=snippet1&highlight=6-9,12)]
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-3.0"
+
 [!code-csharp[](dependency-injection/samples/2.x/DependencyInjectionSample/Startup.cs?name=snippet1&highlight=6-9,12)]
+
+::: moniker-end
 
 The `IOperationSingletonInstance` service is using a specific instance with a known ID of `Guid.Empty`. It's clear when this type is in use (its GUID is all zeroes).
 
 The sample app demonstrates object lifetimes within and between individual requests. The sample app's `IndexModel` requests each kind of `IOperation` type and the `OperationService`. The page then displays all of the page model class's and service's `OperationId` values through property assignments:
 
+::: moniker range=">= aspnetcore-3.0"
+
+[!code-csharp[](dependency-injection/samples/3.x/DependencyInjectionSample/Pages/Index.cshtml.cs?name=snippet1&highlight=7-11,14-18,21-25)]
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-3.0"
+
 [!code-csharp[](dependency-injection/samples/2.x/DependencyInjectionSample/Pages/Index.cshtml.cs?name=snippet1&highlight=7-11,14-18,21-25)]
+
+::: moniker-end
 
 Two following output shows the results of two requests:
 
@@ -310,8 +429,59 @@ Observe which of the `OperationId` values vary within a request and between requ
 
 Create an <xref:Microsoft.Extensions.DependencyInjection.IServiceScope> with [IServiceScopeFactory.CreateScope](xref:Microsoft.Extensions.DependencyInjection.IServiceScopeFactory.CreateScope*) to resolve a scoped service within the app's scope. This approach is useful to access a scoped service at startup to run initialization tasks. The following example shows how to obtain a context for the `MyScopedService` in `Program.Main`:
 
+::: moniker range=">= aspnetcore-3.0"
+
 ```csharp
-public static void Main(string[] args)
+// using System;
+// using System.Threading.Tasks;
+// using Microsoft.Extensions.DependencyInjection;
+// using Microsoft.AspNetCore.Hosting;
+// using Microsoft.Extensions.Hosting;
+
+public static async Task Main(string[] args)
+{
+    var host = CreateHostBuilder(args).Build();
+
+    using (var serviceScope = host.Services.CreateScope())
+    {
+        var services = serviceScope.ServiceProvider;
+
+        try
+        {
+            var serviceContext = services.GetRequiredService<MyScopedService>();
+            // Use the context here
+        }
+        catch (Exception ex)
+        {
+            var logger = services.GetRequiredService<ILogger<Program>>();
+            logger.LogError(ex, "An error occurred.");
+        }
+    }
+
+    await host.RunAsync();
+}
+
+public static IHostBuilder CreateHostBuilder(string[] args) =>
+    Host.CreateDefaultBuilder(args)
+        .ConfigureWebHostDefaults(webBuilder =>
+        {
+            webBuilder.UseStartup<Startup>();
+        });
+```
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-3.0"
+
+```csharp
+// using System;
+// using System.Threading.Tasks;
+// using Microsoft.AspNetCore;
+// using Microsoft.AspNetCore.Hosting;
+// using Microsoft.Extensions.DependencyInjection;
+// using Microsoft.Extensions.Logging;
+
+public static async Task Main(string[] args)
 {
     var host = CreateWebHostBuilder(args).Build();
 
@@ -331,9 +501,15 @@ public static void Main(string[] args)
         }
     }
 
-    host.Run();
+    await host.RunAsync();
 }
+
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>();
 ```
+
+::: moniker-end
 
 ## Scope validation
 

--- a/aspnetcore/fundamentals/dependency-injection.md
+++ b/aspnetcore/fundamentals/dependency-injection.md
@@ -602,22 +602,22 @@ The following sample replaces the built-in container with [Autofac](https://auto
 
 * Configure the container in `Startup.ConfigureServices` and return an `IServiceProvider`:
 
-    ```csharp
-    public IServiceProvider ConfigureServices(IServiceCollection services)
-    {
-        services.AddControllersWithViews();
-        // Add other framework services
+   ```csharp
+   public IServiceProvider ConfigureServices(IServiceCollection services)
+   {
+       services.AddControllersWithViews();
+       // Add other framework services
 
-        // Add Autofac
-        var containerBuilder = new ContainerBuilder();
-        containerBuilder.RegisterModule<DefaultModule>();
-        containerBuilder.Populate(services);
-        var container = containerBuilder.Build();
-        return new AutofacServiceProvider(container);
-    }
-    ```
+       // Add Autofac
+       var containerBuilder = new ContainerBuilder();
+       containerBuilder.RegisterModule<DefaultModule>();
+       containerBuilder.Populate(services);
+       var container = containerBuilder.Build();
+       return new AutofacServiceProvider(container);
+   }
+   ```
 
-    To use a 3rd party container, `Startup.ConfigureServices` must return `IServiceProvider`.
+   To use a 3rd party container, `Startup.ConfigureServices` must return `IServiceProvider`.
 
 ::: moniker-end
 
@@ -625,36 +625,36 @@ The following sample replaces the built-in container with [Autofac](https://auto
 
 * Configure the container in `Startup.ConfigureServices` and return an `IServiceProvider`:
 
-    ```csharp
-    public IServiceProvider ConfigureServices(IServiceCollection services)
-    {
-        services.AddMvc();
-        // Add other framework services
+   ```csharp
+   public IServiceProvider ConfigureServices(IServiceCollection services)
+   {
+       services.AddMvc();
+       // Add other framework services
 
-        // Add Autofac
-        var containerBuilder = new ContainerBuilder();
-        containerBuilder.RegisterModule<DefaultModule>();
-        containerBuilder.Populate(services);
-        var container = containerBuilder.Build();
-        return new AutofacServiceProvider(container);
-    }
-    ```
+       // Add Autofac
+       var containerBuilder = new ContainerBuilder();
+       containerBuilder.RegisterModule<DefaultModule>();
+       containerBuilder.Populate(services);
+       var container = containerBuilder.Build();
+       return new AutofacServiceProvider(container);
+   }
+   ```
 
-    To use a 3rd party container, `Startup.ConfigureServices` must return `IServiceProvider`.
+   To use a 3rd party container, `Startup.ConfigureServices` must return `IServiceProvider`.
 
 ::: moniker-end
 
 * Configure Autofac in `DefaultModule`:
 
-    ```csharp
-    public class DefaultModule : Module
-    {
-        protected override void Load(ContainerBuilder builder)
-        {
-            builder.RegisterType<CharacterRepository>().As<ICharacterRepository>();
-        }
-    }
-    ```
+   ```csharp
+   public class DefaultModule : Module
+   {
+       protected override void Load(ContainerBuilder builder)
+       {
+           builder.RegisterType<CharacterRepository>().As<ICharacterRepository>();
+       }
+   }
+   ```
 
 At runtime, Autofac is used to resolve types and inject dependencies. To learn more about using Autofac with ASP.NET Core, see the [Autofac documentation](https://docs.autofac.org/en/latest/integration/aspnetcore.html).
 

--- a/aspnetcore/fundamentals/dependency-injection.md
+++ b/aspnetcore/fundamentals/dependency-injection.md
@@ -598,6 +598,31 @@ The following sample replaces the built-in container with [Autofac](https://auto
   * [Autofac](https://www.nuget.org/packages/Autofac/)
   * [Autofac.Extensions.DependencyInjection](https://www.nuget.org/packages/Autofac.Extensions.DependencyInjection/)
 
+::: moniker range=">= aspnetcore-3.0"
+
+* Configure the container in `Startup.ConfigureServices` and return an `IServiceProvider`:
+
+    ```csharp
+    public IServiceProvider ConfigureServices(IServiceCollection services)
+    {
+        services.AddControllersWithViews();
+        // Add other framework services
+
+        // Add Autofac
+        var containerBuilder = new ContainerBuilder();
+        containerBuilder.RegisterModule<DefaultModule>();
+        containerBuilder.Populate(services);
+        var container = containerBuilder.Build();
+        return new AutofacServiceProvider(container);
+    }
+    ```
+
+    To use a 3rd party container, `Startup.ConfigureServices` must return `IServiceProvider`.
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-3.0"
+
 * Configure the container in `Startup.ConfigureServices` and return an `IServiceProvider`:
 
     ```csharp
@@ -616,6 +641,8 @@ The following sample replaces the built-in container with [Autofac](https://auto
     ```
 
     To use a 3rd party container, `Startup.ConfigureServices` must return `IServiceProvider`.
+
+::: moniker-end
 
 * Configure Autofac in `DefaultModule`:
 

--- a/aspnetcore/fundamentals/dependency-injection.md
+++ b/aspnetcore/fundamentals/dependency-injection.md
@@ -432,41 +432,44 @@ Create an <xref:Microsoft.Extensions.DependencyInjection.IServiceScope> with [IS
 ::: moniker range=">= aspnetcore-3.0"
 
 ```csharp
-// using System;
-// using System.Threading.Tasks;
-// using Microsoft.Extensions.DependencyInjection;
-// using Microsoft.AspNetCore.Hosting;
-// using Microsoft.Extensions.Hosting;
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 
-public static async Task Main(string[] args)
+public class Program
 {
-    var host = CreateHostBuilder(args).Build();
-
-    using (var serviceScope = host.Services.CreateScope())
+    public static async Task Main(string[] args)
     {
-        var services = serviceScope.ServiceProvider;
+        var host = CreateHostBuilder(args).Build();
 
-        try
+        using (var serviceScope = host.Services.CreateScope())
         {
-            var serviceContext = services.GetRequiredService<MyScopedService>();
-            // Use the context here
+            var services = serviceScope.ServiceProvider;
+
+            try
+            {
+                var serviceContext = services.GetRequiredService<MyScopedService>();
+                // Use the context here
+            }
+            catch (Exception ex)
+            {
+                var logger = services.GetRequiredService<ILogger<Program>>();
+                logger.LogError(ex, "An error occurred.");
+            }
         }
-        catch (Exception ex)
-        {
-            var logger = services.GetRequiredService<ILogger<Program>>();
-            logger.LogError(ex, "An error occurred.");
-        }
+    
+        await host.RunAsync();
     }
 
-    await host.RunAsync();
+    public static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.UseStartup<Startup>();
+            });
 }
-
-public static IHostBuilder CreateHostBuilder(string[] args) =>
-    Host.CreateDefaultBuilder(args)
-        .ConfigureWebHostDefaults(webBuilder =>
-        {
-            webBuilder.UseStartup<Startup>();
-        });
 ```
 
 ::: moniker-end
@@ -474,39 +477,42 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
 ::: moniker range="< aspnetcore-3.0"
 
 ```csharp
-// using System;
-// using System.Threading.Tasks;
-// using Microsoft.AspNetCore;
-// using Microsoft.AspNetCore.Hosting;
-// using Microsoft.Extensions.DependencyInjection;
-// using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
-public static async Task Main(string[] args)
+public class Program
 {
-    var host = CreateWebHostBuilder(args).Build();
-
-    using (var serviceScope = host.Services.CreateScope())
+    public static async Task Main(string[] args)
     {
-        var services = serviceScope.ServiceProvider;
+        var host = CreateWebHostBuilder(args).Build();
 
-        try
+        using (var serviceScope = host.Services.CreateScope())
         {
-            var serviceContext = services.GetRequiredService<MyScopedService>();
-            // Use the context here
+            var services = serviceScope.ServiceProvider;
+
+            try
+            {
+                var serviceContext = services.GetRequiredService<MyScopedService>();
+                // Use the context here
+            }
+            catch (Exception ex)
+            {
+                var logger = services.GetRequiredService<ILogger<Program>>();
+                logger.LogError(ex, "An error occurred.");
+            }
         }
-        catch (Exception ex)
-        {
-            var logger = services.GetRequiredService<ILogger<Program>>();
-            logger.LogError(ex, "An error occurred.");
-        }
+    
+        await host.RunAsync();
     }
 
-    await host.RunAsync();
+    public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+        WebHost.CreateDefaultBuilder(args)
+            .UseStartup<Startup>();
 }
-
-public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>();
 ```
 
 ::: moniker-end

--- a/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/DependencyInjectionSample.csproj
+++ b/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/DependencyInjectionSample.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+  
+</Project>

--- a/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Interfaces/IMyDependency.cs
+++ b/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Interfaces/IMyDependency.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+
+namespace DependencyInjectionSample.Interfaces
+{
+    #region snippet1
+    public interface IMyDependency
+    {
+        Task WriteMessage(string message);
+    }
+    #endregion
+}

--- a/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Interfaces/IOperation.cs
+++ b/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Interfaces/IOperation.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace DependencyInjectionSample.Interfaces
+{
+    #region snippet1
+    public interface IOperation
+    {
+        Guid OperationId { get; }
+    }
+
+    public interface IOperationTransient : IOperation
+    {
+    }
+
+    public interface IOperationScoped : IOperation
+    {
+    }
+
+    public interface IOperationSingleton : IOperation
+    {
+    }
+
+    public interface IOperationSingletonInstance : IOperation
+    {
+    }
+    #endregion
+}

--- a/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Models/Operation.cs
+++ b/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Models/Operation.cs
@@ -1,0 +1,24 @@
+using System;
+using DependencyInjectionSample.Interfaces;
+
+namespace DependencyInjectionSample.Models
+{
+    #region snippet1
+    public class Operation : IOperationTransient, 
+        IOperationScoped, 
+        IOperationSingleton, 
+        IOperationSingletonInstance
+    {
+        public Operation() : this(Guid.NewGuid())
+        {
+        }
+
+        public Operation(Guid id)
+        {
+            OperationId = id;
+        }
+
+        public Guid OperationId { get; private set; }
+    }
+    #endregion
+}

--- a/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Pages/Error.cshtml
+++ b/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Pages/Error.cshtml
@@ -1,0 +1,26 @@
+﻿@page
+@model ErrorModel
+@{
+    ViewData["Title"] = "Error";
+}
+
+<h1 class="text-danger">Error.</h1>
+<h2 class="text-danger">An error occurred while processing your request.</h2>
+
+@if (Model.ShowRequestId)
+{
+    <p>
+        <strong>Request ID:</strong> <code>@Model.RequestId</code>
+    </p>
+}
+
+<h3>Development Mode</h3>
+<p>
+    Swapping to the <strong>Development</strong> environment displays detailed information about the error that occurred.
+</p>
+<p>
+    <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
+    It can result in displaying sensitive information from exceptions to end users.
+    For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
+    and restarting the app.
+</p>

--- a/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Pages/Error.cshtml.cs
+++ b/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Pages/Error.cshtml.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace DependencyInjectionSample.Pages
+{
+    [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+    public class ErrorModel : PageModel
+    {
+        public string RequestId { get; set; }
+
+        public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+
+        public void OnGet()
+        {
+            RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
+        }
+    }
+}

--- a/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Pages/Index.cshtml
+++ b/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Pages/Index.cshtml
@@ -1,0 +1,50 @@
+﻿@page
+@model IndexModel
+@{
+    ViewData["Title"] = "Dependency Injection Sample";
+}
+
+<h1>@ViewData["Title"]</h1>
+
+<div class="row">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h2 class="panel-title">MyDependency</h2>
+        </div>
+        <div class="panel-body">
+            <p>The <code>IndexModel</code> has called the <code>IMyDependency</code> implemention (<code>MyDependency</code>). The service's <code>WriteMessage</code> method was called with a message string that indicates the page called the method on the service. The <code>WriteMessage</code> method created a log entry with the message string.</p>
+        </div>
+    </div>
+</div>
+
+<div class="row">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h2 class="panel-title">Operations</h2>
+        </div>
+        <div class="panel-body">
+            <h3>Page Model Operations</h3>
+            <dl>
+                <dt>Transient</dt>
+                <dd>@Model.TransientOperation.OperationId</dd>
+                <dt>Scoped</dt>
+                <dd>@Model.ScopedOperation.OperationId</dd>
+                <dt>Singleton</dt>
+                <dd>@Model.SingletonOperation.OperationId</dd>
+                <dt>Instance</dt>
+                <dd>@Model.SingletonInstanceOperation.OperationId</dd>
+            </dl>
+            <h3>OperationService Operations</h3>
+            <dl>
+                <dt>Transient</dt>
+                <dd>@Model.OperationService.TransientOperation.OperationId</dd>
+                <dt>Scoped</dt>
+                <dd>@Model.OperationService.ScopedOperation.OperationId</dd>
+                <dt>Singleton</dt>
+                <dd>@Model.OperationService.SingletonOperation.OperationId</dd>
+                <dt>Instance</dt>
+                <dd>@Model.OperationService.SingletonInstanceOperation.OperationId</dd>
+            </dl>
+        </div>
+    </div>
+</div>

--- a/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Pages/Index.cshtml.cs
+++ b/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Pages/Index.cshtml.cs
@@ -1,0 +1,42 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using DependencyInjectionSample.Interfaces;
+using DependencyInjectionSample.Services;
+
+namespace DependencyInjectionSample.Pages
+{
+    #region snippet1
+    public class IndexModel : PageModel
+    {
+        private readonly IMyDependency _myDependency;
+
+        public IndexModel(
+            IMyDependency myDependency, 
+            OperationService operationService,
+            IOperationTransient transientOperation,
+            IOperationScoped scopedOperation,
+            IOperationSingleton singletonOperation,
+            IOperationSingletonInstance singletonInstanceOperation)
+        {
+            _myDependency = myDependency;
+            OperationService = operationService;
+            TransientOperation = transientOperation;
+            ScopedOperation = scopedOperation;
+            SingletonOperation = singletonOperation;
+            SingletonInstanceOperation = singletonInstanceOperation;
+        }
+
+        public OperationService OperationService { get; }
+        public IOperationTransient TransientOperation { get; }
+        public IOperationScoped ScopedOperation { get; }
+        public IOperationSingleton SingletonOperation { get; }
+        public IOperationSingletonInstance SingletonInstanceOperation { get; }
+
+        public async Task OnGetAsync()
+        {
+            await _myDependency.WriteMessage(
+                "IndexModel.OnGetAsync created this message.");
+        }
+    }
+    #endregion
+}

--- a/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Pages/Shared/_Layout.cshtml
+++ b/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Pages/Shared/_Layout.cshtml
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>@ViewData["Title"]</title>
+    <style>body{margin:0;padding-bottom:20px;font-family:"Helvetica Neue", Helvetica, Arial, sans-serif;font-size:14px;line-height:1.42857143;color:#333;background-color:#fff;}h1{font-size:24px;margin:.67em 0;}pre{overflow:auto;}code,pre{font-family:monospace, monospace;font-size:1em;}button,input{margin:0;font:inherit;color:inherit;}button{overflow:visible;}button{text-transform:none;}input{line-height:normal;}{box-sizing:border-box;}:before,*:after{box-sizing:border-box;}input,button{font-family:inherit;font-size:inherit;line-height:inherit;}a{color:#337ab7;text-decoration:none;}h1,h2,h3,h4{font-family:inherit;font-weight:500;line-height:1.1;color:inherit;margin-top:20px;margin-bottom:10px;}h3{font-size:16px;}h4{font-size:18px;}p{margin:0 0 10px;}ol{margin-top:0;margin-bottom:10px;}code,pre{font-family:Menlo, Monaco, Consolas, "Courier New", monospace;}code{padding:2px 4px;font-size:90%;color:#c7254e;background-color:#f9f2f4;border-radius:4px;}pre{display:block;padding:9.5px;margin:0 0 10px;font-size:13px;line-height:1.42857143;color:#333;word-break:break-all;word-wrap:break-word;background-color:#f5f5f5;border:1px solid #ccc;-radius:4px;}pre code{padding:0;font-size:inherit;color:inherit;white-space:pre-wrap;background-color:transparent;border-radius:0;}.container{padding-right:15px;padding-left:15px;margin-right:auto;margin-left:auto;}.container{width:800px;}.btn{display:inline-block;padding:6px 12px;margin-bottom:0;font-size:14px;font-weight:normal;line-height:1.42857143;text-align:center;white-space:nowrap;vertical-align:middle;background-image:none;border:1px solid transparent;border-radius:4px;;color:#fff;background-color:green;border-color:gray;float:right}.panel{margin-bottom:20px;background-color:#fff;border:1px solid transparent;border-radius:4px;box-shadow:0 1px 1px rgba(0, 0, 0, .05);}.panel-body{padding:15px;}.panel-heading{padding:10px 15px;border-bottom:1px solid transparent;border-top-left-radius:3px;border-top-right-radius:3px;}.panel-title{margin-top:0;margin-bottom:0;font-size:16px;color:inherit;}.panel-default{border-color:#ddd;}.panel-default > .panel-heading{color:#333;background-color:#f5f5f5;border-color:#ddd;}.clearfix:before,.clearfix:after,.container:before,.container:after,.panel-body:before,.panel-body:after{display:table;content:" ";}.clearfix:after,.container:after,.panel-body:after{clear:both;}.body-content{padding-left:15px;padding-right:15px;}.panel-body{font-size:16px;}</style>
+</head>
+<body>
+    <div class="container body-content">
+        @RenderBody()
+    </div>
+</body>
+</html>

--- a/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Pages/_ViewImports.cshtml
+++ b/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Pages/_ViewImports.cshtml
@@ -1,0 +1,4 @@
+@using DependencyInjectionSample
+@using DependencyInjectionSample.Models
+@namespace DependencyInjectionSample.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Pages/_ViewStart.cshtml
+++ b/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Pages/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+﻿@{
+    Layout = "_Layout";
+}

--- a/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Program.cs
+++ b/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Program.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+namespace DependencyInjectionSample
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/README.md
+++ b/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/README.md
@@ -1,3 +1,3 @@
-# ASP.NET Core Dependency Injection Sample
+# ASP.NET Core Dependency Injection
 
 This sample illustrates the use of dependency injection with ASP.NET Core. This sample demonstrates the scenario described in the [Dependency injection in ASP.NET Core](https://docs.microsoft.com/aspnet/core/fundamentals/dependency-injection) topic.

--- a/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Services/MyDependency.cs
+++ b/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Services/MyDependency.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+using DependencyInjectionSample.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace DependencyInjectionSample.Services
+{
+    #region snippet1
+    public class MyDependency : IMyDependency
+    {
+        private readonly ILogger<MyDependency> _logger;
+
+        public MyDependency(ILogger<MyDependency> logger)
+        {
+            _logger = logger;
+        }
+
+        public Task WriteMessage(string message)
+        {
+            _logger.LogInformation(
+                "MyDependency.WriteMessage called. Message: {MESSAGE}", 
+                message);
+
+            return Task.FromResult(0);
+        }
+    }
+    #endregion
+}

--- a/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Services/OperationService.cs
+++ b/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Services/OperationService.cs
@@ -1,0 +1,26 @@
+using DependencyInjectionSample.Interfaces;
+
+namespace DependencyInjectionSample.Services
+{
+    #region snippet1
+    public class OperationService
+    {
+        public OperationService(
+            IOperationTransient transientOperation,
+            IOperationScoped scopedOperation,
+            IOperationSingleton singletonOperation,
+            IOperationSingletonInstance instanceOperation)
+        {
+            TransientOperation = transientOperation;
+            ScopedOperation = scopedOperation;
+            SingletonOperation = singletonOperation;
+            SingletonInstanceOperation = instanceOperation;
+        }
+
+        public IOperationTransient TransientOperation { get; }
+        public IOperationScoped ScopedOperation { get; }
+        public IOperationSingleton SingletonOperation { get; }
+        public IOperationSingletonInstance SingletonInstanceOperation { get; }
+    }
+    #endregion
+}

--- a/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Startup.cs
+++ b/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/Startup.cs
@@ -1,0 +1,51 @@
+using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using DependencyInjectionSample.Interfaces;
+using DependencyInjectionSample.Models;
+using DependencyInjectionSample.Services;
+
+namespace DependencyInjectionSample
+{
+    public class Startup
+    {
+        #region snippet1
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddRazorPages();
+
+            services.AddScoped<IMyDependency, MyDependency>();
+            services.AddTransient<IOperationTransient, Operation>();
+            services.AddScoped<IOperationScoped, Operation>();
+            services.AddSingleton<IOperationSingleton, Operation>();
+            services.AddSingleton<IOperationSingletonInstance>(new Operation(Guid.Empty));
+
+            // OperationService depends on each of the other Operation types.
+            services.AddTransient<OperationService, OperationService>();
+        }
+        #endregion
+
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                app.UseExceptionHandler("/Error");
+            }
+
+            app.UseStaticFiles();
+
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapRazorPages();
+            });
+        }
+    }
+}

--- a/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/appsettings.Development.json
+++ b/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/appsettings.Development.json
@@ -1,7 +1,7 @@
 ﻿{
   "Logging": {
     "LogLevel": {
-      "Default": "Error",
+      "Default": "Debug",
       "System": "Information",
       "Microsoft": "Information"
     }

--- a/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/appsettings.json
+++ b/aspnetcore/fundamentals/dependency-injection/samples/3.x/DependencyInjectionSample/appsettings.json
@@ -1,0 +1,10 @@
+﻿{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/aspnetcore/fundamentals/host/generic-host.md
+++ b/aspnetcore/fundamentals/host/generic-host.md
@@ -107,7 +107,7 @@ Services that are registered automatically include the following:
 * [IHostLifetime](#ihostlifetime)
 * [IHostEnvironment / IWebHostEnvironment](#ihostenvironment)
 
-For a list of all framework-provided services, see <xref:fundamentals/dependency-injection#framework-provided-services>.
+For more information on framework-provided services, see <xref:fundamentals/dependency-injection#framework-provided-services>.
 
 ## IHostApplicationLifetime
 

--- a/aspnetcore/fundamentals/startup.md
+++ b/aspnetcore/fundamentals/startup.md
@@ -53,7 +53,7 @@ The host provides services that are available to the `Startup` class constructor
 Only the following service types can be injected into the `Startup` constructor when using <xref:Microsoft.Extensions.Hosting.IHostBuilder>:
 
 * `IWebHostEnvironment`
-* `IHostEnvironment`
+* <xref:Microsoft.Extensions.Hosting.IHostEnvironment>
 * <xref:Microsoft.Extensions.Configuration.IConfiguration>
 
 [!code-csharp[](startup/3.0_samples/StartupFilterSample/StartUp2.cs?name=snippet)]


### PR DESCRIPTION
Fixes #12839

[Internal Review Topic](#)

* New 3.0 sample confirmed working.
* Few content changes, so I used our standard versioning approach.
* Wording changes to the *Framework-provided services* section steering it away from saying or implying that *this is a full list* ... there are over 200 services registered by a typical template-based web app. I make it say that the table represents a small sample of them.
* *Call services from main* section updated to show:
  * Generic Host and Web Host examples per version of doc.
  * Converted over to async.

**Need guidance on alt container setup for 3.0 ...**

There's a section here on [default container replacement (this links to the live topic)](https://docs.microsoft.com/aspnet/core/fundamentals/dependency-injection?#default-service-container-replacement), and idk how that should change for 3.0.