### PR TITLE
Changed InvokeAsync<object> to InvokeVoidAsync

### DIFF
--- a/aspnetcore/includes/blazor-prerendering.md
+++ b/aspnetcore/includes/blazor-prerendering.md
@@ -15,7 +15,7 @@ To delay JavaScript interop calls until after the connection with the browser is
     {
         if (firstRender)
         {
-            JSRuntime.InvokeAsync<object>(
+            JSRuntime.InvokeVoidAsync(
                 "setElementValue", myInput, "Value set after render");
         }
     }


### PR DESCRIPTION
Changed `InvokeAsync<object>` to `InvokeVoidAsync` for functions that we don't need the result or don't return something.

I thought that is appropariate even if the specific function returns a value since we don't need it in the sample. This is also done to reflect the use of the code below where we explicitly specify the type that we actually want back `InvokeAsync<string>`