### PR TITLE
Run Blazor without debugging

### DIFF
--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -5,7 +5,7 @@ description: Get started with Blazor by building a Blazor app with the tooling o
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/15/2019
+ms.date: 10/21/2019
 uid: blazor/get-started
 ---
 # Get started with ASP.NET Core Blazor
@@ -40,7 +40,7 @@ Get started with Blazor:
 
    5\. For a Blazor WebAssembly experience, choose the **Blazor WebAssembly App** template. For a Blazor Server experience, choose the **Blazor Server App** template. Select **Create**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>.
 
-   6\. Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> to run the app.
+   6\. Press **Ctrl**+**F5** to run the app.
 
    > [!NOTE]
    > If you installed the Blazor Visual Studio extension for a prior preview release of ASP.NET Core Blazor (Preview 6 or earlier), you can uninstall the extension. Installing the Blazor templates in a command shell is now sufficient to surface the templates in Visual Studio.

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -40,7 +40,7 @@ Get started with Blazor:
 
    5\. For a Blazor WebAssembly experience, choose the **Blazor WebAssembly App** template. For a Blazor Server experience, choose the **Blazor Server App** template. Select **Create**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>.
 
-   6\. Press **<kbd>Ctrl</kbd>+<kbd>F5</kbd>** to run the app.
+   6\. Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> to run the app.
 
    > [!NOTE]
    > If you installed the Blazor Visual Studio extension for a prior preview release of ASP.NET Core Blazor (Preview 6 or earlier), you can uninstall the extension. Installing the Blazor templates in a command shell is now sufficient to surface the templates in Visual Studio.

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -40,7 +40,7 @@ Get started with Blazor:
 
    5\. For a Blazor WebAssembly experience, choose the **Blazor WebAssembly App** template. For a Blazor Server experience, choose the **Blazor Server App** template. Select **Create**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>.
 
-   6\. Press **F5** to run the app.
+   6\. Press **<kbd>Ctrl</kbd>+<kbd>F5</kbd>** to run the app.
 
    > [!NOTE]
    > If you installed the Blazor Visual Studio extension for a prior preview release of ASP.NET Core Blazor (Preview 6 or earlier), you can uninstall the extension. Installing the Blazor templates in a command shell is now sufficient to surface the templates in Visual Studio.


### PR DESCRIPTION
F5 is problematic with Blazor WebAssembly apps. Instead let's recommend Ctrl+F5