### PR TITLE
components reconnect status failed is renamed

### DIFF
--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -131,7 +131,7 @@ When the client detects that the connection has been lost, a default UI is displ
 
 * `components-reconnect-show` &ndash; Show the UI to indicate the connection was lost and the client is attempting to reconnect.
 * `components-reconnect-hide` &ndash; The client has an active connection, hide the UI.
-* `components-reconnect-failed` &ndash; Reconnection failed. To attempt reconnection again, call `window.Blazor.reconnect()`.
+* `components-reconnect-rejected` &ndash; Reconnection rejected. To attempt reconnection again, call `window.Blazor.reconnect()`.
 
 ### Stateful reconnection after prerendering
 

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -132,11 +132,9 @@ When the client detects that the connection has been lost, a default UI is displ
 * `components-reconnect-show` &ndash; Show the UI to indicate a lost connection and the client is attempting to reconnect.
 * `components-reconnect-hide` &ndash; The client has an active connection, hide the UI.
 * `components-reconnect-failed` &ndash; Reconnection failed, probably due to a network failure. To attempt reconnection, call `window.Blazor.reconnect()`.
-* `components-reconnect-rejected` &ndash; Reconnection rejected. The server was reached but refused the connection, and the user's state on the server is gone. This connection state may result when:
+* `components-reconnect-rejected` &ndash; Reconnection rejected. The server was reached but refused the connection, and the user's state on the server is gone. To attempt reconnection, call `window.Blazor.reconnect()`. This connection state may result when:
   * A crash in the circuit (server-side code) occurs.
   * The client is disconnected long enough for the server to drop the user's state. Instances of components that the user was interacting with are disposed.
-  
-  To attempt reconnection, call `window.Blazor.reconnect()`.
 
 ### Stateful reconnection after prerendering
 

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -5,7 +5,7 @@ description: Understand Blazor WebAssembly and Blazor Server hosting models.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/23/2019
+ms.date: 10/02/2019
 uid: blazor/hosting-models
 ---
 # ASP.NET Core Blazor hosting models
@@ -129,9 +129,10 @@ Blazor Server apps require an active SignalR connection to the server. If the co
 
 When the client detects that the connection has been lost, a default UI is displayed to the user while the client attempts to reconnect. If reconnection fails, the user is provided the option to retry. To customize the UI, define an element with `components-reconnect-modal` as its `id` in the *_Host.cshtml* Razor page. The client updates this element with one of the following CSS classes based on the state of the connection:
 
-* `components-reconnect-show` &ndash; Show the UI to indicate the connection was lost and the client is attempting to reconnect.
+* `components-reconnect-show` &ndash; Show the UI to indicate a lost connection and the client is attempting to reconnect.
 * `components-reconnect-hide` &ndash; The client has an active connection, hide the UI.
-* `components-reconnect-rejected` &ndash; Reconnection rejected. To attempt reconnection again, call `window.Blazor.reconnect()`.
+* `components-reconnect-failed` &ndash; Reconnection failed. To attempt reconnection, call `window.Blazor.reconnect()`.
+* `components-reconnect-rejected` &ndash; Reconnection rejected. To attempt reconnection, call `window.Blazor.reconnect()`.
 
 ### Stateful reconnection after prerendering
 

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -131,8 +131,12 @@ When the client detects that the connection has been lost, a default UI is displ
 
 * `components-reconnect-show` &ndash; Show the UI to indicate a lost connection and the client is attempting to reconnect.
 * `components-reconnect-hide` &ndash; The client has an active connection, hide the UI.
-* `components-reconnect-failed` &ndash; Reconnection failed. To attempt reconnection, call `window.Blazor.reconnect()`.
-* `components-reconnect-rejected` &ndash; Reconnection rejected. To attempt reconnection, call `window.Blazor.reconnect()`.
+* `components-reconnect-failed` &ndash; Reconnection failed, probably due to a network failure. To attempt reconnection, call `window.Blazor.reconnect()`.
+* `components-reconnect-rejected` &ndash; Reconnection rejected. The server was reached but refused the connection, and the user's state on the server is gone. This connection state may result when:
+  * A crash in the circuit (server-side code) occurs.
+  * The client is disconnected long enough for the server to drop the user's state. Instances of components that the user was interacting with are disposed.
+  
+  To attempt reconnection, call `window.Blazor.reconnect()`.
 
 ### Stateful reconnection after prerendering
 


### PR DESCRIPTION
`components-reconnect-failed` is renamed to `components-reconnect-rejected` so just updating this



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->