### PR TITLE
Blazor minimum versions

### DIFF
--- a/aspnetcore/blazor/supported-platforms.md
+++ b/aspnetcore/blazor/supported-platforms.md
@@ -5,7 +5,7 @@ description: Learn about the supported platforms for ASP.NET Core Blazor.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/23/2019
+ms.date: 10/05/2019
 uid: blazor/supported-platforms
 ---
 # ASP.NET Core Blazor supported platforms
@@ -16,7 +16,7 @@ By [Luke Latham](https://github.com/guardrex)
 
 ## Browser requirements
 
-### Blazor WebAssembly
+### Blazor WebAssembly (Preview)
 
 | Browser                          | Version               |
 | -------------------------------- | :-------------------: |
@@ -30,13 +30,13 @@ By [Luke Latham](https://github.com/guardrex)
 
 ### Blazor Server
 
-| Browser                          | Version    |
-| -------------------------------- | :--------: |
-| Microsoft Edge                   | Current    |
-| Mozilla Firefox                  | Current    |
-| Google Chrome, including Android | Current    |
-| Safari, including iOS            | Current    |
-| Microsoft Internet Explorer      | 11&dagger; |
+| Browser                          | Version     |
+| -------------------------------- | :---------: |
+| Microsoft Edge                   | 44          |
+| Mozilla Firefox                  | 69          |
+| Google Chrome, including Android | 77          |
+| Safari macOS/iOS                 | 13 / 12.4.2 |
+| Microsoft Internet Explorer      | 11&dagger;  |
 
 &dagger;Additional polyfills are required (for example, promises can be added via a [Polyfill.io](https://polyfill.io/v3/) bundle).
 


### PR DESCRIPTION
Fixes #13614

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/supported-platforms?view=aspnetcore-3.0&branch=pr-en-us-14842)

Assumes that the browser versions at the time of 3.0 release are the correct ones to list for Blazor Server.

Blazor WebAssembly remains on "Current" versions while in preview.