### PR TITLE
Update .ghal.rules.json for v3

### DIFF
--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -1,16 +1,40 @@
 {
-  "labels": {
-    "product": {
-      "(?i).*": "Source - Docs.ms"
-    },
-    "contentsource": {
-      "(?i).*master\/aspnetcore\/blazor.*": "Blazor",
-      "(?i).*master\/aspnetcore\/host-and-deploy\/blazor.*": "Blazor",
-      "(?i).*master\/aspnetcore\/tutorials\/*blazor*.*": "Blazor",
-      "(?i).*master\/aspnetcore\/grpc.*": "gRPC",
-      "(?i).*master\/aspnetcore\/tutorials\/grpc*.*": "gRPC",
-      "(?i).*master\/aspnetcore\/signalr.*": "SignalR",
-      "(?i).*master\/aspnetcore\/tutorials\/signalr*.*": "SignalR"
+  "version": 3,
+  "configRevision": 1,
+
+  "issue": {
+    "opened": {
+      "processor-default": {
+        "labels-add": [ ":watch: Not Triaged" ]
+      },
+      "processor-meta-docs": {
+        "default": {
+          "labels-add": "Source - Docs.ms"
+        },
+        "contentsource": {
+          "(?i).*master\/aspnetcore\/blazor.*": {
+            "labels-add": "Blazor"
+          },
+          "(?i).*master\/aspnetcore\/host-and-deploy\/blazor.*": {
+            "labels-add": "Blazor"
+          },
+          "(?i).*master\/aspnetcore\/tutorials\/*blazor*.*": {
+            "labels-add": "Blazor"
+          },
+          "(?i).*master\/aspnetcore\/grpc.*": {
+            "labels-add": "gRPC"
+          },
+          "(?i).*master\/aspnetcore\/tutorials\/grpc*.*": {
+            "labels-add": "gRPC"
+          },
+          "(?i).*master\/aspnetcore\/signalr.*": {
+            "labels-add": "SignalR"
+          },
+          "(?i).*master\/aspnetcore\/tutorials\/signalr*.*": {
+            "labels-add": "SignalR"
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
I ported the existing ruleset. I need to merge before I can deploy the tool update.

The new tool does not support the old v1 and v2 schemas anymore.