### PR TITLE
Hosted Services sample updates

### DIFF
--- a/aspnetcore/fundamentals/host/hosted-services.md
+++ b/aspnetcore/fundamentals/host/hosted-services.md
@@ -10,7 +10,7 @@ uid: fundamentals/host/hosted-services
 ---
 # Background tasks with hosted services in ASP.NET Core
 
-By [Luke Latham](https://github.com/guardrex)
+By [Luke Latham](https://github.com/guardrex) and [Jeow Li Huan](https://github.com/huan086)
 
 ::: moniker range=">= aspnetcore-3.0"
 
@@ -143,7 +143,7 @@ In the following `QueueHostedService` example:
 * Background tasks in the queue are dequeued and executed in `BackgroundProcessing`.
 * Work items are awaited before the service stops in `StopAsync`.
 
-[!code-csharp[](hosted-services/samples/3.x/BackgroundTasksSample/Services/QueuedHostedService.cs?name=snippet1&highlight=22-27,34-35,39,53-54)]
+[!code-csharp[](hosted-services/samples/3.x/BackgroundTasksSample/Services/QueuedHostedService.cs?name=snippet1&highlight=28-29,33)]
 
 A `MonitorLoop` service handles enqueuing tasks for the hosted service whenever the `w` key is selected on an input device:
 

--- a/aspnetcore/fundamentals/host/hosted-services.md
+++ b/aspnetcore/fundamentals/host/hosted-services.md
@@ -141,13 +141,17 @@ In the following `QueueHostedService` example:
 
 * The `BackgroundProcessing` method returns a `Task`, which is awaited in `ExecuteAsync`.
 * Background tasks in the queue are dequeued and executed in `BackgroundProcessing`.
+* Work items are awaited before the service stops in `StopAsync`.
 
-[!code-csharp[](hosted-services/samples/3.x/BackgroundTasksSample/Services/QueuedHostedService.cs?name=snippet1&highlight=28,39-40,44)]
+[!code-csharp[](hosted-services/samples/3.x/BackgroundTasksSample/Services/QueuedHostedService.cs?name=snippet1&highlight=22-27,34-35,39,53-54)]
 
 A `MonitorLoop` service handles enqueuing tasks for the hosted service whenever the `w` key is selected on an input device:
 
 * The `IBackgroundTaskQueue` is injected into the `MonitorLoop` service.
 * `IBackgroundTaskQueue.QueueBackgroundWorkItem` is called to enqueue a work item.
+* The work item simulates a long-running background task:
+  * Three 5-second delays are executed (`Task.Delay`).
+  * A `try-catch` statement traps <xref:System.OperationCanceledException> if the task is cancelled.
 
 [!code-csharp[](hosted-services/samples/3.x/BackgroundTasksSample/Services/MonitorLoop.cs?name=snippet_Monitor&highlight=7,33)]
 

--- a/aspnetcore/fundamentals/host/hosted-services/samples/3.x/BackgroundTasksSample/Services/MonitorLoop.cs
+++ b/aspnetcore/fundamentals/host/hosted-services/samples/3.x/BackgroundTasksSample/Services/MonitorLoop.cs
@@ -41,17 +41,43 @@ namespace BackgroundTasksSample.Services
                     // Enqueue a background work item
                     _taskQueue.QueueBackgroundWorkItem(async token =>
                     {
+                        // Simulate three 5-second tasks to complete
+                        // for each enqueued work item
+
+                        int delayLoop = 0;
                         var guid = Guid.NewGuid().ToString();
 
-                        for (int delayLoop = 0; delayLoop < 3; delayLoop++)
+                        _logger.LogInformation(
+                            "Queued Background Task {Guid} is starting.", guid);
+
+                        while (!token.IsCancellationRequested && delayLoop < 3)
                         {
+                            try
+                            {
+                                await Task.Delay(TimeSpan.FromSeconds(5), token);
+                            }
+                            catch (OperationCanceledException)
+                            {
+                                // Prevent throwing if the Delay is cancelled
+                            }
+
+                            delayLoop++;
+
                             _logger.LogInformation(
-                                "Queued Background Task {Guid} is running. {DelayLoop}/3", guid, delayLoop);
-                            await Task.Delay(TimeSpan.FromSeconds(5), token);
+                                "Queued Background Task {Guid} is running. " +
+                                "{DelayLoop}/3", guid, delayLoop);
                         }
 
-                        _logger.LogInformation(
-                            "Queued Background Task {Guid} is complete. 3/3", guid);
+                        if (delayLoop == 3)
+                        {
+                            _logger.LogInformation(
+                                "Queued Background Task {Guid} is complete.", guid);
+                        }
+                        else
+                        {
+                            _logger.LogInformation(
+                                "Queued Background Task {Guid} was cancelled.", guid);
+                        }
                     });
                 }
             }

--- a/aspnetcore/fundamentals/host/hosted-services/samples/3.x/BackgroundTasksSample/Services/QueuedHostedService.cs
+++ b/aspnetcore/fundamentals/host/hosted-services/samples/3.x/BackgroundTasksSample/Services/QueuedHostedService.cs
@@ -9,7 +9,6 @@ namespace BackgroundTasksSample.Services
     #region snippet1
     public class QueuedHostedService : BackgroundService
     {
-        private Task _backgroundTask;
         private readonly ILogger<QueuedHostedService> _logger;
 
         public QueuedHostedService(IBackgroundTaskQueue taskQueue, 
@@ -28,12 +27,7 @@ namespace BackgroundTasksSample.Services
                 $"{Environment.NewLine}Tap W to add a work item to the " +
                 $"background queue.{Environment.NewLine}");
 
-            _backgroundTask = Task.Run(async () =>
-                {
-                    await BackgroundProcessing(stoppingToken);
-                }, stoppingToken);
-
-            await _backgroundTask;
+            await BackgroundProcessing(stoppingToken);
         }
 
         private async Task BackgroundProcessing(CancellationToken stoppingToken)
@@ -58,9 +52,6 @@ namespace BackgroundTasksSample.Services
         public override async Task StopAsync(CancellationToken stoppingToken)
         {
             _logger.LogInformation("Queued Hosted Service is stopping.");
-
-            await Task.WhenAny(_backgroundTask, 
-                    Task.Delay(Timeout.Infinite, stoppingToken));
 
             await base.StopAsync(stoppingToken);
         }

--- a/aspnetcore/fundamentals/host/hosted-services/samples/3.x/BackgroundTasksSample/Services/TimedHostedService.cs
+++ b/aspnetcore/fundamentals/host/hosted-services/samples/3.x/BackgroundTasksSample/Services/TimedHostedService.cs
@@ -33,7 +33,7 @@ namespace BackgroundTasksSample.Services
             executionCount++;
 
             _logger.LogInformation(
-                "Timed Hosted Service is working. Count: {Count}"), executionCount;
+                "Timed Hosted Service is working. Count: {Count}", executionCount);
         }
 
         public Task StopAsync(CancellationToken stoppingToken)


### PR DESCRIPTION
Fixes #14746 
Fixes #12342

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-2.1&branch=pr-en-us-14765)

On stopping, the sample revision throws ...

```console
Unhandled exception. System.OperationCanceledException: The operation was canceled.
   at System.Threading.CancellationToken.ThrowOperationCanceledException()
   at Microsoft.Extensions.Hosting.Internal.Host.StopAsync(CancellationToken cancellationToken)
   at Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.WaitForShutdownAsync(IHost host, CancellationToken token)
   at BackgroundTasksSample.Program.Main(String[] args) in C:\Users\guard\Desktop\BackgroundTasksSample\Program.cs:line 40
   at BackgroundTasksSample.Program.<Main>(String[] args)
```

Even if that would happen in this scenario (normally for this example), I'd *greatly prefer* to resolve it for a nice, graceful no-:beetle:-feeling app shutdown.

The sample is up over at :point_right: https://github.com/guardrex/BackgroundTasksSample

*It's `async`, tokens, and 🐢 all the way down!*:tm: :smile:

Cross-ref:

* Original issue for the genesis of the topic 👉 #3352
* PR that produced the first version with additional discussion 👉 #6484

cc: @huan086