### PR TITLE
Use `Microsoft.NET.Sdk.Worker` project SDK on .NET Core 3.0 Windows Service sample

### DIFF
--- a/aspnetcore/host-and-deploy/windows-service/samples/3.x/AspNetCoreService/SampleApp.csproj
+++ b/aspnetcore/host-and-deploy/windows-service/samples/3.x/AspNetCoreService/SampleApp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>


### PR DESCRIPTION
Update the sample code linked to [Host ASP.NET Core in a Windows Service](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/windows-service?view=aspnetcore-3.0) to use the new `Microsoft.NET.Sdk.Worker` project SDK introduced with .NET Core 3.0