### PR TITLE
Update Customer.cs model

### DIFF
--- a/aspnetcore/razor-pages/index/sample/RazorPagesContacts/Data/Customer.cs
+++ b/aspnetcore/razor-pages/index/sample/RazorPagesContacts/Data/Customer.cs
@@ -6,7 +6,7 @@ namespace RazorPagesContacts.Data
     {
         public int Id { get; set; }
 
-        [Required, StringLength(100)]
+        [Required, StringLength(10)]
         public string Name { get; set; }
     }
 }


### PR DESCRIPTION
The example Model code in section "Write a basic form" uses a required string length of 10 for validation, however the model Data Annotation in Model code for section "Validation" uses a required length of 100 which does not matching the rest of the examples. The "Write a basic form" section model code is correct (requiring a string length of 10). However the "Validation" section is incorrect (requiring a string length of 100). Model code seems to be coming from two different locations, "Write a basic form" section using: index/3.0sample/RazorPagesContacts/Models/Customer.cs, and "Validation" section using "index/sample/RazorPagesContacts/Data/Customer.cs" Either update "Validation" model code to require string length of 10, or update the code reference to use the same one as "Write a basic form" section model code.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->