### PR TITLE
Set Blazor docs release date to GA date

### DIFF
--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -5,7 +5,7 @@ description: Learn how to call a web API from a Blazor app using JSON helpers, i
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 08/13/2019
+ms.date: 09/23/2019
 uid: blazor/call-web-api
 ---
 # Call a web API from ASP.NET Core Blazor

--- a/aspnetcore/blazor/class-libraries.md
+++ b/aspnetcore/blazor/class-libraries.md
@@ -5,7 +5,7 @@ description: Discover how components can be included in Blazor apps from an exte
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 08/13/2019
+ms.date: 09/23/2019
 uid: blazor/class-libraries
 ---
 # ASP.NET Core Razor components class libraries

--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -5,7 +5,7 @@ description: Learn how to create and use Razor components, including how to bind
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/21/2019
+ms.date: 09/23/2019
 uid: blazor/components
 ---
 # Create and use ASP.NET Core Razor components

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -5,7 +5,7 @@ description: Learn how to debug Blazor apps.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 08/22/2019
+ms.date: 09/23/2019
 uid: blazor/debug
 ---
 # Debug ASP.NET Core Blazor

--- a/aspnetcore/blazor/dependency-injection.md
+++ b/aspnetcore/blazor/dependency-injection.md
@@ -5,7 +5,7 @@ description: See how Blazor apps can inject services into components.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/06/2019
+ms.date: 09/23/2019
 uid: blazor/dependency-injection
 ---
 # ASP.NET Core Blazor dependency injection

--- a/aspnetcore/blazor/forms-validation.md
+++ b/aspnetcore/blazor/forms-validation.md
@@ -5,7 +5,7 @@ description: Learn how to use forms and field validation scenarios in Blazor.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/15/2019
+ms.date: 09/23/2019
 uid: blazor/forms-validation
 ---
 # ASP.NET Core Blazor forms and validation

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -5,7 +5,7 @@ description: Get started with Blazor by building a Blazor app with the tooling o
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/05/2019
+ms.date: 09/23/2019
 uid: blazor/get-started
 ---
 # Get started with ASP.NET Core Blazor

--- a/aspnetcore/blazor/handle-errors.md
+++ b/aspnetcore/blazor/handle-errors.md
@@ -5,7 +5,7 @@ description: Discover how ASP.NET Core Blazor how Blazor manages unhandled excep
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 08/06/2019
+ms.date: 09/23/2019
 uid: blazor/handle-errors
 ---
 # Handle errors in ASP.NET Core Blazor apps

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -5,7 +5,7 @@ description: Understand Blazor WebAssembly and Blazor Server hosting models.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/07/2019
+ms.date: 09/23/2019
 uid: blazor/hosting-models
 ---
 # ASP.NET Core Blazor hosting models

--- a/aspnetcore/blazor/index.md
+++ b/aspnetcore/blazor/index.md
@@ -5,7 +5,7 @@ description: Explore ASP.NET Core Blazor, a way to build interactive client-side
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: "mvc, seoapril2019"
-ms.date: 09/05/2019
+ms.date: 09/23/2019
 uid: blazor/index
 ---
 # Introduction to Blazor

--- a/aspnetcore/blazor/javascript-interop.md
+++ b/aspnetcore/blazor/javascript-interop.md
@@ -5,7 +5,7 @@ description: Learn how to invoke JavaScript functions from .NET and .NET methods
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/07/2019
+ms.date: 09/23/2019
 uid: blazor/javascript-interop
 ---
 # ASP.NET Core Blazor JavaScript interop

--- a/aspnetcore/blazor/layouts.md
+++ b/aspnetcore/blazor/layouts.md
@@ -5,7 +5,7 @@ description: Learn how to create reusable layout components for Blazor apps.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/21/2019
+ms.date: 09/23/2019
 uid: blazor/layouts
 ---
 # ASP.NET Core Blazor layouts

--- a/aspnetcore/blazor/routing.md
+++ b/aspnetcore/blazor/routing.md
@@ -5,7 +5,7 @@ description: Learn how to route requests in apps and about the NavLink component
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/21/2019
+ms.date: 09/23/2019
 uid: blazor/routing
 ---
 # ASP.NET Core Blazor routing

--- a/aspnetcore/blazor/state-management.md
+++ b/aspnetcore/blazor/state-management.md
@@ -5,7 +5,7 @@ description: Learn how to persist state in Blazor Server apps.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/21/2019
+ms.date: 09/23/2019
 uid: blazor/state-management
 ---
 # ASP.NET Core Blazor state management

--- a/aspnetcore/blazor/supported-platforms.md
+++ b/aspnetcore/blazor/supported-platforms.md
@@ -5,7 +5,7 @@ description: Learn about the supported platforms for ASP.NET Core Blazor.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 07/01/2019
+ms.date: 09/23/2019
 uid: blazor/supported-platforms
 ---
 # ASP.NET Core Blazor supported platforms

--- a/aspnetcore/host-and-deploy/blazor/configure-linker.md
+++ b/aspnetcore/host-and-deploy/blazor/configure-linker.md
@@ -5,7 +5,7 @@ description: Learn how to control the Intermediate Language (IL) Linker when bui
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 07/02/2019
+ms.date: 09/23/2019
 uid: host-and-deploy/blazor/configure-linker
 ---
 # Configure the Linker for ASP.NET Core Blazor

--- a/aspnetcore/host-and-deploy/blazor/index.md
+++ b/aspnetcore/host-and-deploy/blazor/index.md
@@ -5,7 +5,7 @@ description: Discover how to host and deploy Blazor apps.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/05/2019
+ms.date: 09/23/2019
 uid: host-and-deploy/blazor/index
 ---
 # Host and deploy ASP.NET Core Blazor

--- a/aspnetcore/host-and-deploy/blazor/server.md
+++ b/aspnetcore/host-and-deploy/blazor/server.md
@@ -5,7 +5,7 @@ description: Learn how to host and deploy a Blazor Server app using ASP.NET Core
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/07/2019
+ms.date: 09/23/2019
 uid: host-and-deploy/blazor/server
 ---
 # Host and deploy Blazor Server

--- a/aspnetcore/host-and-deploy/blazor/webassembly.md
+++ b/aspnetcore/host-and-deploy/blazor/webassembly.md
@@ -5,7 +5,7 @@ description: Learn how to host and deploy a Blazor app using ASP.NET Core, Conte
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/05/2019
+ms.date: 09/23/2019
 uid: host-and-deploy/blazor/webassembly
 ---
 # Host and deploy ASP.NET Core Blazor WebAssembly

--- a/aspnetcore/security/blazor/index.md
+++ b/aspnetcore/security/blazor/index.md
@@ -5,7 +5,7 @@ description: Learn about Blazor authentication and authorization scenarios.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/05/2019
+ms.date: 09/23/2019
 uid: security/blazor/index
 ---
 # ASP.NET Core Blazor authentication and authorization

--- a/aspnetcore/security/blazor/server.md
+++ b/aspnetcore/security/blazor/server.md
@@ -5,7 +5,7 @@ description: Learn how to mitigate security threats to Blazor Server apps.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/07/2019
+ms.date: 09/23/2019
 uid: security/blazor/server
 ---
 # Secure ASP.NET Core Blazor Server apps


### PR DESCRIPTION
Because Blazor's first release is 3.0 GA, we can mark the Blazor docs date with the 3.0 GA date. In this way, readers know the docs are current as of the 3.0 GA release and don't merely apply to some prior Blazor preview release.