### PR TITLE
Remove SetBasePath from config examples

### DIFF
--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -5,7 +5,7 @@ description: Learn how to use the Configuration API to configure an ASP.NET Core
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/18/2019
+ms.date: 10/24/2019
 uid: fundamentals/configuration/index
 ---
 # Configuration in ASP.NET Core
@@ -531,13 +531,10 @@ Call `ConfigureAppConfiguration` when building the host to specify the app's con
 ```csharp
 .ConfigureAppConfiguration((hostingContext, config) =>
 {
-    config.SetBasePath(Directory.GetCurrentDirectory());
     config.AddIniFile(
         "config.ini", optional: true, reloadOnChange: true);
 })
 ```
-
-The base path is set with <xref:Microsoft.Extensions.Configuration.FileConfigurationExtensions.SetBasePath*>.
 
 A generic example of an INI configuration file:
 
@@ -596,13 +593,10 @@ Call `ConfigureAppConfiguration` when building the host to specify the app's con
 ```csharp
 .ConfigureAppConfiguration((hostingContext, config) =>
 {
-    config.SetBasePath(Directory.GetCurrentDirectory());
     config.AddJsonFile(
         "config.json", optional: true, reloadOnChange: true);
 })
 ```
-
-The base path is set with <xref:Microsoft.Extensions.Configuration.FileConfigurationExtensions.SetBasePath*>.
 
 **Example**
 
@@ -637,13 +631,10 @@ Call `ConfigureAppConfiguration` when building the host to specify the app's con
 ```csharp
 .ConfigureAppConfiguration((hostingContext, config) =>
 {
-    config.SetBasePath(Directory.GetCurrentDirectory());
     config.AddXmlFile(
         "config.xml", optional: true, reloadOnChange: true);
 })
 ```
-
-The base path is set with <xref:Microsoft.Extensions.Configuration.FileConfigurationExtensions.SetBasePath*>.
 
 XML configuration files can use distinct element names for repeating sections:
 
@@ -726,14 +717,11 @@ Call `ConfigureAppConfiguration` when building the host to specify the app's con
 ```csharp
 .ConfigureAppConfiguration((hostingContext, config) =>
 {
-    config.SetBasePath(Directory.GetCurrentDirectory());
     var path = Path.Combine(
         Directory.GetCurrentDirectory(), "path/to/files");
     config.AddKeyPerFile(directoryPath: path, optional: true);
 })
 ```
-
-The base path is set with <xref:Microsoft.Extensions.Configuration.FileConfigurationExtensions.SetBasePath*>.
 
 ## Memory Configuration Provider
 

--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -1001,13 +1001,13 @@ These keys and values are loaded in the sample app using the Memory Configuratio
 
 ::: moniker range=">= aspnetcore-3.0"
 
-[!code-csharp[](index/samples/3.x/ConfigurationSample/Program.cs?name=snippet_Program&highlight=5-12,23)]
+[!code-csharp[](index/samples/3.x/ConfigurationSample/Program.cs?name=snippet_Program&highlight=5-12,22)]
 
 ::: moniker-end
 
 ::: moniker range="< aspnetcore-3.0"
 
-[!code-csharp[](index/samples/2.x/ConfigurationSample/Program.cs?name=snippet_Program&highlight=5-12,23)]
+[!code-csharp[](index/samples/2.x/ConfigurationSample/Program.cs?name=snippet_Program&highlight=5-12,22)]
 
 ::: moniker-end
 
@@ -1185,7 +1185,7 @@ An `AddEFConfiguration` extension method permits adding the configuration source
 
 The following code shows how to use the custom `EFConfigurationProvider` in *Program.cs*:
 
-[!code-csharp[](index/samples/3.x/ConfigurationSample/Program.cs?name=snippet_Program&highlight=30-31)]
+[!code-csharp[](index/samples/3.x/ConfigurationSample/Program.cs?name=snippet_Program&highlight=29-30)]
 
 ::: moniker-end
 
@@ -1221,7 +1221,7 @@ An `AddEFConfiguration` extension method permits adding the configuration source
 
 The following code shows how to use the custom `EFConfigurationProvider` in *Program.cs*:
 
-[!code-csharp[](index/samples/2.x/ConfigurationSample/Program.cs?name=snippet_Program&highlight=30-31)]
+[!code-csharp[](index/samples/2.x/ConfigurationSample/Program.cs?name=snippet_Program&highlight=29-30)]
 
 ::: moniker-end
 

--- a/aspnetcore/fundamentals/configuration/index/samples/2.x/ConfigurationSample/Program.cs
+++ b/aspnetcore/fundamentals/configuration/index/samples/2.x/ConfigurationSample/Program.cs
@@ -30,7 +30,6 @@ namespace ConfigurationSample
             WebHost.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration((hostingContext, config) =>
                 {
-                    config.SetBasePath(Directory.GetCurrentDirectory());
                     config.AddInMemoryCollection(arrayDict);
                     config.AddJsonFile(
                         "json_array.json", optional: false, reloadOnChange: false);

--- a/aspnetcore/fundamentals/configuration/index/samples/3.x/ConfigurationSample/Program.cs
+++ b/aspnetcore/fundamentals/configuration/index/samples/3.x/ConfigurationSample/Program.cs
@@ -30,7 +30,6 @@ namespace ConfigurationSample
             Host.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration((hostingContext, config) =>
                 {
-                    config.SetBasePath(Directory.GetCurrentDirectory());
                     config.AddInMemoryCollection(arrayDict);
                     config.AddJsonFile(
                         "json_array.json", optional: false, reloadOnChange: false);


### PR DESCRIPTION
Fixes #15300

Not tested given that ...

https://github.com/aspnet/Extensions/blob/d656c4f7e22d1c0b84cab1b453c50ce73c89a071/src/Hosting/Hosting/src/HostBuilder.cs#L191

https://github.com/aspnet/AspNetCore/blob/master/src/Hosting/Hosting/src/WebHostBuilder.cs#L269

... but let me know if I should run a round of testing on these updates.

Thanks @RehanSaeed! :rocket: