### PR TITLE
remove custom JWT stuff from the SignalR auth doc

### DIFF
--- a/aspnetcore/signalr/authn-and-authz.md
+++ b/aspnetcore/signalr/authn-and-authz.md
@@ -53,6 +53,9 @@ In standard web APIs, bearer tokens are sent in an HTTP header. However, SignalR
 
 [!code-csharp[Configure Server to accept access token from Query String](authn-and-authz/sample/Startup.cs?name=snippet)]
 
+> [!NOTE]
+> The query string is used on browser when connecting with WebSockets and Server-Sent Events due to browser API limitations. When using HTTPS, query string values are secured by the TLS connection. However, many servers log query string values. See the [Security considerations in ASP.NET Core SignalR](xref:signalr/security) article for more information. SignalR uses headers to transmit tokens in environments which support them (such as the .NET and Java Clients).
+
 ### Cookies vs. bearer tokens 
 
 Because cookies are specific to browsers, sending them from other kinds of clients adds complexity compared to sending bearer tokens. For this reason, cookie authentication isn't recommended unless the app only needs to authenticate users from the browser client. Bearer token authentication is the recommended approach when using clients other than the browser client.

--- a/aspnetcore/signalr/authn-and-authz/sample/Controllers/AccountController.cs
+++ b/aspnetcore/signalr/authn-and-authz/sample/Controllers/AccountController.cs
@@ -32,52 +32,5 @@ namespace SignalRAuthenticationSample.Controllers
             _logger.LogInformation("User logged out.");
             return RedirectToPage("/Index");
         }
-
-        [HttpPost]
-        public async Task<IActionResult> Token(string email, string password)
-        {
-            try
-            {
-                // Check the password but don't "sign in" (which would set a cookie)
-                var user = await _signInManager.UserManager.FindByEmailAsync(email);
-                if (user == null)
-                {
-                    return Json(new
-                    {
-                        error = "Login failed"
-                    });
-                }
-
-                var result = await _signInManager.CheckPasswordSignInAsync(user, password, lockoutOnFailure: false);
-                if (result.Succeeded)
-                {
-                    var principal = await _signInManager.CreateUserPrincipalAsync(user);
-                    var token = new JwtSecurityToken(
-                        "SignalRAuthenticationSample",
-                        "SignalRAuthenticationSample",
-                        principal.Claims,
-                        expires: DateTime.UtcNow.AddDays(30),
-                        signingCredentials: SigningCreds);
-                    return Json(new
-                    {
-                        token = _tokenHandler.WriteToken(token)
-                    });
-                }
-                else
-                {
-                    return Json(new
-                    {
-                        error = result.IsLockedOut ? "User is locked out" : "Login failed"
-                    });
-                }
-            }
-            catch (Exception ex)
-            {
-                return Json(new
-                {
-                    error = ex.ToString()
-                });
-            }
-        }
     }
 }

--- a/aspnetcore/signalr/authn-and-authz/sample/Pages/Index.cshtml
+++ b/aspnetcore/signalr/authn-and-authz/sample/Pages/Index.cshtml
@@ -8,16 +8,12 @@
 
 <div id="errorDiv" class="row alert alert-danger" style="display: none"></div>
 
-<form id="loginForm" action="#">
-    <h1>Login to the Chat</h1>
-    <input type="text" placeholder="email" name="email" />
-    <input type="password" placeholder="password" name="password" />
-    <button type="submit">Login</button>
-</form>
+<div class="row alert alert-warning">This sample does not include code to acquire the actual JWT token. See the "TODO" comments in 'wwwroot/js/chat.ts' for more information.</div>
+
+<!-- TODO: Add UI to allow the user to log-in, if necessary -->
 
 <div id="chatDiv" class="row" style="display: none">
     <h1>Chat</h1>
-    <button id="logoutButton">Logout</button>
 
     <div id="connectingDiv">Connecting...</div>
 

