### PR TITLE
Clarify EFCore package

### DIFF
--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn how to migrate an ASP.NET Core 2.2 project to ASP.NET Core 3.0.
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/25/2019
+ms.date: 09/29/2019
 uid: migration/22-to-30
 ---
 # Migrate from ASP.NET Core 2.2 to 3.0
@@ -194,13 +194,16 @@ If your app is using docker, use a base image that includes ASP.NET Core 3.0. Fo
 
 ASP.NET Core 3.0 removes some assemblies that were previously part of the `Microsoft.AspNetCore.App` package reference. To continue using features provided by these assemblies, reference the 3.0 versions of the corresponding packages:
 
-* Entity Framework Core &ndash; For more information on referencing the database provider-specific package, see [Database Providers](/ef/core/providers/index).
+* [Microsoft.EntityFrameworkCore](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore)
+
+  For more information on referencing the database provider-specific package, see [Database Providers](/ef/core/providers/index).
 
 * Identity UI
 
   Support for [Identity UI](xref:security/authentication/identity) can be added by referencing the [Microsoft.AspNetCore.Identity.UI](https://www.nuget.org/packages/Microsoft.AspNetCore.Identity.UI) package.
 
 * SPA Services
+
   * [Microsoft.AspNetCore.SpaServices](https://www.nuget.org/packages/Microsoft.AspNetCore.SpaServices)
   * [Microsoft.AspNetCore.SpaServices.Extensions](https://www.nuget.org/packages/Microsoft.AspNetCore.SpaServices.Extensions)
 


### PR DESCRIPTION
Fixes #14695

* Clarify EFCore package by naming the package and linking out to NuGet.
* Disambiguate the providers remark by moving it down a line so that it's just implying that 'if you need this, go here.'

Thanks @sbsw! 🏍