### PR TITLE
Merge to live part II 10-9

### DIFF
--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -1062,7 +1062,7 @@ In `Startup.ConfigureServices`, call `AddJsonProtocol` to set serializer options
 services.AddSignalR(...)
         .AddJsonProtocol(options =>
         {
-            options.WriteIndented = false;
+            options.PayloadSerializerOptions.WriteIndented = false;
         })
 ```
 
@@ -1073,7 +1073,7 @@ new HubConnectionBuilder()
     .WithUrl("/chatHub")
     .AddJsonProtocol(options =>
     {
-        options.WriteIndented = false;
+        options.PayloadSerializerOptions.WriteIndented = false;
     })
     .Build();
 ```

--- a/aspnetcore/performance/performance-best-practices.md
+++ b/aspnetcore/performance/performance-best-practices.md
@@ -170,7 +170,6 @@ The preceding code asynchronously reads the entire HTTP request body into memory
 > If the request is large, reading the entire HTTP request body into memory could lead to an out of memory (OOM) condition. OOM can result in a Denial Of Service.  For more information, see [Avoid reading large request bodies or response bodies into memory](#arlb) in this document.
 
 ## Prefer ReadAsFormAsync over Request.Form
-<!-- TODO Review required. I change all the API's here from original -->
 
 Use `HttpContext.Request.ReadFormAsync` instead of `HttpContext.Request.Form`.
 `HttpContext.Request.Form` can be safely read only with the following conditions:
@@ -251,9 +250,6 @@ The preceding code frequently captures a null or incorrect `HttpContext` in the 
 
 ## Do not use the HttpContext after the request is complete
 
-<!-- TODO Review, original uses `in flight`, which won't MT (Machine translate) 
-`HttpContext` is only valid as long as there is an active HTTP request `in flight`.
--->
 `HttpContext` is only valid as long as there is an active HTTP request in the ASP.NET Core pipeline. The entire ASP.NET Core pipeline is an asynchronous chain of delegates that executes every request. When the `Task` returned from this chain completes, the `HttpContext` is recycled.
 
 **Do not do this:** The following example uses `async void`:
@@ -286,7 +282,7 @@ The preceding code frequently captures a null or incorrect `HttpContext` in the 
 
 ## Do not capture services injected into the controllers on background threads
 
-**Do not do this:** The following example shows a closure is capturing the `DbContext` from the `Controller` action parameter. This is a bad practice.  The work item could run outside of the request scope. The `PokemonDbContext` is scoped to the request, resulting in an `ObjectDisposedException`.
+**Do not do this:** The following example shows a closure is capturing the `DbContext` from the `Controller` action parameter. This is a bad practice.  The work item could run outside of the request scope. The `ContosoDbContext` is scoped to the request, resulting in an `ObjectDisposedException`.
 
 [!code-csharp[](performance-best-practices/samples/3.0/Controllers/FireAndForgetSecondController.cs?name=snippet1)]
 
@@ -295,14 +291,14 @@ The preceding code frequently captures a null or incorrect `HttpContext` in the 
 * Injects an <xref:Microsoft.Extensions.DependencyInjection.IServiceScopeFactory> in order to create a scope in the background work item. `IServiceScopeFactory` is a singleton.
 * Creates a new dependency injection scope in the background thread.
 * Doesn't reference anything from the controller.
-* Doesn't capture the `PokemonDbContext` from the incoming request.
+* Doesn't capture the `ContosoDbContext` from the incoming request.
 
 [!code-csharp[](performance-best-practices/samples/3.0/Controllers/FireAndForgetSecondController.cs?name=snippet2)]
 
 The following highlighted code:
 
 * Creates a scope for the lifetime of the background operation and resolves services from it.
-* Uses `PokemonDbContext` from the correct scope.
+* Uses `ContosoDbContext` from the correct scope.
 
 [!code-csharp[](performance-best-practices/samples/3.0/Controllers/FireAndForgetSecondController.cs?name=snippet2&highlight=9-16)]
 

--- a/aspnetcore/performance/performance-best-practices/samples/3.0/Controllers/FireAndForgetSecondController.cs
+++ b/aspnetcore/performance/performance-best-practices/samples/3.0/Controllers/FireAndForgetSecondController.cs
@@ -11,13 +11,13 @@ namespace performance_best_practices.Controllers
     {
     #region snippet1
         [HttpGet("/fire-and-forget-1")]
-        public IActionResult FireAndForget1([FromServices]PokemonDbContext context)
+        public IActionResult FireAndForget1([FromServices]ContosoDbContext context)
         {
             _ = Task.Run(async () =>
             {
                 await Task.Delay(1000);
 
-                context.Pokemon.Add(new Pokemon());
+                context.Contoso.Add(new Contoso());
                 await context.SaveChangesAsync();
             });
 
@@ -27,18 +27,18 @@ namespace performance_best_practices.Controllers
         #endregion
     }
 
-    public class Pokemon
+    public class Contoso
     {
-        public Pokemon()
+        public Contoso()
         {
         }
 
-        public void Add (Pokemon p) { }
+        public void Add (Contoso p) { }
     }
 
-    public class PokemonDbContext
+    public class ContosoDbContext
     {
-        public  Pokemon  Pokemon;
+        public  Contoso  Contoso;
 
         internal Task SaveChangesAsync()
         {
@@ -61,9 +61,9 @@ namespace performance_best_practices.Controllers
 
                 using (var scope = serviceScopeFactory.CreateScope())
                 {
-                    var context = scope.ServiceProvider.GetRequiredService<PokemonDbContext>();
+                    var context = scope.ServiceProvider.GetRequiredService<ContosoDbContext>();
 
-                    context.Pokemon.Add(new Pokemon());
+                    context.Contoso.Add(new Contoso());
 
                     await context.SaveChangesAsync();                                        
                 }

--- a/aspnetcore/performance/performance-best-practices/samples/3.0/Controllers/MyFirstController.cs
+++ b/aspnetcore/performance/performance-best-practices/samples/3.0/Controllers/MyFirstController.cs
@@ -11,12 +11,12 @@ namespace performance_best_practices.Controllers
     #region snippet1
     public class BadStreamReaderController : Controller
     {
-        [HttpGet("/pokemon")]
-        public ActionResult<PokemonData> Get()
+        [HttpGet("/contoso")]
+        public ActionResult<ContosoData> Get()
         {           
             var json = new StreamReader(Request.Body).ReadToEnd();
 
-            return JsonSerializer.Deserialize<PokemonData>(json);
+            return JsonSerializer.Deserialize<ContosoData>(json);
         }
     }
     #endregion
@@ -24,15 +24,15 @@ namespace performance_best_practices.Controllers
     #region snippet2
     public class GoodStreamReaderController : Controller
     {
-        [HttpGet("/pokemon")]
-        public async Task<ActionResult<PokemonData>> Get()
+        [HttpGet("/contoso")]
+        public async Task<ActionResult<ContosoData>> Get()
         {
-            return await JsonSerializer.DeserializeAsync<PokemonData>(Request.Body);
+            return await JsonSerializer.DeserializeAsync<ContosoData>(Request.Body);
         }
 
     }
     #endregion
-    public class PokemonData
+    public class ContosoData
     {
     }
 }

--- a/aspnetcore/signalr/configuration.md
+++ b/aspnetcore/signalr/configuration.md
@@ -14,15 +14,16 @@ uid: signalr/configuration
 
 ASP.NET Core SignalR supports two protocols for encoding messages: [JSON](https://www.json.org/) and [MessagePack](https://msgpack.org/index.html). Each protocol has serialization configuration options.
 
-JSON serialization can be configured on the server using the [AddJsonProtocol](/dotnet/api/microsoft.extensions.dependencyinjection.jsonprotocoldependencyinjectionextensions.addjsonprotocol) extension method, which can be added after [AddSignalR](/dotnet/api/microsoft.extensions.dependencyinjection.signalrdependencyinjectionextensions.addsignalr) in your `Startup.ConfigureServices` method. The `AddJsonProtocol` method takes a delegate that receives an `options` object. The [PayloadSerializerSettings](/dotnet/api/microsoft.aspnetcore.signalr.jsonhubprotocoloptions.payloadserializersettings) property on that object is a JSON.NET `JsonSerializerSettings` object that can be used to configure serialization of arguments and return values. See the [JSON.NET Documentation](https://www.newtonsoft.com/json/help/html/Introduction.htm) for more details.
+::: moniker range=">= aspnetcore-3.0"
 
-As an example, to configure the serializer to use "PascalCase" property names, instead of the default "camelCase" names, use the following code:
+JSON serialization can be configured on the server using the [AddJsonProtocol](/dotnet/api/microsoft.extensions.dependencyinjection.jsonprotocoldependencyinjectionextensions.addjsonprotocol) extension method. `AddJsonProtocol` can be added after [AddSignalR](/dotnet/api/microsoft.extensions.dependencyinjection.signalrdependencyinjectionextensions.addsignalr) in `Startup.ConfigureServices`. The `AddJsonProtocol` method takes a delegate that receives an `options` object. The [PayloadSerializerOptions](/dotnet/api/microsoft.aspnetcore.signalr.jsonhubprotocoloptions.payloadserializeroptions) property on that object is a `System.Text.Json` <xref:System.Text.Json.JsonSerializerOptions> object that can be used to configure serialization of arguments and return values. For more information, see the [System.Text.Json documentation](/dotnet/api/system.text.json).
+
+As an example, to configure the serializer to not change the casing of property names, instead of the default "camelCase" names, use the following code in `Startup.ConfigureServices`:
 
 ```csharp
 services.AddSignalR()
     .AddJsonProtocol(options => {
-        options.PayloadSerializerSettings.ContractResolver =
-        new DefaultContractResolver();
+        options.PayloadSerializerOptions.PropertyNamingPolicy = null
     });
 ```
 
@@ -35,11 +36,47 @@ using Microsoft.Extensions.DependencyInjection;
 // When constructing your connection:
 var connection = new HubConnectionBuilder()
     .AddJsonProtocol(options => {
+        options.PayloadSerializerOptions.PropertyNamingPolicy = null;
+    })
+    .Build();
+```
+
+### Switch to Newtonsoft.Json
+
+If you need features of `Newtonsoft.Json` that aren't supported in `System.Text.Json`, See [Switch to Newtonsoft.Json](xref:migration/22-to-30#switch-to-newtonsoftjson).
+
+::: moniker-end
+
+::: moniker range="<= aspnetcore-2.2"
+
+JSON serialization can be configured on the server using the [AddJsonProtocol](/dotnet/api/microsoft.extensions.dependencyinjection.jsonprotocoldependencyinjectionextensions.addjsonprotocol) extension method, which can be added after [AddSignalR](/dotnet/api/microsoft.extensions.dependencyinjection.signalrdependencyinjectionextensions.addsignalr) in your `Startup.ConfigureServices` method. The `AddJsonProtocol` method takes a delegate that receives an `options` object. The [PayloadSerializerSettings](/dotnet/api/microsoft.aspnetcore.signalr.jsonhubprotocoloptions.payloadserializersettings) property on that object is a JSON.NET `JsonSerializerSettings` object that can be used to configure serialization of arguments and return values. For more information, see the [JSON.NET documentation](https://www.newtonsoft.com/json/help/html/Introduction.htm).
+ 
+As an example, to configure the serializer to use "PascalCase" property names, instead of the default "camelCase" names, use the following code in `Startup.ConfigureServices`:
+ 
+```csharp
+services.AddSignalR()
+    .AddJsonProtocol(options => {
+        options.PayloadSerializerSettings.ContractResolver =
+            new DefaultContractResolver();
+    });
+```
+
+In the .NET client, the same `AddJsonProtocol` extension method exists on [HubConnectionBuilder](/dotnet/api/microsoft.aspnetcore.signalr.client.hubconnectionbuilder). The `Microsoft.Extensions.DependencyInjection` namespace must be imported to resolve the extension method:
+
+```csharp
+// At the top of the file:
+using Microsoft.Extensions.DependencyInjection;
+ 
+// When constructing your connection:
+var connection = new HubConnectionBuilder()
+    .AddJsonProtocol(options => {
         options.PayloadSerializerSettings.ContractResolver =
             new DefaultContractResolver();
     })
     .Build();
 ```
+
+::: moniker-end
 
 > [!NOTE]
 > It's not possible to configure JSON serialization in the JavaScript client at this time.


### PR DESCRIPTION
* SignalR now uses System.Text.Json

Starting in 3.0, SignalR no longer defaults to using Newtonsoft.Json

https://docs.microsoft.com/en-us/aspnet/core/migration/22-to-30?view=aspnetcore-3.0&tabs=visual-studio#systemtextjson-is-the-default-protocol

* Address PR feedback

* Documentation -> documentation

* Apply suggestions from code review

Co-Authored-By: Scott Addie <10702007+scottaddie@users.noreply.github.com>

* Update configuration.md (#14958)

* Update configuration.md

* Update configuration.md



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->