### PR TITLE
Updated signalr script tag (#14810)

### DIFF
--- a/aspnetcore/tutorials/signalr.md
+++ b/aspnetcore/tutorials/signalr.md
@@ -112,7 +112,7 @@ The SignalR server library is included in the ASP.NET Core 3.0 shared framework.
 * Run the following command to get the SignalR client library by using LibMan. You might have to wait a few seconds before seeing output.
 
   ```console
-  libman install @microsoft/signalr@latest -p unpkg -d wwwroot/lib/signalr --files dist/browser/signalr.js --files dist/browser/signalr.min.js
+  libman install @microsoft/signalr@latest -p unpkg -d wwwroot/js/signalr --files dist/browser/signalr.js --files dist/browser/signalr.min.js
   ```
 
   The parameters specify the following options:

--- a/aspnetcore/tutorials/signalr/sample-snapshot/3.x/Index.cshtml
+++ b/aspnetcore/tutorials/signalr/sample-snapshot/3.x/Index.cshtml
@@ -26,5 +26,5 @@
             <ul id="messagesList"></ul>
         </div>
     </div>
-<script src="~/lib/signalr/dist/browser/signalr.js"></script>
+<script src="~/js/signalr/dist/browser/signalr.js"></script>
 <script src="~/js/chat.js"></script>


### PR DESCRIPTION
Fixes #14810

The location of signalr.js was incorrect according to Target Location set
up when Client-Side Library was added earlier in tutorial.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->