### PR TITLE
Bookmark update

### DIFF
--- a/aspnetcore/data/ef-mvc/read-related-data.md
+++ b/aspnetcore/data/ef-mvc/read-related-data.md
@@ -3,7 +3,7 @@ title: "Tutorial: Read related data - ASP.NET MVC with EF Core"
 description: "In this tutorial you'll read and display related data -- that is, data that the Entity Framework loads into navigation properties."
 author: tdykstra
 ms.author: riande
-ms.date: 03/27/2019
+ms.date: 09/28/2019
 ms.topic: tutorial
 uid: data/ef-mvc/read-related-data
 ---
@@ -183,7 +183,7 @@ You've made the following changes to the existing code:
   }
   ```
 
-* Added a **Courses** column that displays courses taught by each instructor. For more information, see the [Explicit line transition with @:](xref:mvc/views/razor#explicit-line-transition-with-) section of the Razor syntax article.
+* Added a **Courses** column that displays courses taught by each instructor. For more information, see the [Explicit line transition](xref:mvc/views/razor#explicit-line-transition) section of the Razor syntax article.
 
 * Added code that dynamically adds `class="success"` to the `tr` element of the selected instructor. This sets a background color for the selected row using a Bootstrap class.
 

--- a/aspnetcore/data/ef-rp/read-related-data.md
+++ b/aspnetcore/data/ef-rp/read-related-data.md
@@ -4,7 +4,7 @@ author: tdykstra
 description: In this tutorial you read and display related data -- that is, data that the Entity Framework loads into navigation properties.
 ms.author: riande
 ms.custom: mvc
-ms.date: 07/22/2019
+ms.date: 09/28/2019
 uid: data/ef-rp/read-related-data
 ---
 
@@ -253,7 +253,7 @@ The preceding code makes the following changes:
   }
   ```
 
-* Adds a **Courses** column that displays courses taught by each instructor. See [Explicit Line Transition with `@:`](xref:mvc/views/razor#explicit-line-transition-with-) for more about this razor syntax.
+* Adds a **Courses** column that displays courses taught by each instructor. See [Explicit line transition](xref:mvc/views/razor#explicit-line-transition) for more about this razor syntax.
 
 * Adds code that dynamically adds `class="success"` to the `tr` element of the selected instructor and course. This sets a background color for the selected row using a Bootstrap class.
 
@@ -522,7 +522,7 @@ The preceding markup makes the following changes:
   }
   ```
 
-* Added a **Courses** column that displays courses taught by each instructor. See [Explicit line transition with `@:`](xref:mvc/views/razor#explicit-line-transition-with-) for more about this razor syntax.
+* Added a **Courses** column that displays courses taught by each instructor. See [Explicit line transition](xref:mvc/views/razor#explicit-line-transition) for more about this razor syntax.
 
 * Added code that dynamically adds `class="success"` to the `tr` element of the selected instructor. This sets a background color for the selected row using a Bootstrap class.
 

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -3,7 +3,7 @@ title: Razor syntax reference for ASP.NET Core
 author: rick-anderson
 description: Learn about Razor markup syntax for embedding server-based code into webpages.
 ms.author: riande
-ms.date: 09/19/2019
+ms.date: 09/28/2019
 uid: mvc/views/razor
 ---
 # Razor syntax reference for ASP.NET Core
@@ -221,9 +221,9 @@ The `<text>` tag is useful to control whitespace when rendering content:
 * Only the content between the `<text>` tag is rendered.
 * No whitespace before or after the `<text>` tag appears in the HTML output.
 
-### Explicit line transition with \@&colon;
+### Explicit line transition
 
-To render the rest of an entire line as HTML inside a code block, use the `@:` syntax:
+To render the rest of an entire line as HTML inside a code block, use `@:` syntax:
 
 ```cshtml
 @for (var i = 0; i < people.Length; i++)


### PR DESCRIPTION
Fixes #14681

Discussion in #14668.

Turns out that the loc version ends up with the correct destination heading (i.e., `<h3 id="explicit-line-transition-with-colon">`), which would have been easy to deal with in the source links by merely updating three bookmarks to this destination from `xref:mvc/views/razor#explicit-line-transition-with-` to `xref:mvc/views/razor#explicit-line-transition-with-colon`. The problem is on the English-side: The destination header is rendered as `<h3 id="explicit-line-transition-with-">`, and that's no good.

Best solution is to remove the colon: It's not necessary to describe this section, and removing it fixes the cross-topic bookmark issue everywhere.