### PR TITLE
Use dotnet build with publish profiles for now

### DIFF
--- a/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
+++ b/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
@@ -5,7 +5,7 @@ description: Learn how to create publish profiles in Visual Studio and use them 
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/10/2019
+ms.date: 10/12/2019
 uid: host-and-deploy/visual-studio-publish-profiles
 ---
 # Visual Studio publish profiles for ASP.NET Core app deployment
@@ -146,45 +146,21 @@ When publishing to an Azure target, the *.pubxml* file contains your Azure subsc
 
 Sensitive information (like the publish password) is encrypted on a per user/machine level. It's stored in the *Properties/PublishProfiles/{PROFILE NAME}.pubxml.user* file. Because this file can store sensitive information, it shouldn't be checked into source control.
 
-For an overview of how to publish an ASP.NET Core web app, see <xref:host-and-deploy/index>. The MSBuild tasks and targets necessary to publish an ASP.NET Core web app are open-source at the [aspnet/websdk repository](https://github.com/aspnet/websdk).
+For an overview of how to publish an ASP.NET Core web app, see <xref:host-and-deploy/index>. The MSBuild tasks and targets necessary to publish an ASP.NET Core web app are open-source in the [aspnet/websdk repository](https://github.com/aspnet/websdk).
+
+The following commands can use folder, MSDeploy, and [Kudu](https://github.com/projectkudu/kudu/wiki) publish profiles. Because MSDeploy lacks cross-platform support, the following MSDeploy options are supported only on Windows.
+
+**Folder (works cross-platform):**
 
 <!--
 
-NOTE: The following content is temporarily changed to use 'dotnet build' due to a possible issue with the Web SDK, which is under investigation on https://github.com/aspnet/websdk/issues/888. This section can be reverted back to using 'dotnet publish' when the engineering issue is resolved. Content follows ...
-
-The `dotnet publish` command can use folder, MSDeploy, and [Kudu](https://github.com/projectkudu/kudu/wiki) publish profiles. Because MSDeploy lacks cross-platform support, the following MSDeploy options are supported only on Windows.
-
-**Folder (works cross-platform):**
+NOTE: Add back the following 'dotnet publish' folder publish example after https://github.com/aspnet/websdk/issues/888 is resolved.
 
 ```dotnetcli
 dotnet publish WebApplication.csproj /p:PublishProfile=<FolderProfileName>
 ```
 
-**MSDeploy:**
-
-```dotnetcli
-dotnet publish WebApplication.csproj /p:PublishProfile=<MsDeployProfileName> /p:Password=<DeploymentPassword>
-```
-
-**MSDeploy package:**
-
-```dotnetcli
-dotnet publish WebApplication.csproj /p:PublishProfile=<MsDeployPackageProfileName>
-```
-
-In the preceding examples, don't pass `deployonbuild` to `dotnet publish`.
-
-
-
-For more information, see [Microsoft.NET.Sdk.Publish](https://github.com/aspnet/websdk#microsoftnetsdkpublish).
-
-`dotnet publish` supports Kudu APIs to publish to Azure from any platform. Visual Studio publish supports the Kudu APIs, but it's supported by WebSDK for cross-platform publish to Azure.
-
 -->
-
-The `dotnet build` command can use folder, MSDeploy, and [Kudu](https://github.com/projectkudu/kudu/wiki) publish profiles. Because MSDeploy lacks cross-platform support, the following MSDeploy options are supported only on Windows.
-
-**Folder (works cross-platform):**
 
 ```dotnetcli
 dotnet build WebApplication.csproj /p:DeployOnBuild=true /p:PublishProfile=<FolderProfileName>
@@ -193,18 +169,29 @@ dotnet build WebApplication.csproj /p:DeployOnBuild=true /p:PublishProfile=<Fold
 **MSDeploy:**
 
 ```dotnetcli
+dotnet publish WebApplication.csproj /p:PublishProfile=<MsDeployProfileName> /p:Password=<DeploymentPassword>
+```
+
+```dotnetcli
 dotnet build WebApplication.csproj /p:DeployOnBuild=true /p:PublishProfile=<MsDeployProfileName> /p:Password=<DeploymentPassword>
 ```
 
 **MSDeploy package:**
 
 ```dotnetcli
+dotnet publish WebApplication.csproj /p:PublishProfile=<MsDeployPackageProfileName>
+```
+
+```dotnetcli
 dotnet build WebApplication.csproj /p:DeployOnBuild=true /p:PublishProfile=<MsDeployPackageProfileName>
 ```
 
-In the preceding examples, don't pass `deployonbuild` to `dotnet build`.
+In the preceding examples:
 
-`dotnet build` supports Kudu APIs to publish to Azure from any platform. Visual Studio publish supports the Kudu APIs, but it's supported by WebSDK for cross-platform publish to Azure.
+* `dotnet publish` and `dotnet build` support Kudu APIs to publish to Azure from any platform. Visual Studio publish supports the Kudu APIs, but it's supported by WebSDK for cross-platform publish to Azure.
+* For `dotnet publish`, don't pass `deployonbuild` to the command.
+
+For more information, see [Microsoft.NET.Sdk.Publish](https://github.com/aspnet/websdk#microsoftnetsdkpublish).
 
 Add a publish profile to the project's *Properties/PublishProfiles* folder with the following content:
 
@@ -219,24 +206,17 @@ Add a publish profile to the project's *Properties/PublishProfiles* folder with 
 </Project>
 ```
 
-<!--
-
-NOTE: Temporarily removed until https://github.com/aspnet/websdk/issues/888 is resolved. The topic will use the 'dotnet build' approach with DeployOnBuild for now. Content follows ...
-
-Run the following command to zip up the publish contents and publish it to Azure using the Kudu APIs:
-
-```dotnetcli
-dotnet publish /p:PublishProfile=Azure /p:Configuration=Release
-```
-
--->
-
-Set the following MSBuild properties when using a publish profile:
-
-* `DeployOnBuild=true`
-* `PublishProfile={PUBLISH PROFILE}`
+## Folder publish example
 
 When publishing with a profile named *FolderProfile*, use either of the following commands:
+
+<!--
+
+NOTE: Temporarily removed until https://github.com/aspnet/websdk/issues/888 is resolved.
+
+* `dotnet publish /p:Configuration=Release /p:PublishProfile=FolderProfile`
+
+-->
 
 * `dotnet build /p:DeployOnBuild=true /p:PublishProfile=FolderProfile`
 * `msbuild /p:DeployOnBuild=true /p:PublishProfile=FolderProfile`
@@ -275,6 +255,16 @@ MSBuild file.
 In the preceding example:
 
 * The `<ExcludeApp_Data>` property is present merely to satisfy an XML schema requirement. The `<ExcludeApp_Data>` property has no effect on the publish process, even if there's an *App_Data* folder in the project root. The *App_Data* folder doesn't receive special treatment as it does in ASP.NET 4.x projects.
+
+<!--
+
+NOTE: Temporarily removed from 'Using the .NET Core CLI' below until https://github.com/aspnet/websdk/issues/888 is resolved.
+
+    ```dotnetcli
+    dotnet publish /p:Configuration=Release /p:PublishProfile=FolderProfile
+    ```
+
+-->
 
 * The `<LastUsedBuildConfiguration>` property is set to `Release`. When publishing from Visual Studio, the value of `<LastUsedBuildConfiguration>` is set using the value when the publish process is started. `<LastUsedBuildConfiguration>` is special and shouldn't be overridden in an imported MSBuild file. This property can, however, be overridden from the command line using one of the following approaches.
   * Using the .NET Core CLI:

--- a/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
+++ b/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
@@ -189,7 +189,7 @@ dotnet build WebApplication.csproj /p:DeployOnBuild=true /p:PublishProfile=<MsDe
 In the preceding examples:
 
 * `dotnet publish` and `dotnet build` support Kudu APIs to publish to Azure from any platform. Visual Studio publish supports the Kudu APIs, but it's supported by WebSDK for cross-platform publish to Azure.
-* For `dotnet publish`, don't pass `deployonbuild` to the command.
+* Don't pass `DeployOnBuild` to the `dotnet publish` command.
 
 For more information, see [Microsoft.NET.Sdk.Publish](https://github.com/aspnet/websdk#microsoftnetsdkpublish).
 

--- a/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
+++ b/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
@@ -5,7 +5,7 @@ description: Learn how to create publish profiles in Visual Studio and use them 
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 06/21/2019
+ms.date: 10/10/2019
 uid: host-and-deploy/visual-studio-publish-profiles
 ---
 # Visual Studio publish profiles for ASP.NET Core app deployment
@@ -148,6 +148,10 @@ Sensitive information (like the publish password) is encrypted on a per user/mac
 
 For an overview of how to publish an ASP.NET Core web app, see <xref:host-and-deploy/index>. The MSBuild tasks and targets necessary to publish an ASP.NET Core web app are open-source at the [aspnet/websdk repository](https://github.com/aspnet/websdk).
 
+<!--
+
+NOTE: The following content is temporarily changed to use 'dotnet build' due to a possible issue with the Web SDK, which is under investigation on https://github.com/aspnet/websdk/issues/888. This section can be reverted back to using 'dotnet publish' when the engineering issue is resolved. Content follows ...
+
 The `dotnet publish` command can use folder, MSDeploy, and [Kudu](https://github.com/projectkudu/kudu/wiki) publish profiles. Because MSDeploy lacks cross-platform support, the following MSDeploy options are supported only on Windows.
 
 **Folder (works cross-platform):**
@@ -170,9 +174,37 @@ dotnet publish WebApplication.csproj /p:PublishProfile=<MsDeployPackageProfileNa
 
 In the preceding examples, don't pass `deployonbuild` to `dotnet publish`.
 
+
+
 For more information, see [Microsoft.NET.Sdk.Publish](https://github.com/aspnet/websdk#microsoftnetsdkpublish).
 
 `dotnet publish` supports Kudu APIs to publish to Azure from any platform. Visual Studio publish supports the Kudu APIs, but it's supported by WebSDK for cross-platform publish to Azure.
+
+-->
+
+The `dotnet build` command can use folder, MSDeploy, and [Kudu](https://github.com/projectkudu/kudu/wiki) publish profiles. Because MSDeploy lacks cross-platform support, the following MSDeploy options are supported only on Windows.
+
+**Folder (works cross-platform):**
+
+```dotnetcli
+dotnet build WebApplication.csproj /p:DeployOnBuild=true /p:PublishProfile=<FolderProfileName>
+```
+
+**MSDeploy:**
+
+```dotnetcli
+dotnet build WebApplication.csproj /p:DeployOnBuild=true /p:PublishProfile=<MsDeployProfileName> /p:Password=<DeploymentPassword>
+```
+
+**MSDeploy package:**
+
+```dotnetcli
+dotnet build WebApplication.csproj /p:DeployOnBuild=true /p:PublishProfile=<MsDeployPackageProfileName>
+```
+
+In the preceding examples, don't pass `deployonbuild` to `dotnet build`.
+
+`dotnet build` supports Kudu APIs to publish to Azure from any platform. Visual Studio publish supports the Kudu APIs, but it's supported by WebSDK for cross-platform publish to Azure.
 
 Add a publish profile to the project's *Properties/PublishProfiles* folder with the following content:
 
@@ -187,21 +219,27 @@ Add a publish profile to the project's *Properties/PublishProfiles* folder with 
 </Project>
 ```
 
+<!--
+
+NOTE: Temporarily removed until https://github.com/aspnet/websdk/issues/888 is resolved. The topic will use the 'dotnet build' approach with DeployOnBuild for now. Content follows ...
+
 Run the following command to zip up the publish contents and publish it to Azure using the Kudu APIs:
 
 ```dotnetcli
 dotnet publish /p:PublishProfile=Azure /p:Configuration=Release
 ```
 
+-->
+
 Set the following MSBuild properties when using a publish profile:
 
 * `DeployOnBuild=true`
 * `PublishProfile={PUBLISH PROFILE}`
 
-When publishing with a profile named *FolderProfile*, either of the commands below can be executed:
+When publishing with a profile named *FolderProfile*, use either of the following commands:
 
 * `dotnet build /p:DeployOnBuild=true /p:PublishProfile=FolderProfile`
-* `msbuild      /p:DeployOnBuild=true /p:PublishProfile=FolderProfile`
+* `msbuild /p:DeployOnBuild=true /p:PublishProfile=FolderProfile`
 
 The .NET Core CLI's [dotnet build](/dotnet/core/tools/dotnet-build) command calls `msbuild` to run the build and publish process. The `dotnet build` and `msbuild` commands are equivalent when passing in a folder profile. When calling `msbuild` directly on Windows, the .NET Framework version of MSBuild is used. Calling `dotnet build` on a non-folder profile:
 


### PR DESCRIPTION
Fixes #14178

* Temp workaround until https://github.com/aspnet/websdk/issues/888 is investigated/resolved.
* I leave the prior text in place in a comment ... easy to revert this on the next doc update.
* I go with `dotnet build` for all four examples (but I only tested the first one):
  * Folder
  * MSDeploy
  * MSDeploy package
  * Azure Kudu

... if it's known that the problem only pertains to folder publishing, let me know, and I'll make an update here. If it's not known on the others and you'd rather not show `dotnet build` for them for now, I can run an Azure publish and see what happens. :ear:

Thanks @Aszan for the report.