### PR TITLE
Update SignalR Client Features matrix

### DIFF
--- a/aspnetcore/signalr/client-features.md
+++ b/aspnetcore/signalr/client-features.md
@@ -14,7 +14,7 @@ uid: signalr/client-features
 
 The table below shows the features and support for the clients that offer real-time support.
 
-| Feature | .NET Core | JavaScript | Java |
+| Feature | .NET | JavaScript | Java |
 | ---- | :-: | :-: | :-: |
 | Azure SignalR Service Support |✔|✔|✔|
 | [Server-to-client Streaming](xref:signalr/streaming)          |✔|✔|✔|
@@ -23,6 +23,8 @@ The table below shows the features and support for the clients that offer real-t
 | WebSockets Transport |✔|✔|✔|
 | Server-Sent Events Transport |✔|✔| |
 | Long Polling Transport |✔|✔|✔|
+| JSON Hub Protocol |✔|✔|✔|
+| MessagePack Hub Protocol |✔|✔| |
 
 Support for automatic reconnect in the Java client is tracked in [our issue tracker](https://github.com/aspnet/AspNetCore/issues/8711).
 

--- a/aspnetcore/signalr/client-features.md
+++ b/aspnetcore/signalr/client-features.md
@@ -16,9 +16,15 @@ The table below shows the features and support for the clients that offer real-t
 
 | Feature | .NET Core | JavaScript | Java |
 | ---- | :-: | :-: | :-: |
+| Azure SignalR Service Support |✔|✔|✔|
 | [Server-to-client Streaming](xref:signalr/streaming)          |✔|✔|✔|
 | [Client-to-server Streaming](xref:signalr/streaming)          |✔|✔|✔|
 | Automatic Reconnection ([.NET](/aspnet/core/signalr/dotnet-client?view=aspnetcore-3.0&tabs=visual-studio#handle-lost-connection), [JavaScript](/aspnet/core/signalr/javascript-client?view=aspnetcore-3.0#reconnect-clients))          |✔|✔| |
+| WebSockets Transport |✔|✔|✔|
+| Server-Sent Events Transport |✔|✔| |
+| Long Polling Transport |✔|✔|✔|
+
+* Support for automatic reconnect in the Java client is tracked in [our issue tracker](https://github.com/aspnet/AspNetCore/issues/8711).
 
 ## Additional resources
 

--- a/aspnetcore/signalr/client-features.md
+++ b/aspnetcore/signalr/client-features.md
@@ -24,7 +24,7 @@ The table below shows the features and support for the clients that offer real-t
 | Server-Sent Events Transport |✔|✔| |
 | Long Polling Transport |✔|✔|✔|
 
-* Support for automatic reconnect in the Java client is tracked in [our issue tracker](https://github.com/aspnet/AspNetCore/issues/8711).
+Support for automatic reconnect in the Java client is tracked in [our issue tracker](https://github.com/aspnet/AspNetCore/issues/8711).
 
 ## Additional resources
 


### PR DESCRIPTION
A few updates:

* Added transports
* Added Azure SignalR support - every client supports it, but we do get questions like "can I use the service with Java?" so it's helpful to confirm that in the matrix, and technically the client has to do some (very minimal) work to support it. I put this at the top, because it's so awesome 😉, and that messed up the visual diff a bit (sorry!).
* Added note about issue tracking automatic reconnect