### PR TITLE
Update link

### DIFF
--- a/aspnetcore/security/authentication/azure-active-directory/index.md
+++ b/aspnetcore/security/authentication/azure-active-directory/index.md
@@ -3,7 +3,7 @@ title: Azure Active Directory with ASP.NET Core
 author: rick-anderson
 description: Discover topics related to authentication with Azure Active Directory in ASP.NET Core.
 ms.author: riande
-ms.date: 10/04/2017
+ms.date: 10/16/2017
 ms.custom: "mvc, seodec18"
 uid: security/authentication/azure-active-directory/index
 ---
@@ -12,7 +12,7 @@ uid: security/authentication/azure-active-directory/index
 ## Azure AD V1 samples
 
 The following samples show how to integrate Azure AD V1, enabling users to sign-in with a work and school account:
-* [Integrating Azure AD Into an ASP.NET Core Web App](https://azure.microsoft.com/documentation/samples/active-directory-dotnet-webapp-openidconnect-aspnetcore/)
+* [Integrating Azure AD Into an ASP.NET Core Web App](https://github.com/Azure-Samples/active-directory-dotnet-webapp-openidconnect-aspnetcore)
 * [Calling a ASP.NET Core Web API From a WPF Application Using Azure AD](https://azure.microsoft.com/documentation/samples/active-directory-dotnet-native-aspnetcore/)
 * [Calling a Web API in an ASP.NET Core Web Application Using Azure AD](https://azure.microsoft.com/documentation/samples/active-directory-dotnet-webapp-webapi-openidconnect-aspnetcore/)
 

--- a/aspnetcore/security/authentication/azure-active-directory/index.md
+++ b/aspnetcore/security/authentication/azure-active-directory/index.md
@@ -13,7 +13,7 @@ uid: security/authentication/azure-active-directory/index
 
 The following samples show how to integrate Azure AD V1, enabling users to sign-in with a work and school account:
 * [Integrating Azure AD Into an ASP.NET Core Web App](https://github.com/Azure-Samples/active-directory-dotnet-webapp-openidconnect-aspnetcore)
-* [Calling a ASP.NET Core Web API From a WPF Application Using Azure AD](https://azure.microsoft.com/documentation/samples/active-directory-dotnet-native-aspnetcore/)
+* [Calling a ASP.NET Core Web API From a WPF Application Using Azure AD](https://github.com/Azure-Samples/active-directory-dotnet-native-aspnetcore)
 * [Calling a Web API in an ASP.NET Core Web Application Using Azure AD](https://azure.microsoft.com/documentation/samples/active-directory-dotnet-webapp-webapi-openidconnect-aspnetcore/)
 
 ## Azure AD V2 samples


### PR DESCRIPTION
Fixes #15139

@jmprieur The README doesn't make it clear if that's v1, but I suppose that it is because the link segment (`active-directory-dotnet-webapp-openidconnect-aspnetcore`) is the same as before. Best for you to check me on this one to see if I used the correct link here.

Thanks @CJEdgerton! :rocket: