### PR TITLE
Fix docs about Configuration

### DIFF
--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -220,7 +220,7 @@ To configure the host builder, call <xref:Microsoft.Extensions.Hosting.HostBuild
 ```csharp
 public static IHostBuilder CreateHostBuilder(string[] args) =>
     Host.CreateDefaultBuilder(args)
-        .ConfigureHostConfiguration((hostingContext, config) =>
+        .ConfigureHostConfiguration(config =>
         {
             var dict = new Dictionary<string, string>
             {


### PR DESCRIPTION
The method `IHostBuilder.ConfigureHostConfiguration()` does not have a reference to the `IHostBuilderContext` in its action. Only `ConfigureAppConfiguration()` has it. So the code example is invalid and should be changed.