### PR TITLE
Fix TypeScript target snippet in Razor UI docs

### DIFF
--- a/aspnetcore/razor-pages/ui-class.md
+++ b/aspnetcore/razor-pages/ui-class.md
@@ -3,7 +3,7 @@ title: Reusable Razor UI in class libraries with ASP.NET Core
 author: Rick-Anderson
 description: Explains how to create reusable Razor UI using partial views in a class library in ASP.NET Core.
 ms.author: riande
-ms.date: 10/24/2019
+ms.date: 10/26/2019
 ms.custom: "mvc, seodec18"
 uid: razor-pages/ui-class
 ---
@@ -112,12 +112,12 @@ To include TypeScript files in an RCL:
 
 1. Include the TypeScript target as a dependency of the `ResolveCurrentProjectStaticWebAssets` target by adding the following target inside of a `PropertyGroup` in the project file:
 
-    ```xml
-    <ResolveCurrentProjectStaticWebAssetsInputsDependsOn>
-        CompileTypeScript;
-        $(ResolveCurrentProjectStaticWebAssetsInputs)
-    </ResolveCurrentProjectStaticWebAssetsInputsDependsOn>
-    ```
+   ```xml
+   <ResolveCurrentProjectStaticWebAssetsInputsDependsOn>
+       CompileTypeScript;
+       $(ResolveCurrentProjectStaticWebAssetsInputs)
+   </ResolveCurrentProjectStaticWebAssetsInputsDependsOn>
+   ```
 
 ### Consume content from a referenced RCL
 

--- a/aspnetcore/razor-pages/ui-class.md
+++ b/aspnetcore/razor-pages/ui-class.md
@@ -112,12 +112,12 @@ To include TypeScript files in an RCL:
 
 1. Include the TypeScript target as a dependency of the `ResolveCurrentProjectStaticWebAssets` target by adding the following target inside of a `PropertyGroup` in the project file:
 
-   ```xml
-  <ResolveCurrentProjectStaticWebAssetsInputsDependsOn>
-    CompileTypeScript;
-    $(ResolveCurrentProjectStaticWebAssetsInputs)
-  </ResolveCurrentProjectStaticWebAssetsInputsDependsOn>
-   ```
+    ```xml
+    <ResolveCurrentProjectStaticWebAssetsInputsDependsOn>
+        CompileTypeScript;
+        $(ResolveCurrentProjectStaticWebAssetsInputs)
+    </ResolveCurrentProjectStaticWebAssetsInputsDependsOn>
+    ```
 
 ### Consume content from a referenced RCL
 

--- a/aspnetcore/razor-pages/ui-class.md
+++ b/aspnetcore/razor-pages/ui-class.md
@@ -114,8 +114,8 @@ To include TypeScript files in an RCL:
 
    ```xml
    <ResolveCurrentProjectStaticWebAssetsInputsDependsOn>
-       CompileTypeScript;
-       $(ResolveCurrentProjectStaticWebAssetsInputs)
+     CompileTypeScript;
+     $(ResolveCurrentProjectStaticWebAssetsInputs)
    </ResolveCurrentProjectStaticWebAssetsInputsDependsOn>
    ```
 


### PR DESCRIPTION
This fixes rendering of the configuration for TypeScript integration.

Thanks!

For context:
https://docs.microsoft.com/en-us/aspnet/core/razor-pages/ui-class?view=aspnetcore-3.0&tabs=visual-studio#feedback

![image](https://user-images.githubusercontent.com/14539/67626348-6eb2f100-f84a-11e9-83c4-7ee7f2ff86d3.png)
