### PR TITLE
Fix in AdditionalFields property sample

### DIFF
--- a/aspnetcore/mvc/models/validation/sample/Models/User.cs
+++ b/aspnetcore/mvc/models/validation/sample/Models/User.cs
@@ -10,9 +10,9 @@ namespace ValidationSample.Models
         #endregion
 
         #region snippet_UserNameProperties
-        [Remote(action: "VerifyName", controller: "Users", AdditionalFields = nameof(FirstName))]
-        public string FirstName { get; set; }
         [Remote(action: "VerifyName", controller: "Users", AdditionalFields = nameof(LastName))]
+        public string FirstName { get; set; }
+        [Remote(action: "VerifyName", controller: "Users", AdditionalFields = nameof(FirstName))]
         public string LastName { get; set; }
         #endregion
 


### PR DESCRIPTION
The AdditionalFields property of the [Remote] attribute is for the other fields that you want to relate but in the sample code, the field is referring to itself as an additional field.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->