--- a/aspnetcore/signalr/authn-and-authz/sample/Startup.cs
+++ b/aspnetcore/signalr/authn-and-authz/sample/Startup.cs
@@ -49,21 +49,6 @@ namespace SignalRAuthenticationSample
                 })
                 .AddJwtBearer(options =>
                 {
-                    // Configure JWT Bearer Auth to expect our security key
-                    options.TokenValidationParameters =
-                        new TokenValidationParameters
-                        {
-                            LifetimeValidator = (before, expires, token, param) =>
-                            {
-                                return expires > DateTime.UtcNow;
-                            },
-                            ValidateAudience = false,
-                            ValidateIssuer = false,
-                            ValidateActor = false,
-                            ValidateLifetime = true,
-                            IssuerSigningKey = SecurityKey
-                        };
-
                     // We have to hook the OnMessageReceived event in order to
                     // allow the JWT authentication handler to read the access
                     // token from the query string when a WebSocket or 

--- a/aspnetcore/signalr/authn-and-authz/sample/wwwroot/js/chat.ts
+++ b/aspnetcore/signalr/authn-and-authz/sample/wwwroot/js/chat.ts
@@ -15,7 +15,6 @@ function showIf(condition: any, ifTrue: HTMLElement, ifFalse?: HTMLElement) {
     }
 }
 
-const loginForm = dom<HTMLFormElement>("loginForm");
 const chatDiv = dom<HTMLDivElement>("chatDiv");
 const errorDiv = dom<HTMLDivElement>("errorDiv");
 const logoutButton = dom<HTMLButtonElement>("logoutButton");
@@ -34,27 +33,18 @@ class ViewModel {
     public connection: signalR.HubConnection;
     public connectionStarted: boolean;
 
-    public async loginFormSubmitted(evt: Event) {
+    // TODO: Bind this method to a UI event that is triggered when the user is logging in
+    // For example, if you add UI with a username/password box and a login button, this
+    // method should be triggered when the login button is clicked.
+    public async connect(evt: Event) {
         try {
             evt.preventDefault();
 
-            // Send the username and password to the server
-            const formData = new FormData(loginForm);
-            const resp = await fetch("/account/token", { method: "POST", body: formData });
+            // TODO: Use the user input to acquire a JWT token from your authentication provider.
+            // Or, trigger an OIDC/OAuth login flow to acquire a token.
+            throw new Error("TODO: Add code to acquire the token.")
 
-            if (resp.status !== 200) {
-                this.error = `HTTP ${resp.status} error from server`;
-                return;
-            }
-
-            const json = await resp.json();
-
-            if (json["error"]) {
-                this.error = `Login error: ${json["error"]}`;
-                return;
-            } else {
-                this.loginToken = json["token"];
-            }
+            this.loginToken = "BOGUS TOKEN. Replace this with the real token.";
 
             // Update rendering while we connect
             this.render();
@@ -111,25 +101,18 @@ class ViewModel {
         messageList.appendChild(li);
     }
 
-    public async logoutButtonClicked(evt: MouseEvent) {
-        evt.preventDefault();
-
-        if (this.connection) {
-            await this.connection.stop();
-            this.connection = null;
-        }
-
-        // Just clear the token and re-render
-        this.loginToken = null;
-        this.render();
-    }
-
     // Update the state of DOM elements based on the view model
     public render() {
         errorDiv.textContent = this.error;
 
+        // Renders the errorDiv if there's an error
         showIf(this.error, errorDiv);
-        showIf(this.loginToken, chatDiv, loginForm);
+
+        // Renders the chatDiv if we're "authenticated" and now connecting.
+        showIf(this.loginToken, chatDiv);
+
+        // Renders the "connecting..." message if we're still connecting, or the
+        // full chat UI if we've connected.
         showIf(this.connectionStarted, connectedDiv, connectingDiv);
     }
 
@@ -137,8 +120,6 @@ class ViewModel {
         const model = new ViewModel();
 
         // Bind events
-        loginForm.addEventListener("submit", (e) => model.loginFormSubmitted(e));
-        logoutButton.addEventListener("click", (e) => model.logoutButtonClicked(e));
         messageForm.addEventListener("submit", (e) => model.messageFormSubmitted(e));
         directMessageForm.addEventListener("submit", (e) => model.directMessageFormSubmitted(e));
     }


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore.Docs/issues/15017

The JWT configuration in the sample is insecure. To simplify things, I've removed all the JWT issuance code entirely from the sample and replaced it with placeholders explaining where to inject your JWT acquisition/validation code and how to get the token to SignalR.

Stand by for internal review link.

cc @leastprivilege
