### PR TITLE
L124311: Adding two spaces to create hard break-line before snippet

### DIFF
--- a/aspnetcore/security/authentication/2fa.md
+++ b/aspnetcore/security/authentication/2fa.md
@@ -76,10 +76,10 @@ info: Successfully saved SMSAccountIdentification = 12345 to the secret store.
 
 * Add code in the *Services/MessageServices.cs* file to enable SMS. Use either the Twilio or the ASPSMS section:
 
-**Twilio:**
+**Twilio:**  
 [!code-csharp[](2fa/sample/Web2FA/Services/MessageServices_twilio.cs)]
 
-**ASPSMS:**
+**ASPSMS:**  
 [!code-csharp[](2fa/sample/Web2FA/Services/MessageServices_ASPSMS.cs)]
 
 ### Configure startup to use `SMSoptions`


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
Description: Missing hard break-line before snippet is preventing content to show properly. Please consider adding two spaces at the final of the line.