### PR TITLE
Add KeyVaultName for Azure Managed Identities

### DIFF
--- a/aspnetcore/security/key-vault-configuration.md
+++ b/aspnetcore/security/key-vault-configuration.md
@@ -184,6 +184,13 @@ The sample app:
 
 [!code-csharp[](key-vault-configuration/sample/Program.cs?name=snippet2&highlight=13-21)]
 
+*appsettings.json*:
+```
+{
+  "KeyVaultName": "Key Vault Name"
+}
+```
+
 When you run the app, a webpage shows the loaded secret values. In the Development environment, secret values have the `_dev` suffix because they're provided by User Secrets. In the Production environment, the values load with the `_prod` suffix because they're provided by Azure Key Vault.
 
 If you receive an `Access denied` error, confirm that the app is registered with Azure AD and provided access to the key vault. Confirm that you've restarted the service in Azure.

--- a/aspnetcore/security/key-vault-configuration.md
+++ b/aspnetcore/security/key-vault-configuration.md
@@ -188,7 +188,7 @@ Key vault name example value: `contosovault`
     
 *appsettings.json*:
 
-```
+```json
 {
   "KeyVaultName": "Key Vault Name"
 }

--- a/aspnetcore/security/key-vault-configuration.md
+++ b/aspnetcore/security/key-vault-configuration.md
@@ -5,7 +5,7 @@ description: Learn how to use the Azure Key Vault Configuration Provider to conf
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/07/2019
+ms.date: 10/14/2019
 uid: security/key-vault-configuration
 ---
 # Azure Key Vault Configuration Provider in ASP.NET Core
@@ -184,7 +184,10 @@ The sample app:
 
 [!code-csharp[](key-vault-configuration/sample/Program.cs?name=snippet2&highlight=13-21)]
 
+Key vault name example value: `contosovault`
+    
 *appsettings.json*:
+
 ```
 {
   "KeyVaultName": "Key Vault Name"


### PR DESCRIPTION
This is just a suggestion - and maybe it was just me, but when reading the section *Use Managed identities for Azure resources*, I didn't find it obvious that you still need the `KeyVaultName` setting specified. 

I thought the setting was only required if using the *Use Application ID and X.509 certificate for non-Azure-hosted apps* approach.

If the setting is not present, this leads to an error like the following during startup:

*Unhandled Exception: System.UriFormatException: Invalid URI: The hostname could not be parsed*
```
....
at Microsoft.Azure.KeyVault.KeyVaultClient.GetSecretsWithHttpMessagesAsync(String vaultBaseUrl, Nullable`1 maxresults, Dictionary`2 customHeaders, CancellationToken cancellationToken)
...
at Microsoft.AspNetCore.Hosting.WebHostBuilder.Build()
```

Feel free to delete if you don't think this will help readability.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->