### PR TITLE
Improve naming and Add IsIPv4MappedToIPv6 to example

### DIFF
--- a/aspnetcore/security/ip-safelist.md
+++ b/aspnetcore/security/ip-safelist.md
@@ -41,7 +41,7 @@ The middleware parses the string into an array and looks for the remote IP addre
 
 If you want a safelist only for specific controllers or action methods, use an action filter. Here's an example: 
 
-[!code-csharp[](ip-safelist/samples/2.x/ClientIpAspNetCore/Filters/ClientIdCheckFilter.cs)]
+[!code-csharp[](ip-safelist/samples/2.x/ClientIpAspNetCore/Filters/ClientIpCheckFilter.cs)]
 
 The action filter is added to the services container.
 
@@ -57,7 +57,7 @@ In the sample app, the filter is applied to the `Get` method. So when you test t
 
 If you want a safelist for a Razor Pages app, use a Razor Pages filter. Here's an example: 
 
-[!code-csharp[](ip-safelist/samples/2.x/ClientIpAspNetCore/Filters/ClientIdCheckPageFilter.cs)]
+[!code-csharp[](ip-safelist/samples/2.x/ClientIpAspNetCore/Filters/ClientIpCheckPageFilter.cs)]
 
 This filter is enabled by adding it to the MVC Filters collection.
 

--- a/aspnetcore/security/ip-safelist/samples/2.x/ClientIpAspNetCore/Controllers/ValuesController.cs
+++ b/aspnetcore/security/ip-safelist/samples/2.x/ClientIpAspNetCore/Controllers/ValuesController.cs
@@ -17,7 +17,7 @@ namespace ClientIpAspNetCore.Controllers
 
         // GET api/values
         #region snippet_Filter
-        [ServiceFilter(typeof(ClientIdCheckFilter))]
+        [ServiceFilter(typeof(ClientIpCheckFilter))]
         [HttpGet]
         public IEnumerable<string> Get()
         #endregion

--- a/aspnetcore/security/ip-safelist/samples/2.x/ClientIpAspNetCore/Filters/ClientIpCheckFilter.cs
+++ b/aspnetcore/security/ip-safelist/samples/2.x/ClientIpAspNetCore/Filters/ClientIpCheckFilter.cs
@@ -10,12 +10,12 @@ using Microsoft.Extensions.Logging;
 
 namespace ClientIpAspNetCore.Filters
 {
-    public class ClientIdCheckFilter : ActionFilterAttribute
+    public class ClientIpCheckFilter : ActionFilterAttribute
     {
         private readonly ILogger _logger;
         private readonly string _safelist;
 
-        public ClientIdCheckFilter
+        public ClientIpCheckFilter
             (ILoggerFactory loggerFactory, IConfiguration configuration)
         {
             _logger = loggerFactory.CreateLogger("ClientIdCheckFilter");

--- a/aspnetcore/security/ip-safelist/samples/2.x/ClientIpAspNetCore/Filters/ClientIpCheckFilter.cs
+++ b/aspnetcore/security/ip-safelist/samples/2.x/ClientIpAspNetCore/Filters/ClientIpCheckFilter.cs
@@ -30,12 +30,15 @@ namespace ClientIpAspNetCore.Filters
 
             string[] ip = _safelist.Split(';');
 
-            var bytes = remoteIp.GetAddressBytes();
             var badIp = true;
             foreach (var address in ip)
             {
+                if (remoteIp.IsIPv4MappedToIPv6)
+                {
+                    remoteIp = remoteIp.MapToIPv4();
+                }
                 var testIp = IPAddress.Parse(address);
-                if (testIp.GetAddressBytes().SequenceEqual(bytes))
+                if (testIp.Equals(remoteIp))
                 {
                     badIp = false;
                     break;

--- a/aspnetcore/security/ip-safelist/samples/2.x/ClientIpAspNetCore/Filters/ClientIpCheckPageFilter.cs
+++ b/aspnetcore/security/ip-safelist/samples/2.x/ClientIpAspNetCore/Filters/ClientIpCheckPageFilter.cs
@@ -28,12 +28,15 @@ namespace ClientIpAspNetCore
 
             string[] ip = _safelist.Split(';');
 
-            var bytes = remoteIp.GetAddressBytes();
             var badIp = true;
             foreach (var address in ip)
             {
+                if (remoteIp.IsIPv4MappedToIPv6)
+                {
+                    remoteIp = remoteIp.MapToIPv4();
+                }
                 var testIp = IPAddress.Parse(address);
-                if (testIp.GetAddressBytes().SequenceEqual(bytes))
+                if (testIp.Equals(remoteIp))
                 {
                     badIp = false;
                     break;

--- a/aspnetcore/security/ip-safelist/samples/2.x/ClientIpAspNetCore/Filters/ClientIpCheckPageFilter.cs
+++ b/aspnetcore/security/ip-safelist/samples/2.x/ClientIpAspNetCore/Filters/ClientIpCheckPageFilter.cs
@@ -8,12 +8,12 @@ using System.Net;
 
 namespace ClientIpAspNetCore
 {
-    public class ClientIdCheckPageFilter : IPageFilter
+    public class ClientIpCheckPageFilter : IPageFilter
     {
         private readonly ILogger _logger;
         private readonly string _safelist;
 
-        public ClientIdCheckPageFilter
+        public ClientIpCheckPageFilter
             (ILoggerFactory loggerFactory, IConfiguration configuration)
         {
             _logger = loggerFactory.CreateLogger("ClientIdCheckPageFilter");

--- a/aspnetcore/security/ip-safelist/samples/2.x/ClientIpAspNetCore/Startup.cs
+++ b/aspnetcore/security/ip-safelist/samples/2.x/ClientIpAspNetCore/Startup.cs
@@ -34,12 +34,12 @@ namespace ClientIpAspNetCore
         #region snippet_ConfigureServices
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddScoped<ClientIdCheckFilter>();
+            services.AddScoped<ClientIpCheckFilter>();
 
             services.AddMvc(options =>
             {
                 options.Filters.Add
-                    (new ClientIdCheckPageFilter
+                    (new ClientIpCheckPageFilter
                         (_loggerFactory, Configuration));
             }).SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
         }


### PR DESCRIPTION
1. Add IsIPv4MappedToIPv6 to example for better support

2. Do changes below because they are doing ip-filtering
ClientIdCheckFilter -> ClientIpCheckFilter
ClientIdCheckPageFilter  -> ClientIpCheckPageFilter 

