### PR TITLE
Migrated asp.net core best practice to performance article & moved code to samples

### DIFF
--- a/aspnetcore/performance/performance-best-practices.md
+++ b/aspnetcore/performance/performance-best-practices.md
@@ -13,7 +13,7 @@ By [Mike Rousos](https://github.com/mjrousos)
 
 This article provides guidelines for performance best practices with ASP.NET Core.
 
-## [Understanding hot code paths](#hot)
+## Understanding hot code paths
 
 In this document, a *hot code path* is defined as a code path that is frequently called and where much of the execution time occurs. Hot code paths typically limit app scale-out and performance.
 
@@ -34,7 +34,7 @@ A common performance problem in ASP.NET Core apps is blocking calls that could b
 
 **Do**:
 
-* Make [hot code paths](#hot) asynchronous.
+* Make [hot code paths](#understanding-hot-code-paths) asynchronous.
 * Call data access and long-running operations APIs asynchronously.
 * Make controller/Razor Page actions asynchronous. The entire call stack is asynchronous in order to benefit from [async/await](/dotnet/csharp/programming-guide/concepts/async/) patterns.
 
@@ -43,13 +43,13 @@ A profiler, such as [PerfView](https://github.com/Microsoft/perfview), can be us
 ## Minimize large object allocations
 
 <!-- TODO review Bill - replaced original .NET language below with .NET Core since this targets .NET Core -->
-The [.NET Core garbage collector](/dotnet/standard/garbage-collection/) manages allocation and release of memory automatically in ASP.NET Core apps. Automatic garbage collection generally means that developers don't need to worry about how or when memory is freed. However, cleaning up unreferenced objects takes CPU time, so developers should minimize allocating objects in [hot code paths](#hot). Garbage collection is especially expensive on large objects (> 85 K bytes). Large objects are stored on the [large object heap](/dotnet/standard/garbage-collection/large-object-heap) and require a full (generation 2) garbage collection to clean up. Unlike generation 0 and generation 1 collections, a generation 2 collection requires a temporary suspension of app execution. Frequent allocation and de-allocation of large objects can cause inconsistent performance.
+The [.NET Core garbage collector](/dotnet/standard/garbage-collection/) manages allocation and release of memory automatically in ASP.NET Core apps. Automatic garbage collection generally means that developers don't need to worry about how or when memory is freed. However, cleaning up unreferenced objects takes CPU time, so developers should minimize allocating objects in [hot code paths](#understanding-hot-code-paths). Garbage collection is especially expensive on large objects (> 85 K bytes). Large objects are stored on the [large object heap](/dotnet/standard/garbage-collection/large-object-heap) and require a full (generation 2) garbage collection to clean up. Unlike generation 0 and generation 1 collections, a generation 2 collection requires a temporary suspension of app execution. Frequent allocation and de-allocation of large objects can cause inconsistent performance.
 
 Recommendations:
 
 * **Do** consider caching large objects that are frequently used. Caching large objects prevents expensive allocations.
 * **Do** pool buffers by using an [`ArrayPool<T>`](/dotnet/api/system.buffers.arraypool-1) to store large arrays.
-* **Do not** allocate many, short-lived large objects on [hot code paths](#hot).
+* **Do not** allocate many, short-lived large objects on [hot code paths](#understanding-hot-code-paths).
 
 Memory issues, such as the preceding, can be diagnosed by reviewing garbage collection (GC) stats in [PerfView](https://github.com/Microsoft/perfview) and examining:
 
@@ -102,7 +102,7 @@ You want all of your code to be fast, frequently called code paths are the most 
 Recommendations:
 
 * **Do not** use custom middleware components with long-running tasks.
-* **Do** use performance profiling tools, such as [Visual Studio Diagnostic Tools](/visualstudio/profiling/profiling-feature-tour) or [PerfView](https://github.com/Microsoft/perfview)), to identify [hot code paths](#hot).
+* **Do** use performance profiling tools, such as [Visual Studio Diagnostic Tools](/visualstudio/profiling/profiling-feature-tour) or [PerfView](https://github.com/Microsoft/perfview)), to identify [hot code paths](#understanding-hot-code-paths).
 
 ## Complete long-running Tasks outside of HTTP requests
 
@@ -143,7 +143,7 @@ Exceptions should be rare. Throwing and catching exceptions is slow relative to 
 
 Recommendations:
 
-* **Do not** use throwing or catching exceptions as a means of normal program flow, especially in [hot code paths](#hot).
+* **Do not** use throwing or catching exceptions as a means of normal program flow, especially in [hot code paths](#understanding-hot-code-paths).
 * **Do** include logic in the app to detect and handle conditions that would cause an exception.
 * **Do** throw or catch exceptions for unusual or unexpected conditions.
 

--- a/aspnetcore/performance/performance-best-practices.md
+++ b/aspnetcore/performance/performance-best-practices.md
@@ -13,13 +13,13 @@ By [Mike Rousos](https://github.com/mjrousos)
 
 This article provides guidelines for performance best practices with ASP.NET Core.
 
-## Understanding hot code paths
-
-In this document, a *hot code path* is defined as a code path that is frequently called and where much of the execution time occurs. Hot code paths typically limit app scale-out and performance.
-
 ## Cache aggressively
 
 Caching is discussed in several parts of this document. For more information, see <xref:performance/caching/response>.
+
+## Understand hot code paths
+
+In this document, a *hot code path* is defined as a code path that is frequently called and where much of the execution time occurs. Hot code paths typically limit app scale-out and performance and are discussed in several parts of this document.
 
 ## Avoid blocking calls
 
@@ -34,7 +34,7 @@ A common performance problem in ASP.NET Core apps is blocking calls that could b
 
 **Do**:
 
-* Make [hot code paths](#understanding-hot-code-paths) asynchronous.
+* Make [hot code paths](#understand-hot-code-paths) asynchronous.
 * Call data access and long-running operations APIs asynchronously.
 * Make controller/Razor Page actions asynchronous. The entire call stack is asynchronous in order to benefit from [async/await](/dotnet/csharp/programming-guide/concepts/async/) patterns.
 
@@ -43,13 +43,13 @@ A profiler, such as [PerfView](https://github.com/Microsoft/perfview), can be us
 ## Minimize large object allocations
 
 <!-- TODO review Bill - replaced original .NET language below with .NET Core since this targets .NET Core -->
-The [.NET Core garbage collector](/dotnet/standard/garbage-collection/) manages allocation and release of memory automatically in ASP.NET Core apps. Automatic garbage collection generally means that developers don't need to worry about how or when memory is freed. However, cleaning up unreferenced objects takes CPU time, so developers should minimize allocating objects in [hot code paths](#understanding-hot-code-paths). Garbage collection is especially expensive on large objects (> 85 K bytes). Large objects are stored on the [large object heap](/dotnet/standard/garbage-collection/large-object-heap) and require a full (generation 2) garbage collection to clean up. Unlike generation 0 and generation 1 collections, a generation 2 collection requires a temporary suspension of app execution. Frequent allocation and de-allocation of large objects can cause inconsistent performance.
+The [.NET Core garbage collector](/dotnet/standard/garbage-collection/) manages allocation and release of memory automatically in ASP.NET Core apps. Automatic garbage collection generally means that developers don't need to worry about how or when memory is freed. However, cleaning up unreferenced objects takes CPU time, so developers should minimize allocating objects in [hot code paths](#understand-hot-code-paths). Garbage collection is especially expensive on large objects (> 85 K bytes). Large objects are stored on the [large object heap](/dotnet/standard/garbage-collection/large-object-heap) and require a full (generation 2) garbage collection to clean up. Unlike generation 0 and generation 1 collections, a generation 2 collection requires a temporary suspension of app execution. Frequent allocation and de-allocation of large objects can cause inconsistent performance.
 
 Recommendations:
 
 * **Do** consider caching large objects that are frequently used. Caching large objects prevents expensive allocations.
 * **Do** pool buffers by using an [`ArrayPool<T>`](/dotnet/api/system.buffers.arraypool-1) to store large arrays.
-* **Do not** allocate many, short-lived large objects on [hot code paths](#understanding-hot-code-paths).
+* **Do not** allocate many, short-lived large objects on [hot code paths](#understand-hot-code-paths).
 
 Memory issues, such as the preceding, can be diagnosed by reviewing garbage collection (GC) stats in [PerfView](https://github.com/Microsoft/perfview) and examining:
 
@@ -102,7 +102,7 @@ You want all of your code to be fast, frequently called code paths are the most 
 Recommendations:
 
 * **Do not** use custom middleware components with long-running tasks.
-* **Do** use performance profiling tools, such as [Visual Studio Diagnostic Tools](/visualstudio/profiling/profiling-feature-tour) or [PerfView](https://github.com/Microsoft/perfview)), to identify [hot code paths](#understanding-hot-code-paths).
+* **Do** use performance profiling tools, such as [Visual Studio Diagnostic Tools](/visualstudio/profiling/profiling-feature-tour) or [PerfView](https://github.com/Microsoft/perfview)), to identify [hot code paths](#understand-hot-code-paths).
 
 ## Complete long-running Tasks outside of HTTP requests
 
@@ -143,7 +143,7 @@ Exceptions should be rare. Throwing and catching exceptions is slow relative to 
 
 Recommendations:
 
-* **Do not** use throwing or catching exceptions as a means of normal program flow, especially in [hot code paths](#understanding-hot-code-paths).
+* **Do not** use throwing or catching exceptions as a means of normal program flow, especially in [hot code paths](#understand-hot-code-paths).
 * **Do** include logic in the app to detect and handle conditions that would cause an exception.
 * **Do** throw or catch exceptions for unusual or unexpected conditions.
 
@@ -163,7 +163,7 @@ All IO in ASP.NET Core is asynchronous. Servers implement the `Stream` interface
 [!code-csharp[](performance-best-practices/samples/3.x/Controllers/MyFirstController.cs?name=snippet2)]
 
 [!NOTE]
-If the request is large, it could lead to out of memory problems, which can result in a Denial Of Service. See [Avoid reading large request bodies or response bodies into memory](#avoid-reading-large-requests) for more information.**
+If the request is large, it could lead to out of memory problems, which can result in a Denial Of Service. See [Avoid reading large request bodies or response bodies into memory](#avoid-reading-large-request-bodies-or-response-bodies-into-memory) for more information.**
 
 ## Prefer using HttpRequest.ReadAsFormAsync() over HttpRequest.Form
 
@@ -178,7 +178,7 @@ Use `HttpRequest.ReadAsFormAsync()` instead of `HttpRequest.Form`. The only time
 
 [!code-csharp[](performance-best-practices/samples/3.x/Controllers/MySecondController.cs?name=snippet2)]
 
-## [Avoid reading large request bodies or response bodies into memory](#avoid-reading-large-requests)
+## Avoid reading large request bodies or response bodies into memory
 
 In .NET, any single object allocation greater than 85 KB ends up in the large object heap ([LOH](https://blogs.msdn.microsoft.com/maoni/2006/04/19/large-object-heap/)). Large objects are expensive in two ways:
 
@@ -196,7 +196,7 @@ Naively storing a large request or response body into a single `byte[]` or `stri
 When using a serializer/de-serializer that only supports synchronous reads and writes (like JSON.NET) then chose to buffer the data into memory before passing data into the serializer/de-serializer.
 
 [!NOTE]
-If the request is large, it could lead to out of memory problems, which can result in a Denial Of Service. See [Avoid reading large request bodies or response bodies into memory](#avoid-reading-large-requests) for more information.**
+If the request is large, it could lead to out of memory problems, which can result in a Denial Of Service. See [Avoid reading large request bodies or response bodies into memory](#avoid-reading-large-request-bodies-or-response-bodies-into-memory) for more information.**
 
 ## Do not store IHttpContextAccessor.HttpContext in a field
 

--- a/aspnetcore/performance/performance-best-practices.md
+++ b/aspnetcore/performance/performance-best-practices.md
@@ -4,14 +4,14 @@ author: mjrousos
 description: Tips for increasing performance in ASP.NET Core apps and avoiding common performance problems.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
-ms.date: 05/10/2019
+ms.date: 09/26/2019
 uid: performance/performance-best-practices
 ---
 # ASP.NET Core Performance Best Practices
 
 By [Mike Rousos](https://github.com/mjrousos)
 
-This topic provides guidelines for performance best practices with ASP.NET Core.
+This article provides guidelines for performance best practices with ASP.NET Core.
 
 <a name="hot"></a>
 
@@ -148,3 +148,126 @@ Recommendations:
 * **Do** throw or catch exceptions for unusual or unexpected conditions.
 
 App diagnostic tools, such as Application Insights, can help to identify common exceptions in an app that may affect performance.
+
+## Avoid using synchronous Read/Write overloads on HttpRequest.Body and HttpResponse.Body
+
+All IO in ASP.NET Core is asynchronous. Servers implement the `Stream` interface, which has both synchronous and asynchronous overloads. The asynchronous ones should be preferred to avoid blocking thread pool threads. This could lead to thread pool starvation.
+
+**Do not do this:** The following example uses the `StreamReader.ReadToEnd`. It blocks the current thread to wait for the result. This is an example of [sync over async](perfomance-best-practices.md#avoid-using-taskresult-and-taskwait).
+
+[!code-csharp[](performance-best-practices/samples/3.x/MyFirstController.cs?name=snippet1)]
+
+**Do this:** The following example uses `StreamReader.ReadToEndAsync` and does not block the thread while reading.
+
+[!code-csharp[](performance-best-practices/samples/3.x/MyFirstController.cs?name=snippet2)]
+
+[!NOTE]
+If the request is large, it could lead to out of memory problems, which can result in a Denial Of Service. See [Avoid reading large request bodies or response bodies into memory](#avoid-reading-large-request-bodies-or-response-bodies-into-memory) for more information.**
+
+## Prefer using HttpRequest.ReadAsFormAsync() over HttpRequest.Form
+
+Use `HttpRequest.ReadAsFormAsync()` instead of `HttpRequest.Form`. The only time it is safe to use `HttpRequest.Form` is when the form has already been read by a call to `HttpRequest.ReadAsFormAsync()` and the cached form value is being read using `HttpRequest.Form`.
+
+**Do not do this:** The following example uses `HttpRequest.Form`.   `HttpRequest.Form` uses [sync over async](performance-best-practices.md#avoid-using-taskresult-and-taskwait) and can lead to thread pool starvation.
+
+[!code-csharp[](performance-best-practices/samples/3.x/MySecondController.cs?name=snippet1)]
+
+**Do this:** The following example uses `HttpRequest.ReadAsFormAsync()` to read the form body asynchronously.
+
+[!code-csharp[](performance-best-practices/samples/3.x/MySecondController.cs?name=snippet2)]
+
+## Avoid reading large request bodies or response bodies into memory
+
+In .NET, any single object allocation greater than 85 KB ends up in the large object heap ([LOH](https://blogs.msdn.microsoft.com/maoni/2006/04/19/large-object-heap/)). Large objects are expensive in two ways:
+
+* The allocation cost is high since the memory for a newly allocated large object has to be cleared. The CLR guarantees that memory for all newly allocated objects is cleared.
+* LOH is collected with the rest of the heap (it requires a "full garbage collection" or Gen2 collection)
+
+This [blog post](https://adamsitnik.com/Array-Pool/#the-problem) describes the problem succinctly:
+
+> When a large object is allocated, it’s marked as Gen 2 object. Not Gen 0 as for small objects. The consequences are that if you run out of memory in LOH, GC cleans up whole managed heap, not only LOH. So it cleans up Gen 0, Gen 1 and Gen 2 including LOH. This is called full garbage collection and is the most time-consuming garbage collection. For many applications, it can be acceptable. But definitely not for high-performance web servers, where few big memory buffers are needed to handle an average web request (read from a socket, decompress, decode JSON & more).
+
+Naively storing a large request or response body into a single `byte[]` or `string` may result in quickly running out of space in the LOH and may cause performance issues for your application because of full GCs running. 
+
+## Use buffered and synchronous reads and writes as an alternative to asynchronous reading and writing
+
+When using a serializer/de-serializer that only supports synchronous reads and writes (like JSON.NET) then chose to buffer the data into memory before passing data into the serializer/de-serializer.
+
+[!NOTE]
+If the request is large, it could lead to out of memory problems, which can result in a Denial Of Service. See [Avoid reading large request bodies or response bodies into memory](#avoid-reading-large-request-bodies-or-response-bodies-into-memory) for more information.**
+
+## Do not store IHttpContextAccessor.HttpContext in a field
+
+The `IHttpContextAccessor.HttpContext` will return the `HttpContext` of the active request when accessed from the request thread. The `IHttpContextAccessor.HttpContext` should not be stored in a field or variable.
+
+**Do not do this:** The following example stores the HttpContext in a field then attempts to use it later.
+
+[!code-csharp[](performance-best-practices/samples/3.x/MyType.cs?name=snippet1)]
+
+The preceding logic will likely capture a null or fraudulent HttpContext in the constructor for later use.
+
+**Do this:** The following example stores the IHttpContextAccessor itself in a field and uses the HttpContext field at the correct time (checking for null).
+
+[!code-csharp[](performance-best-practices/samples/3.x/MyType.cs?name=snippet2)]
+
+## Do not access the HttpContext from multiple threads in parallel. It is not thread safe
+
+The `HttpContext` is *NOT* thread-safe. Accessing it from multiple threads in parallel can cause corruption resulting in undefined behavior (hangs, crashes, data corruption).
+
+**Do not do this:** The following example makes three parallel requests and logs the incoming request path before and after the outgoing http request. The request path is accessed from multiple threads, potentially in parallel.
+
+[!code-csharp[](performance-best-practices/samples/3.x/AsyncFirstController.cs?name=snippet1)]
+
+**Do this:** The following example copies all data from the incoming request before making the three parallel requests.
+
+[!code-csharp[](performance-best-practices/samples/3.x/AsyncFirstController.cs?name=snippet2)]
+
+## Do not use the HttpContext after the request is complete
+
+The `HttpContext` is only valid as long as there is an active http request in flight. The entire ASP.NET Core pipeline is an asynchronous chain of delegates that executes every request. When the `Task` returned from this chain completes, the `HttpContext` is recycled. 
+
+**Do not do this:** The following example uses async void (which is **ALWAYS** a bad practice in ASP.NET Core applications) and as a result, accesses the `HttpResponse` after the http request is complete. It will crash the process as a result.
+
+[!code-csharp[](performance-best-practices/samples/3.x/AsyncVoidController.cs?name=snippet1)]
+
+**Do this:** The following example returns a `Task` to the framework so the http request doesn't complete until the entire action completes.
+
+[!code-csharp[](performance-best-practices/samples/3.x/AsyncSecondController.cs?name=snippet1)]
+
+## Do not capture the HttpContext in background threads
+
+**Do not do this:** The following example shows a closure is capturing the `HttpContext` from the `Controller` property. This is a bad practice since the work item could run outside of the request scope and as a result, could attempt to read fraudulent `HttpContext`.
+
+[!code-csharp[](performance-best-practices/samples/3.x/FireAndForgetFirstController.cs?name=snippet1)]
+
+**Do this:** The following example copies the data required in the background task during the request explicitly and does not reference anything from the controller itself.
+
+[!code-csharp[](performance-best-practices/samples/3.x/FireAndForgetFirstController.cs?name=snippet2)]
+
+## Do not capture services injected into the controllers on background threads
+
+**Do not do this:** The following example shows a closure is capturing the DbContext from the Controller action parameter. This is a bad practice.  The work item could run outside of the request scope and the PokemonDbContext is scoped to the request, resulting in an `ObjectDisposedException`.
+
+[!code-csharp[](performance-best-practices/samples/3.x/FireAndForgetSecondController.cs?name=snippet1)]
+
+**Do this:** The following example injects an `IServiceScopeFactory` and creates a new dependency injection scope in the background thread and does not reference anything from the controller itself.
+
+[!code-csharp[](performance-best-practices/samples/3.x/FireAndForgetSecondController.cs?name=snippet2)]
+
+## Avoid adding headers after the HttpResponse has started
+
+ASP.NET Core does not buffer the http response body. So the first time the response is written, the headers are sent along with that chunk of the body to the client. When this happens, it's no longer possible to change response headers.
+
+**Do not do this:** This logic tries to add response headers after the response has already started.
+
+[!code-csharp[](performance-best-practices/samples/3.x/Startup.cs?name=snippet1)]
+
+**Do this:** The following example checks if the http response has started before writing to the body.
+
+[!code-csharp[](performance-best-practices/samples/3.x/Startup.cs?name=snippet2)]
+
+**Do this:** The following example uses `HttpResponse.OnStarting` to set the headers before the response headers are flushed to the client.
+
+This allows you to register a callback that will be invoked just before response headers are written to the client. It gives you the ability to append or override headers just in time, without requiring knowledge of the next middleware in the pipeline.
+
+[!code-csharp[](performance-best-practices/samples/3.x/Startup.cs?name=snippet3)]

--- a/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/AsyncFirstController.cs
+++ b/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/AsyncFirstController.cs
@@ -1,0 +1,93 @@
+﻿/*
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace performance_best_practices.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+
+#if BAD
+    #region snippit1
+    public class AsyncFirstController : Controller
+    {
+        [HttpGet("/search")]
+        public async Task<SearchResults> Get(string query)
+        {
+            var query1 = SearchAsync(SearchEngine.Google, query);
+            var query2 = SearchAsync(SearchEngine.Bing, query);
+            var query3 = SearchAsync(SearchEngine.DuckDuckGo, query);
+
+            await Task.WhenAll(query1, query2, query3);
+
+            var results1 = await query1;
+            var results2 = await query2;
+            var results3 = await query3;
+
+            return SearchResults.Combine(results1, results2, results3);
+        }
+
+        private async Task<SearchResults> SearchAsync(SearchEngine engine, string query)
+        {
+            var searchResults = SearchResults.Empty;
+            try
+            {
+                _logger.LogInformation("Starting search query from {path}.", HttpContext.Request.Path);
+                searchResults = await _searchService.SearchAsync(engine, query);
+                _logger.LogInformation("Finishing search query from {path}.", HttpContext.Request.Path);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed query from {path}", HttpContext.Request.Path);
+            }
+
+            return searchResults;
+        }
+    }
+    #endregion
+#else
+    #region snippit2
+    public class AsyncFirstController : Controller
+    {
+        [HttpGet("/search")]
+        public async Task<SearchResults> Get(string query)
+        {
+            string path = HttpContext.Request.Path;
+            var query1 = SearchAsync(SearchEngine.Google, query, path);
+            var query2 = SearchAsync(SearchEngine.Bing, query, path);
+            var query3 = SearchAsync(SearchEngine.DuckDuckGo, query, path);
+
+            await Task.WhenAll(query1, query2, query3);
+
+            var results1 = await query1;
+            var results2 = await query2;
+            var results3 = await query3;
+
+            return SearchResults.Combine(results1, results2, results3);
+        }
+
+        private async Task<SearchResults> SearchAsync(SearchEngine engine, string query, string path)
+        {
+            var searchResults = SearchResults.Empty;
+            try
+            {
+                _logger.LogInformation("Starting search query from {path}.", path);
+                searchResults = await _searchService.SearchAsync(engine, query);
+                _logger.LogInformation("Finishing search query from {path}.", path);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed query from {path}", path);
+            }
+
+            return searchResults;
+        }
+    }
+    #endregion
+#endif
+}
+*/

--- a/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/AsyncFirstController.cs
+++ b/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/AsyncFirstController.cs
@@ -12,7 +12,7 @@ namespace performance_best_practices.Controllers
     [ApiController]
 
 #if BAD
-    #region snippit1
+    #region snippet1
     public class AsyncFirstController : Controller
     {
         [HttpGet("/search")]
@@ -50,7 +50,7 @@ namespace performance_best_practices.Controllers
     }
     #endregion
 #else
-    #region snippit2
+    #region snippet2
     public class AsyncFirstController : Controller
     {
         [HttpGet("/search")]

--- a/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/AsyncSecondController.cs
+++ b/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/AsyncSecondController.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 #if BAD
 namespace performance_best_practices.Controllers
 {
-#region snippit1
+#region snippet1
     public class AsyncSecondController : Controller
     {
         [HttpGet("/async")]

--- a/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/AsyncSecondController.cs
+++ b/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/AsyncSecondController.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#if BAD
+namespace performance_best_practices.Controllers
+{
+#region snippit1
+    public class AsyncSecondController : Controller
+    {
+        [HttpGet("/async")]
+        public async Task Get()
+        {
+            await Task.Delay(1000);
+
+            await Response.WriteAsync("Hello World");
+        }
+    }
+#endregion
+}
+#endif

--- a/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/AsyncVoidController.cs
+++ b/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/AsyncVoidController.cs
@@ -11,7 +11,7 @@ namespace performance_best_practices.Controllers
     [Route("api/[controller]")]
     [ApiController]
 
-    #region snippit1
+    #region snippet1
     public class AsyncVoidController : Controller
     {
         [HttpGet("/async")]

--- a/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/AsyncVoidController.cs
+++ b/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/AsyncVoidController.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#if BAD
+namespace performance_best_practices.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+
+    #region snippit1
+    public class AsyncVoidController : Controller
+    {
+        [HttpGet("/async")]
+        public async void Get()
+        {
+            await Task.Delay(1000);
+
+            // THIS will crash the process since we're writing after the response has completed on a background thread
+            await Response.WriteAsync("Hello World");
+        }
+    }
+    #endregion
+}
+#endif

--- a/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/FireAndForgetFirstController.cs
+++ b/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/FireAndForgetFirstController.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+/*
+namespace performance_best_practices.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+#if BAD
+    public class FireAndForgetFirstController : Controller
+    {
+    #region snippet1
+        [HttpGet("/fire-and-forget-1")]
+        public IActionResult FireAndForget1()
+        {
+            _ = Task.Run(() =>
+            {
+                await Task.Delay(1000);
+
+                // This closure is capturing the context from the Controller property. This is bad because this work item could run
+                // outside of the http request leading to reading of bogus data.
+                var path = HttpContext.Request.Path;
+                Log(path);
+            });
+
+            return Accepted();
+        }
+    #endregion
+    }
+#else
+    public class FireAndForgetFirstController : Controller
+    {
+        #region snippet2
+        [HttpGet("/fire-and-forget-3")]
+        public IActionResult FireAndForget3()
+        {
+            string path = HttpContext.Request.Path;
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(1000);
+
+                // This captures just the path
+                Log(path);
+            });
+
+            return Accepted();
+        }
+        #endregion
+    }
+#endif
+}
+*/

--- a/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/FireAndForgetSecondController.cs
+++ b/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/FireAndForgetSecondController.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace performance_best_practices.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+#if BAD
+
+    public class FireAndForgetSecondController : Controller
+    {
+    #region snippet1
+        [HttpGet("/fire-and-forget-1")]
+        public IActionResult FireAndForget1([FromServices]PokemonDbContext context)
+        {
+            _ = Task.Run(() =>
+            {
+                await Task.Delay(1000);
+
+                // This closure is capturing the context from the Controller action parameter. This is bad because this work item could run
+                // outside of the request scope and the PokemonDbContext is scoped to the request. As a result, this throw an ObjectDisposedException
+                context.Pokemon.Add(new Pokemon());
+                await context.SaveChangesAsync();
+            });
+
+            return Accepted();
+        }
+    #endregion
+
+    }
+
+#else
+    public class FireAndForgetSecondController : Controller
+    {
+        #region snippet2
+        [HttpGet("/fire-and-forget-3")]
+        public IActionResult FireAndForget3([FromServices]IServiceScopeFactory serviceScopeFactory)
+        {
+            // This version of fire and forget adds some exception handling. We're also no longer capturing the PokemonDbContext from the incoming request.
+            // Instead, we're injecting an IServiceScopeFactory (which is a singleton) in order to create a scope in the background work item.
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(1000);
+
+                // Create a scope for the lifetime of the background operation and resolve services from it
+                using (var scope = serviceScopeFactory.CreateScope())
+                {
+                    // This will use PokemonDbContext from the correct scope and the operation will succeed
+                    var context = scope.ServiceProvider.GetRequiredService<PokemonDbContext>();
+
+                    context.Pokemon.Add(new Pokemon());
+                    await context.SaveChangesAsync();
+                }
+            });
+
+            return Accepted();
+        }
+        #endregion
+    }
+#endif
+}

--- a/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/MyFirstController.cs
+++ b/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/MyFirstController.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+/*
+namespace performance_best_practices.Controllers
+{
+[Route("api/[controller]")]
+[ApiController]
+
+#if BAD
+    #region snippit1
+    public class MyFirstController : Controller
+    {
+        [HttpGet("/pokemon")]
+        public ActionResult<PokemonData> Get()
+        {
+            // This synchronously reads the entire http request body into memory.
+            // If the client is slowly uploading, we're doing sync over async because Kestrel does *NOT* support synchronous reads.
+            var json = new StreamReader(Request.Body).ReadToEnd();
+
+            return JsonConvert.DeserializeObject<PokemonData>(json);
+        }
+    }
+    #endregion
+#else
+    #region snippet2
+    public class MyFirstController : Controller
+    {
+        [HttpGet("/pokemon")]
+        public async Task<ActionResult<PokemonData>> Get()
+        {
+            // This asynchronously reads the entire http request body into memory.
+            var json = await new StreamReader(Request.Body).ReadToEndAsync();
+
+            return JsonConvert.DeserializeObject<PokemonData>(json);
+        }
+    }
+    #endregion
+#endif
+
+}
+*/

--- a/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/MyFirstController.cs
+++ b/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/MyFirstController.cs
@@ -12,7 +12,7 @@ namespace performance_best_practices.Controllers
 [ApiController]
 
 #if BAD
-    #region snippit1
+    #region snippet1
     public class MyFirstController : Controller
     {
         [HttpGet("/pokemon")]

--- a/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/MySecondController.cs
+++ b/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/MySecondController.cs
@@ -12,7 +12,7 @@ namespace performance_best_practices.Controllers
 [ApiController]
 
 #if BAD
-    #region snippit1
+    #region snippet1
     public class MySecondController : Controller
     {
         [HttpPost("/form-body")]

--- a/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/MySecondController.cs
+++ b/aspnetcore/performance/performance-best-practices/samples/3.x/Controllers/MySecondController.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+/*
+namespace performance_best_practices.Controllers
+{
+[Route("api/[controller]")]
+[ApiController]
+
+#if BAD
+    #region snippit1
+    public class MySecondController : Controller
+    {
+        [HttpPost("/form-body")]
+        public IActionResult Post()
+        {
+            var form = HttpRequest.Form;
+
+            Process(form["id"], form["name"]);
+
+            return Accepted();
+        }
+    }
+    #endregion
+#else
+    #region snippet2
+    public class MySecondController : Controller
+    {
+          [HttpPost("/form-body")]
+        public async Task<IActionResult> Post()
+        {
+            var form = await HttpRequest.ReadAsFormAsync();
+
+            Process(form["id"], form["name"]);
+
+            return Accepted();
+        }
+    }
+    #endregion
+#endif
+}
+*/

--- a/aspnetcore/performance/performance-best-practices/samples/3.x/MyType.cs
+++ b/aspnetcore/performance/performance-best-practices/samples/3.x/MyType.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace performance_best_practices
 {
     #if BAD
-    #region snippit1
+    #region snippet1
     public class MyType
     {
         private readonly HttpContext _context;
@@ -26,7 +26,7 @@ namespace performance_best_practices
     }
     #endregion
     #else
-    #region snippit2
+    #region snippet2
     public class MyType
     {
         private readonly IHttpContextAccessor _accessor;

--- a/aspnetcore/performance/performance-best-practices/samples/3.x/MyType.cs
+++ b/aspnetcore/performance/performance-best-practices/samples/3.x/MyType.cs
@@ -1,0 +1,50 @@
+﻿/*
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace performance_best_practices
+{
+    #if BAD
+    #region snippit1
+    public class MyType
+    {
+        private readonly HttpContext _context;
+        public MyType(IHttpContextAccessor accessor)
+        {
+            _context = accessor.HttpContext;
+        }
+
+        public void CheckAdmin()
+        {
+            if (!_context.User.IsInRole("admin"))
+            {
+                throw new UnauthorizedAccessException("The current user isn't an admin");
+            }
+        }
+    }
+    #endregion
+    #else
+    #region snippit2
+    public class MyType
+    {
+        private readonly IHttpContextAccessor _accessor;
+        public MyType(IHttpContextAccessor accessor)
+        {
+            _accessor = accessor;
+        }
+
+        public void CheckAdmin()
+        {
+            var context = _accessor.HttpContext;
+            if (context != null && !context.User.IsInRole("admin"))
+            {
+                throw new UnauthorizedAccessException("The current user isn't an admin");
+            }
+        }
+    }
+    #endregion
+    #endif
+}
+*/

--- a/aspnetcore/performance/performance-best-practices/samples/3.x/Program.cs
+++ b/aspnetcore/performance/performance-best-practices/samples/3.x/Program.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace performance_best_practices
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/aspnetcore/performance/performance-best-practices/samples/3.x/Startup.cs
+++ b/aspnetcore/performance/performance-best-practices/samples/3.x/Startup.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpsPolicy;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace performance_best_practices
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseHttpsRedirection();
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+/*
+#if BAD
+            #region snippet1
+            app.Use(async (next, context) =>
+            {
+                await context.Response.WriteAsync("Hello ");
+    
+                await next();
+    
+                // This may fail if next() already wrote to the response
+                context.Response.Headers["test"] = "value";    
+            });
+            #endregion
+#else
+            #region snippet2
+            app.Use(async (next, context) =>
+            {
+                await context.Response.WriteAsync("Hello ");
+
+                await next();
+
+                // Check if the response has already started before adding header and writing
+                if (!context.Response.HasStarted)
+                {
+                    context.Response.Headers["test"] = "value";
+                }
+            });
+            #endregion
+            #region snippet3
+            app.Use(async (next, context) =>
+            {
+                // Wire up the callback that will fire just before the response headers are sent to the client.
+                context.Response.OnStarting(() =>
+                {
+                    context.Response.Headers["someheader"] = "somevalue";
+                    return Task.CompletedTask;
+                });
+
+                await next();
+            });
+            #endregion
+#endif
+*/
+        }
+    }
+}

--- a/aspnetcore/performance/performance-best-practices/samples/3.x/appsettings.Development.json
+++ b/aspnetcore/performance/performance-best-practices/samples/3.x/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/aspnetcore/performance/performance-best-practices/samples/3.x/appsettings.json
+++ b/aspnetcore/performance/performance-best-practices/samples/3.x/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/aspnetcore/performance/performance-best-practices/samples/3.x/performance-best-practices.csproj
+++ b/aspnetcore/performance/performance-best-practices/samples/3.x/performance-best-practices.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <RootNamespace>performance_best_practices</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixes #14605

[Internal Review URL](https://review.docs.microsoft.com/en-us/aspnet/core/performance/performance-best-practices?view=aspnetcore-2.1&branch=pr-en-us-14678#avoid-using-synchronous-readwrite-overloads-on-httprequestbody-and-httpresponsebody)

What was done:
Migrated: https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AspNetCoreGuidance.m@
to : performance-best-practices.

Light edit and moved all code snippets into a samples project (3.0).

Project does not compile yet.  @Rick-Anderson will take over for next steps.