### PR TITLE
Added package names to migration doc

### DIFF
--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -174,13 +174,13 @@ Support for [Identity UI](xref:security/authentication/identity) can be added by
 
 * Authentication - Support for third-party authentication flows are available as NuGet packages:
 
-    * [Facebook OAuth](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Facebook)
-    * [Google OAuth](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Google)
-    * [OpenID Connect bearer token](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.JwtBearer)
-    * [Microsoft Account authentication](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.MicrosoftAccount)
-    * [OpenID Connect authentication](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.OpenIdConnect)
-    * [Twitter OAuth](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Twitter)
-    * [WsFederation authentication](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.WsFederation)
+    * Facebook OAuth [(Microsoft.AspNetCore.Authentication.Facebook)](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Facebook)
+    * Google OAuth [(Microsoft.AspNetCore.Authentication.Google)](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Google)
+    * OpenID Connect bearer token [(Microsoft.AspNetCore.Authentication.JwtBearer)](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.JwtBearer)
+    * Microsoft Account authentication [(Microsoft.AspNetCore.Authentication.MicrosoftAccount)](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.MicrosoftAccount)
+    * OpenID Connect authentication [(Microsoft.AspNetCore.Authentication.OpenIdConnect)](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.OpenIdConnect)
+    * Twitter OAuth [(Microsoft.AspNetCore.Authentication.Twitter)](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Twitter)
+    * WsFederation authentication [(Microsoft.AspNetCore.Authentication.WsFederation)](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.WsFederation)
 
 * Formatting and content negotiation support for `System.Net.HttpClient` - The [Microsoft.AspNet.WebApi.Client](https://www.nuget.org/packages/Microsoft.AspNet.WebApi.Client/) NuGet package provides useful extensibility to `System.Net.HttpClient` with APIs such as `ReadAsAsync`, `PostJsonAsync` etc.
 

--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -163,30 +163,31 @@ No additional references are required for these projects:
 
 ASP.NET Core 3.0 removes some assemblies that were previously part of the `Microsoft.AspNetCore.App` package reference. To continue using features provided by these assemblies, reference the 3.0 versions of the corresponding packages:
 
-* Entity Framework Core - See https://docs.microsoft.com/ef/core/providers/index for more information on referencing the database provider-specific package.
+* Entity Framework Core &ndash; See https://docs.microsoft.com/ef/core/providers/index for more information on referencing the database provider-specific package.
 
 * Identity UI
-Support for [Identity UI](xref:security/authentication/identity) can be added by referencing the [Microsoft.AspNetCore.Identity.UI](https://www.nuget.org/packages/Microsoft.AspNetCore.Identity.UI) package.
+
+  Support for [Identity UI](xref:security/authentication/identity) can be added by referencing the [Microsoft.AspNetCore.Identity.UI](https://www.nuget.org/packages/Microsoft.AspNetCore.Identity.UI) package.
 
 * SPA Services
-    * [Microsoft.AspNetCore.SpaServices](https://www.nuget.org/packages/Microsoft.AspNetCore.SpaServices)
-    * [Microsoft.AspNetCore.SpaServices.Extensions](https://www.nuget.org/packages/Microsoft.AspNetCore.SpaServices.Extensions)
+  * [Microsoft.AspNetCore.SpaServices](https://www.nuget.org/packages/Microsoft.AspNetCore.SpaServices)
+  * [Microsoft.AspNetCore.SpaServices.Extensions](https://www.nuget.org/packages/Microsoft.AspNetCore.SpaServices.Extensions)
 
-* Authentication - Support for third-party authentication flows are available as NuGet packages:
+* Authentication &ndash; Support for third-party authentication flows are available as NuGet packages:
 
-    * Facebook OAuth [(Microsoft.AspNetCore.Authentication.Facebook)](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Facebook)
-    * Google OAuth [(Microsoft.AspNetCore.Authentication.Google)](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Google)
-    * OpenID Connect bearer token [(Microsoft.AspNetCore.Authentication.JwtBearer)](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.JwtBearer)
-    * Microsoft Account authentication [(Microsoft.AspNetCore.Authentication.MicrosoftAccount)](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.MicrosoftAccount)
-    * OpenID Connect authentication [(Microsoft.AspNetCore.Authentication.OpenIdConnect)](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.OpenIdConnect)
-    * Twitter OAuth [(Microsoft.AspNetCore.Authentication.Twitter)](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Twitter)
-    * WsFederation authentication [(Microsoft.AspNetCore.Authentication.WsFederation)](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.WsFederation)
+  * Facebook OAuth ([Microsoft.AspNetCore.Authentication.Facebook](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Facebook))
+  * Google OAuth ([Microsoft.AspNetCore.Authentication.Google](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Google))
+  * OpenID Connect bearer token ([Microsoft.AspNetCore.Authentication.JwtBearer](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.JwtBearer))
+  * Microsoft Account authentication ([Microsoft.AspNetCore.Authentication.MicrosoftAccount](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.MicrosoftAccount))
+  * OpenID Connect authentication ([Microsoft.AspNetCore.Authentication.OpenIdConnect](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.OpenIdConnect))
+  * Twitter OAuth ([Microsoft.AspNetCore.Authentication.Twitter](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Twitter))
+  * WsFederation authentication ([Microsoft.AspNetCore.Authentication.WsFederation](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.WsFederation))
 
-* Formatting and content negotiation support for `System.Net.HttpClient` - The [Microsoft.AspNet.WebApi.Client](https://www.nuget.org/packages/Microsoft.AspNet.WebApi.Client/) NuGet package provides useful extensibility to `System.Net.HttpClient` with APIs such as `ReadAsAsync`, `PostJsonAsync` etc.
+* Formatting and content negotiation support for `System.Net.HttpClient` &ndash; The [Microsoft.AspNet.WebApi.Client](https://www.nuget.org/packages/Microsoft.AspNet.WebApi.Client/) NuGet package provides useful extensibility to `System.Net.HttpClient` with APIs such as `ReadAsAsync`, `PostJsonAsync` etc.
 
-* Razor runtime compilation - Support for runtime compilation of Razor views and pages is now part of [Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation).
+* Razor runtime compilation &ndash; Support for runtime compilation of Razor views and pages is now part of [Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation).
 
-* MVC `Newtonsoft.Json` support - Support for using MVC with `Newtonsoft.Json` is now part of [Microsoft.AspNetCore.Mvc.NewtonsoftJson](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.NewtonsoftJson).
+* MVC `Newtonsoft.Json` support &ndash; Support for using MVC with `Newtonsoft.Json` is now part of [Microsoft.AspNetCore.Mvc.NewtonsoftJson](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.NewtonsoftJson).
 
 ### Analyzer support
 


### PR DESCRIPTION
Hey @scottaddie,

When reading this doc, and upgrading my .NET Core 2.2 to .NET Core 3.0 bits I thought it would be nice to see the package names - so I'm adding them.