### PR TITLE
Update documentations for GetFallbackPolicy

### DIFF
--- a/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
+++ b/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
@@ -4,7 +4,7 @@ author: mjrousos
 description: Learn how to use a custom IAuthorizationPolicyProvider in an ASP.NET Core app to dynamically generate authorization policies.
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/15/2019
+ms.date: 09/30/2019
 uid: security/authorization/iauthorizationpolicyprovider
 ---
 # Custom Authorization Policy Providers using IAuthorizationPolicyProvider in ASP.NET Core 
@@ -31,7 +31,7 @@ The `IAuthorizationPolicyProvider` interface contains three APIs:
 
 * [GetPolicyAsync](/dotnet/api/microsoft.aspnetcore.authorization.iauthorizationpolicyprovider.getpolicyasync#Microsoft_AspNetCore_Authorization_IAuthorizationPolicyProvider_GetPolicyAsync_System_String_) returns an authorization policy for a given name.
 * [GetDefaultPolicyAsync](/dotnet/api/microsoft.aspnetcore.authorization.iauthorizationpolicyprovider.getdefaultpolicyasync) returns the default authorization policy (the policy used for `[Authorize]` attributes without a policy specified). 
-* [GetFallbackPolicyAsync](/dotnet/api/microsoft.aspnetcore.authorization.iauthorizationpolicyprovider.getfallbackpolicyasync) returns the fallback authorization policy (the policy used by the AuthorizationMiddleware when no policy is specified). 
+* [GetFallbackPolicyAsync](/dotnet/api/microsoft.aspnetcore.authorization.iauthorizationpolicyprovider.getfallbackpolicyasync) returns the fallback authorization policy (the policy used by the Authorization Middleware when no policy is specified). 
 
 By implementing these APIs, you can customize how authorization policies are provided.
 
@@ -158,9 +158,9 @@ As with all aspects of a custom `IAuthorizationPolicyProvider`, you can customiz
 
 ## Fallback policy
 
-A custom `IAuthorizationPolicyProvider` needs to implement `GetFallbackPolicyAsync` to, optionally, provide a policy that is used by the AuthorizationMiddleware when no policies are specified. If `GetFallbackPolicyAsync` returns a non-null policy, that policy will be used by the AuthorizationMiddleware when no policies are specified for the request.
+A custom `IAuthorizationPolicyProvider` must optionally implement `GetFallbackPolicyAsync` to provide a policy that's used by the Authorization Middleware when no policies are specified. If `GetFallbackPolicyAsync` returns a non-null policy, that policy is used by the Authorization Middleware when no policies are specified for the request.
 
-If no fallback policy is needed, the provider can just return null or defer to the fallback provider:
+If no fallback policy is required, the provider can return `null` or defer to the fallback provider:
 
 ```csharp
 public Task<AuthorizationPolicy> GetRequiredPolicyAsync() => 

--- a/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
+++ b/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
@@ -27,12 +27,13 @@ ASP.NET Core apps use an implementation of the `IAuthorizationPolicyProvider` in
 
 You can customize this behavior by registering a different `IAuthorizationPolicyProvider` implementation in the app’s [dependency injection](xref:fundamentals/dependency-injection) container. 
 
-The `IAuthorizationPolicyProvider` interface contains two APIs:
+The `IAuthorizationPolicyProvider` interface contains three APIs:
 
 * [GetPolicyAsync](/dotnet/api/microsoft.aspnetcore.authorization.iauthorizationpolicyprovider.getpolicyasync#Microsoft_AspNetCore_Authorization_IAuthorizationPolicyProvider_GetPolicyAsync_System_String_) returns an authorization policy for a given name.
 * [GetDefaultPolicyAsync](/dotnet/api/microsoft.aspnetcore.authorization.iauthorizationpolicyprovider.getdefaultpolicyasync) returns the default authorization policy (the policy used for `[Authorize]` attributes without a policy specified). 
+* [GetFallbackPolicyAsync](/dotnet/api/microsoft.aspnetcore.authorization.iauthorizationpolicyprovider.getfallbackpolicyasync) returns the fallback authorization policy (the policy used by the AuthorizationMiddleware when no policy is specified). 
 
-By implementing these two APIs, you can customize how authorization policies are provided.
+By implementing these APIs, you can customize how authorization policies are provided.
 
 ## Parameterized authorize attribute example
 
@@ -155,11 +156,11 @@ public Task<AuthorizationPolicy> GetDefaultPolicyAsync() =>
 
 As with all aspects of a custom `IAuthorizationPolicyProvider`, you can customize this, as needed. In some cases, it may be desirable to retrieve the default policy from a fallback `IAuthorizationPolicyProvider`.
 
-## Required policy
+## Fallback policy
 
-A custom `IAuthorizationPolicyProvider` needs to implement `GetRequiredPolicyAsync` to, optionally, provide a policy that is always required. If `GetRequiredPolicyAsync` returns a non-null policy, that policy will be combined with any other (named or default) policy that is requested.
+A custom `IAuthorizationPolicyProvider` needs to implement `GetFallbackPolicyAsync` to, optionally, provide a policy that is used by the AuthorizationMiddleware when no policies are specified. If `GetFallbackPolicyAsync` returns a non-null policy, that policy will be used by the AuthorizationMiddleware when no policies are specified for the request.
 
-If no required policy is needed, the provider can just return null or defer to the fallback provider:
+If no fallback policy is needed, the provider can just return null or defer to the fallback provider:
 
 ```csharp
 public Task<AuthorizationPolicy> GetRequiredPolicyAsync() => 

--- a/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
+++ b/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
@@ -4,7 +4,7 @@ author: mjrousos
 description: Learn how to use a custom IAuthorizationPolicyProvider in an ASP.NET Core app to dynamically generate authorization policies.
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/30/2019
+ms.date: 11/14/2019
 uid: security/authorization/iauthorizationpolicyprovider
 ---
 # Custom Authorization Policy Providers using IAuthorizationPolicyProvider in ASP.NET Core 
@@ -158,7 +158,7 @@ As with all aspects of a custom `IAuthorizationPolicyProvider`, you can customiz
 
 ## Fallback policy
 
-A custom `IAuthorizationPolicyProvider` can optionally implement `GetFallbackPolicyAsync` to provide a policy that's used when [combining policies](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authorization.authorizationpolicy.combine?view=aspnetcore-3.0) and also by the Authorization Middleware when no policies are specified. If `GetFallbackPolicyAsync` returns a non-null policy, that policy is used by the Authorization Middleware when no policies are specified for the request.
+A custom `IAuthorizationPolicyProvider` can optionally implement `GetFallbackPolicyAsync` to provide a policy that's used when [combining policies](/dotnet/api/microsoft.aspnetcore.authorization.authorizationpolicy.combine) and when no policies are specified. If `GetFallbackPolicyAsync` returns a non-null policy, the returned policy is used by the Authorization Middleware when no policies are specified for the request.
 
 If no fallback policy is required, the provider can return `null` or defer to the fallback provider:
 

--- a/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
+++ b/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
@@ -158,7 +158,7 @@ As with all aspects of a custom `IAuthorizationPolicyProvider`, you can customiz
 
 ## Fallback policy
 
-A custom `IAuthorizationPolicyProvider` must optionally implement `GetFallbackPolicyAsync` to provide a policy that's used by the Authorization Middleware when no policies are specified. If `GetFallbackPolicyAsync` returns a non-null policy, that policy is used by the Authorization Middleware when no policies are specified for the request.
+A custom `IAuthorizationPolicyProvider` can optionally implement `GetFallbackPolicyAsync` to provide a policy that's used by the Authorization Middleware when no policies are specified. If `GetFallbackPolicyAsync` returns a non-null policy, that policy is used by the Authorization Middleware when no policies are specified for the request.
 
 If no fallback policy is required, the provider can return `null` or defer to the fallback provider:
 

--- a/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
+++ b/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
@@ -163,7 +163,7 @@ A custom `IAuthorizationPolicyProvider` can optionally implement `GetFallbackPol
 If no fallback policy is required, the provider can return `null` or defer to the fallback provider:
 
 ```csharp
-public Task<AuthorizationPolicy> GetRequiredPolicyAsync() => 
+public Task<AuthorizationPolicy> GetFallbackPolicyAsync() => 
     Task.FromResult<AuthorizationPolicy>(null);
 ```
 


### PR DESCRIPTION
Note: GetRequiredPolicy was removed/replaced in 3.0, but the docs were updated already to include the obsolete (now non existent method)

Fixes https://github.com/aspnet/AspNetCore/issues/13762

@Rick-Anderson @guardrex not sure who can help review/edit this update.  