### PR TITLE
Update Blazor VS preview language

### DIFF
--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -16,7 +16,7 @@ By [Daniel Roth](https://github.com/danroth27) and [Luke Latham](https://github.
 
 Get started with Blazor:
 
-1. Install the latest [.NET Core 3.0 Preview SDK](https://dotnet.microsoft.com/download/dotnet-core/3.0) release.
+1. Install the latest [.NET Core 3.0 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.0) release.
 
 1. Install the Blazor templates by running the following command in a command shell:
 
@@ -28,7 +28,7 @@ Get started with Blazor:
 
    # [Visual Studio](#tab/visual-studio)
 
-   1\. Install the latest [Visual Studio preview](https://visualstudio.com/vs/preview) with the **ASP.NET and web development** workload.
+   1\. Install the latest [Visual Studio](https://visualstudio.com/vs/) with the **ASP.NET and web development** workload.
 
    2\. Create a new project.
 


### PR DESCRIPTION
Fixes #14511

* Looks like the SDK step and template install step are still required (seems so here with a VS upgrade to 16.3).
* Do we still need to guide readers to get the preview for VS4Mac?
