### PR TITLE
Update intro.md to use dotnet watch run for VS Code instruction

### DIFF
--- a/aspnetcore/data/ef-rp/intro.md
+++ b/aspnetcore/data/ef-rp/intro.md
@@ -501,7 +501,7 @@ Run the app.
 ```dotnetcli
 dotnet new webapp -o ContosoUniversity
 cd ContosoUniversity
-dotnet run
+dotnet watch run
 ```
 
 ---


### PR DESCRIPTION
Fixes #9488 .   (1 of 2 PR's)
[Internal Review](https://review.docs.microsoft.com/en-us/aspnet/core/data/ef-rp/intro?view=aspnetcore-1.0&branch=pr-en-us-15124&tabs=visual-studio-code)     See section *Create the ContosoUniversity Razor Pages web app*

Changed VS code steps specifying "dotnet run" to "dotnet watch run".


