### PR TITLE
TestServer with the Generic Host

### DIFF
--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn how to migrate an ASP.NET Core 2.2 project to ASP.NET Core 3.0.
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/15/2019
+ms.date: 10/18/2019
 uid: migration/22-to-30
 ---
 # Migrate from ASP.NET Core 2.2 to 3.0
@@ -1169,6 +1169,29 @@ var webRootFileProvider =
 ### Publish
 
 Delete the *bin* and *obj* folders in the project directory.
+
+## TestServer
+
+For apps that use <xref:Microsoft.AspNetCore.TestHost.TestServer> directly with the [Generic Host](xref:fundamentals/host/web-host), create the `TestServer` on an <xref:Microsoft.AspNetCore.Hosting.IWebHostBuilder> in <xref:Microsoft.Extensions.Hosting.GenericHostWebHostBuilderExtensions.ConfigureWebHost*>:
+
+```csharp
+[Fact]
+public async Task GenericCreateAndStartHost_GetTestServer()
+{
+    using var host = await new HostBuilder()
+        .ConfigureWebHost(webBuilder =>
+        {
+            webBuilder
+                .UseTestServer()
+                .Configure(app => { });
+        })
+    .StartAsync();
+
+    var response = await host.GetTestServer().CreateClient().GetAsync("/");
+
+    Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+}
+```
 
 <a name="break"></a>
 


### PR DESCRIPTION
Fixes #15196

Doesn't seem necessary to show the "before" aspect. Let me know if you'd like that here.

We can't API-link `UseTestServer` yet ... 3.0 API isn't available yet.