### PR TITLE
Remove extra moniker-end tag causing duplicate content

### DIFF
--- a/aspnetcore/tutorials/signalr-typescript-webpack.md
+++ b/aspnetcore/tutorials/signalr-typescript-webpack.md
@@ -4,7 +4,7 @@ author: ssougnez
 description: In this tutorial, you configure Webpack to bundle and build an ASP.NET Core SignalR web app whose client is written in TypeScript.
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 04/23/2019
+ms.date: 10/04/2019
 uid: tutorials/signalr-typescript-webpack
 ---
 # Use ASP.NET Core SignalR with TypeScript and Webpack
@@ -261,7 +261,7 @@ Confirm that the app works with the following steps.
 
 ::: moniker-end
 
-::: moniker range="<= aspnetcore-2.2"
+::: moniker range="< aspnetcore-3.0"
 
 # [Visual Studio](#tab/visual-studio)
 

--- a/aspnetcore/tutorials/signalr-typescript-webpack.md
+++ b/aspnetcore/tutorials/signalr-typescript-webpack.md
@@ -408,8 +408,6 @@ The following steps configure the conversion of TypeScript to JavaScript and the
 
     [!code-csharp[Startup](signalr-typescript-webpack/sample/2.x/Startup.cs?name=snippet_UseSignalR)]
 
-::: moniker-end
-
 1. Create a new directory, called *Hubs*, in the project root. Its purpose is to store the SignalR hub, which is created in the next step.
 
 1. Create hub *Hubs/ChatHub.cs* with the following code:


### PR DESCRIPTION
There was an extra `::: moniker-end` in the document that was casing the end of the document to appear regardless of the version, causing duplicate content to appear.

Fixes #14815 