### PR TITLE
Integration Testing topic+sample dB replacement

### DIFF
--- a/aspnetcore/test/integration-tests.md
+++ b/aspnetcore/test/integration-tests.md
@@ -5,7 +5,7 @@ description: Learn how integration tests ensure that an app's components functio
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/07/2019
+ms.date: 10/14/2019
 uid: test/integration-tests
 ---
 # Integration tests in ASP.NET Core
@@ -162,6 +162,23 @@ Web host configuration can be created independently of the test classes by inher
    [!code-csharp[](integration-tests/samples/3.x/IntegrationTestsSample/tests/RazorPagesProject.Tests/CustomWebApplicationFactory.cs?name=snippet1)]
 
    Database seeding in the [sample app](https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/test/integration-tests/samples) is performed by the `InitializeDbForTests` method. The method is described in the [Integration tests sample: Test app organization](#test-app-organization) section.
+
+   The SUT's database context is registered in its `Startup.ConfigureServices` method. The test app's `builder.ConfigureServices` callback is executed *after* the app's `Startup.ConfigureServices` code is executed. To use a different database for the tests than the app's database, the app's database context must be replaced in `builder.ConfigureServices`.
+
+   The sample app finds the service descriptor for the database context and uses the descriptor to remove the service registration. Next, the factory adds a new `ApplicationDbContext` that uses an in-memory database for the tests.
+
+   To connect to a different database than the in-memory database, change the `UseInMemoryDatabase` call to connect the context to a different database. To use a SQL Server test database:
+
+   * Reference the [Microsoft.EntityFrameworkCore.SqlServer]https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.SqlServer/) NuGet package in the project file.
+   * Call `UseSqlServer` with a connection string to the database.
+
+   ```csharp
+   services.AddDbContext<ApplicationDbContext>((options, context) => 
+   {
+       context.UseSqlServer(
+           Configuration.GetConnectionString("TestingDbConnectionString"));
+   });
+   ```
 
 2. Use the custom `CustomWebApplicationFactory` in test classes. The following example uses the factory in the `IndexPageTests` class:
 
@@ -343,6 +360,8 @@ Integration tests usually require a small dataset in the database prior to the t
 The sample app seeds the database with three messages in *Utilities.cs* that tests can use when they execute:
 
 [!code-csharp[](integration-tests/samples/3.x/IntegrationTestsSample/tests/RazorPagesProject.Tests/Helpers/Utilities.cs?name=snippet1)]
+
+The SUT's database context is registered in its `Startup.ConfigureServices` method. The test app's `builder.ConfigureServices` callback is executed *after* the app's `Startup.ConfigureServices` code is executed. To use a different database for the tests, the app's database context must be replaced in `builder.ConfigureServices`. For more information, see the [Customize WebApplicationFactory](#customize-webapplicationfactory) section.
 
 ::: moniker-end
 

--- a/aspnetcore/test/integration-tests/samples/3.x/IntegrationTestsSample/tests/RazorPagesProject.Tests/CustomWebApplicationFactory.cs
+++ b/aspnetcore/test/integration-tests/samples/3.x/IntegrationTestsSample/tests/RazorPagesProject.Tests/CustomWebApplicationFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
@@ -16,17 +17,20 @@ namespace RazorPagesProject.Tests
         {
             builder.ConfigureServices(services =>
             {
-                // Create a new service provider.
-                var serviceProvider = new ServiceCollection()
-                    .AddEntityFrameworkInMemoryDatabase()
-                    .BuildServiceProvider();
+                // Remove the app's ApplicationDbContext registration.
+                var descriptor = services.SingleOrDefault(
+                    d => d.ServiceType == 
+                        typeof(DbContextOptions<ApplicationDbContext>));
 
-                // Add a database context (ApplicationDbContext) using an in-memory 
-                // database for testing.
+                if (descriptor != null)
+                {
+                    services.Remove(descriptor);
+                }
+
+                // Add ApplicationDbContext using an in-memory database for testing.
                 services.AddDbContext<ApplicationDbContext>((options, context) => 
                 {
-                    context.UseInMemoryDatabase("InMemoryDbForTesting")
-                        .UseInternalServiceProvider(serviceProvider);
+                    context.UseInMemoryDatabase("InMemoryDbForTesting");
                 });
 
                 // Build the service provider.


### PR DESCRIPTION
Fixes #14354

* I tested this with both an in-memory dB and SQL Server dB.
* Hoping that we can go with something simpler than the lower-level approach taken by the engineering sample (i.e., can't we just `services.AddDbContext<T>(...)` in the normal way after killing the existing service registration as I show here?).
* Interestingly, I didn't need to keep the `UseInternalServiceProvider`. I have no real confidence tho in this move outside of it ✨ *Just Works*:tm: ✨ in testing here. Do you want to ping an EF Core :cat2: to make sure that this approach is sound?