### PR TITLE
Fix Typo in 22-to-30 documentation

### DIFF
--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -309,7 +309,7 @@ For more information, see [Put request trailers in a separate collection (aspnet
 
 ### AllowSynchronousIO disabled
 
-`AllowSynchronousIO` enables or disables synchronous IO APIs, such as `HttpReqeuest.Body.Read`, `HttpResponse.Body.Write`, and `Stream.Flush`. These APIs are a source of thread starvation leading to app crashes. In 3.0, `AllowSynchronousIO` is disabled by default. For more information, see [the Synchronous IO section in the Kestrel article](/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-3.0#synchronous-io).
+`AllowSynchronousIO` enables or disables synchronous IO APIs, such as `HttpRequest.Body.Read`, `HttpResponse.Body.Write`, and `Stream.Flush`. These APIs are a source of thread starvation leading to app crashes. In 3.0, `AllowSynchronousIO` is disabled by default. For more information, see [the Synchronous IO section in the Kestrel article](/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-3.0#synchronous-io).
 
 In addition to enabling `AllowSynchronousIO` with `ConfigureKestrel`'s options, synchronous IO can also be overridden on a per-request basis as a temporary mitigation:
 


### PR DESCRIPTION
There was a small typo in the Migrate from ASP.NET Core 2.2 to 3.0 documentation.