### PR TITLE
Blazor StateHasChanged/TabSet example

### DIFF
--- a/aspnetcore/blazor/common/samples/3.x/BlazorServerSample/Components/Tab.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorServerSample/Components/Tab.razor
@@ -1,5 +1,4 @@
 ﻿@using BlazorSample.UIInterfaces
-@implements IDisposable
 @implements ITab
 
 <li>
@@ -23,11 +22,6 @@
     protected override void OnInitialized()
     {
         ContainerTabSet.AddTab(this);
-    }
-
-    public void Dispose()
-    {
-        ContainerTabSet.RemoveTab(this);
     }
 
     private void Activate()

--- a/aspnetcore/blazor/common/samples/3.x/BlazorServerSample/Pages/CascadingValuesParametersTabSet.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorServerSample/Pages/CascadingValuesParametersTabSet.razor
@@ -126,7 +126,6 @@ namespace BlazorSample.UIInterfaces
 <p>The descendent <code>Tab</code> components capture the containing <code>TabSet</code> as a cascading parameter, so the <code>Tab</code> components add themselves to the <code>TabSet</code> and coordinate on which <code>Tab</code> is active.</p>
 
 <pre><code>@@using BlazorSample.UIInterfaces
-@@implements IDisposable
 @@implements ITab
 
 &lt;li&gt;
@@ -150,11 +149,6 @@ namespace BlazorSample.UIInterfaces
     protected override void OnInitialized()
     {
         ContainerTabSet.AddTab(this);
-    }
-
-    public void Dispose()
-    {
-        ContainerTabSet.RemoveTab(this);
     }
 
     private void Activate()

--- a/aspnetcore/blazor/common/samples/3.x/BlazorWebAssemblySample/Components/Tab.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorWebAssemblySample/Components/Tab.razor
@@ -1,5 +1,4 @@
 ﻿@using BlazorSample.UIInterfaces
-@implements IDisposable
 @implements ITab
 
 <li>
@@ -23,11 +22,6 @@
     protected override void OnInitialized()
     {
         ContainerTabSet.AddTab(this);
-    }
-
-    public void Dispose()
-    {
-        ContainerTabSet.RemoveTab(this);
     }
 
     private void Activate()

--- a/aspnetcore/blazor/common/samples/3.x/BlazorWebAssemblySample/Pages/CascadingValuesParametersTabSet.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorWebAssemblySample/Pages/CascadingValuesParametersTabSet.razor
@@ -126,7 +126,6 @@ namespace BlazorSample.UIInterfaces
 <p>The descendent <code>Tab</code> components capture the containing <code>TabSet</code> as a cascading parameter, so the <code>Tab</code> components add themselves to the <code>TabSet</code> and coordinate on which <code>Tab</code> is active.</p>
 
 <pre><code>@@using BlazorSample.UIInterfaces
-@@implements IDisposable
 @@implements ITab
 
 &lt;li&gt;
@@ -150,11 +149,6 @@ namespace BlazorSample.UIInterfaces
     protected override void OnInitialized()
     {
         ContainerTabSet.AddTab(this);
-    }
-
-    public void Dispose()
-    {
-        ContainerTabSet.RemoveTab(this);
     }
 
     private void Activate()

--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -955,7 +955,7 @@ If a component implements <xref:System.IDisposable>, the [Dispose method](/dotne
 ```
 
 > [!NOTE]
-> Calling `StateHasChanged` in `Dispose` isn't recommended.
+> Calling `StateHasChanged` in `Dispose` isn't supported. `StateHasChanged` might be invoked as part of the renderer being torn down. Requesting UI updates at that point isn't supported.
 
 ## Routing
 

--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -5,7 +5,7 @@ description: Learn how to create and use Razor components, including how to bind
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/05/2019
+ms.date: 10/20/2019
 uid: blazor/components
 ---
 # Create and use ASP.NET Core Razor components
@@ -953,6 +953,9 @@ If a component implements <xref:System.IDisposable>, the [Dispose method](/dotne
     }
 }
 ```
+
+> [!NOTE]
+> Calling `StateHasChanged` in `Dispose` isn't recommended.
 
 ## Routing
 


### PR DESCRIPTION
Fixes #15206

* Calling `RemoveTab` in `Dispose` doesn't seem to be required. Is this update sane, or is there another approach that it should show?
* Engineering issues that touched on `StateHasChanged` and `Dispose` weren't *grokable*:tm: in this context. Do you want to say more in the NOTE?