### PR TITLE
C125519: Reverting change from &colon; to : to avoid issues in localized bookmarks

### DIFF
--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -221,7 +221,7 @@ The `<text>` tag is useful to control whitespace when rendering content:
 * Only the content between the `<text>` tag is rendered.
 * No whitespace before or after the `<text>` tag appears in the HTML output.
 
-### Explicit line transition with \@&colon;
+### Explicit line transition with \@:
 
 To render the rest of an entire line as HTML inside a code block, use the `@:` syntax:
 


### PR DESCRIPTION
[EDIT by guardrex to show encoded value of the colon]

Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: `&colon;` should be changed for `:`



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->