### PR TITLE
L124348: Removing extra space inside code snippet

### DIFF
--- a/aspnetcore/performance/caching/memory.md
+++ b/aspnetcore/performance/caching/memory.md
@@ -236,7 +236,7 @@ Request the `IMemoryCache` instance in the constructor:
 
 The following code uses [TryGetValue](/dotnet/api/microsoft.extensions.caching.memory.imemorycache.trygetvalue?view=aspnetcore-2.0#Microsoft_Extensions_Caching_Memory_IMemoryCache_TryGetValue_System_Object_System_Object__) to check if a time is in the cache. If a time isn't cached, a new entry is created and added to the cache with [Set](/dotnet/api/microsoft.extensions.caching.memory.cacheextensions.set?view=aspnetcore-2.0#Microsoft_Extensions_Caching_Memory_CacheExtensions_Set__1_Microsoft_Extensions_Caching_Memory_IMemoryCache_System_Object___0_Microsoft_Extensions_Caching_Memory_MemoryCacheEntryOptions_).
 
-[!code-csharp [](memory/sample/WebCache/CacheKeys.cs)]
+[!code-csharp[](memory/sample/WebCache/CacheKeys.cs)]
 
 [!code-csharp[](memory/sample/WebCache/Controllers/HomeController.cs?name=snippet1)]
 


### PR DESCRIPTION
Hi @Rick-Anderson 
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: Extra space inside code snippet is preventing correct display
