### PR TITLE
Enhance Windows Service HTTPS coverage (auth note)

### DIFF
--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -5,7 +5,7 @@ description: Learn how to host an ASP.NET Core app in a Windows Service.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/07/2019
+ms.date: 10/10/2019
 uid: host-and-deploy/windows-service
 ---
 # Host ASP.NET Core in a Windows Service
@@ -296,10 +296,12 @@ Services that interact with requests from the Internet or a corporate network an
 
 By default, ASP.NET Core binds to `http://localhost:5000`. Configure the URL and port by setting the `ASPNETCORE_URLS` environment variable.
 
-For additional URL and port configuration approaches, including support for HTTPS endpoints, see the following topics:
+For additional URL and port configuration approaches, see the relevant server article:
 
-* <xref:fundamentals/servers/kestrel#endpoint-configuration> (Kestrel)
-* <xref:fundamentals/servers/httpsys#configure-windows-server> (HTTP.sys)
+* <xref:fundamentals/servers/kestrel#endpoint-configuration>
+* <xref:fundamentals/servers/httpsys#configure-windows-server>
+
+The preceding guidance covers support for HTTPS endpoints. For example, configure the app for HTTPS when authentication is used with a Windows Service.
 
 > [!NOTE]
 > Use of the ASP.NET Core HTTPS development certificate to secure a service endpoint isn't supported.


### PR DESCRIPTION
Fixes  #14239

* The ask is to note in passing that HTTPS should be configured for a Windows Service that uses auth. I think we can all this out with a change in the existing coverage for endpoint configuration.
* I'm going to remove "(Kestrel)" and "(HTTP.sys)" in passing because those are called out in the topic titles that are rendered in the topic.

cc: @CeciAc @taori