### PR TITLE
Remove 'xref' from comment

### DIFF
--- a/aspnetcore/fundamentals/middleware/index.md
+++ b/aspnetcore/fundamentals/middleware/index.md
@@ -81,7 +81,7 @@ FUTURE UPDATE
 
 On the next topic overhaul/release update, add API crosslink to "Database Error Page Middleware" in Item 1 of the list ...
 
-(<xref:Microsoft.AspNetCore.Builder.DatabaseErrorPageExtensions.UseDatabaseErrorPage*>)
+Microsoft.AspNetCore.Builder.DatabaseErrorPageExtensions.UseDatabaseErrorPage*
 
 ... when available via the API docs.
 


### PR DESCRIPTION
The comment that I set up earlier to hold a note for future update didn't work with 'xref' on it.