### PR TITLE
No localization for "Blazor"

### DIFF
--- a/aspnetcore/blazor/routing.md
+++ b/aspnetcore/blazor/routing.md
@@ -6,7 +6,6 @@ monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
 ms.date: 10/15/2019
-no-loc: [Blazor]
 uid: blazor/routing
 ---
 # ASP.NET Core Blazor routing

--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -54,6 +54,7 @@
       "feedback_product_url": "https://github.com/aspnet/Home/blob/master/CONTRIBUTING.md",
       "feedback_system": "GitHub",
       "ms.prod": "aspnet-core",
+      "no-loc": "[Blazor]",
       "uhfHeaderId": "MSDocsHeader-DotNet",
       "searchScope": [
         "ASP.NET Core"


### PR DESCRIPTION
Fixes #15172

This is a global scenario: "Blazor" shouldn't be localized in any repo doc (as opposed to sprinkling in the metadata prop on the individual Blazor topics).