### PR TITLE
Add an example for clearing default configuration sources

### DIFF
--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -5,7 +5,7 @@ description: Learn how to use the Configuration API to configure an ASP.NET Core
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/24/2019
+ms.date: 10/29/2019
 uid: fundamentals/configuration/index
 ---
 # Configuration in ASP.NET Core
@@ -71,6 +71,16 @@ The following applies to apps using the [Generic Host](xref:fundamentals/host/ge
   * [Secret Manager](xref:security/app-secrets) when the app runs in the `Development` environment using the entry assembly.
   * Environment variables using the [Environment Variables Configuration Provider](#environment-variables-configuration-provider).
   * Command-line arguments using the [Command-line Configuration Provider](#command-line-configuration-provider).
+  
+To remove the providers added by `CreateDefaultBuilder`, call `Sources.Clear()` first:
+
+```csharp
+.ConfigureAppConfiguration((hostingContext, config) =>
+{
+    config.Sources.Clear();
+    // Add providers here
+})
+```
 
 ::: moniker-end
 
@@ -91,18 +101,6 @@ The following applies to apps using the [Web Host](xref:fundamentals/host/web-ho
   * Command-line arguments using the [Command-line Configuration Provider](#command-line-configuration-provider).
 
 ::: moniker-end
-
-### Remove default providers
-
-To remove the providers added by `CreateDefaultBuilder`, call `Sources.Clear()` first:
-
-```csharp
-.ConfigureAppConfiguration((hostingContext, config) =>
-{
-    config.Sources.Clear();
-    // Add providers here
-})
-```
 
 ## Security
 

--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -75,11 +75,13 @@ The following applies to apps using the [Generic Host](xref:fundamentals/host/ge
 To remove the providers added by `CreateDefaultBuilder`, call `Sources.Clear()` first:
 
 ```csharp
-.ConfigureAppConfiguration((hostingContext, config) =>
-{
-    config.Sources.Clear();
-    // Add providers here
-})
+Host.CreateDefaultBuilder(args)
+    .ConfigureAppConfiguration((hostingContext, config) =>
+    {
+        config.Sources.Clear();
+        // Add providers here
+    })
+    ...
 ```
 
 ::: moniker-end

--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -92,6 +92,18 @@ The following applies to apps using the [Web Host](xref:fundamentals/host/web-ho
 
 ::: moniker-end
 
+### Remove default providers
+
+To remove the providers added by `CreateDefaultBuilder`, call `Sources.Clear()` first:
+
+```csharp
+.ConfigureAppConfiguration((hostingContext, config) =>
+{
+    config.Sources.Clear();
+    // Add providers here
+})
+```
+
 ## Security
 
 Adopt the following practices to secure sensitive configuration data:

--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -72,7 +72,7 @@ The following applies to apps using the [Generic Host](xref:fundamentals/host/ge
   * Environment variables using the [Environment Variables Configuration Provider](#environment-variables-configuration-provider).
   * Command-line arguments using the [Command-line Configuration Provider](#command-line-configuration-provider).
   
-To remove the providers added by `CreateDefaultBuilder`, call `Sources.Clear()` first:
+To remove the providers added by `CreateDefaultBuilder`, call [Clear](xref:System.Collections.Generic.ICollection*) on the [IConfigurationBuilder.Sources](xref:Microsoft.Extensions.Configuration.IConfigurationBuilder.Sources) first:
 
 ```csharp
 Host.CreateDefaultBuilder(args)

--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -71,18 +71,6 @@ The following applies to apps using the [Generic Host](xref:fundamentals/host/ge
   * [Secret Manager](xref:security/app-secrets) when the app runs in the `Development` environment using the entry assembly.
   * Environment variables using the [Environment Variables Configuration Provider](#environment-variables-configuration-provider).
   * Command-line arguments using the [Command-line Configuration Provider](#command-line-configuration-provider).
-  
-To remove the providers added by `CreateDefaultBuilder`, call [Clear](xref:System.Collections.Generic.ICollection*) on the [IConfigurationBuilder.Sources](xref:Microsoft.Extensions.Configuration.IConfigurationBuilder.Sources) first:
-
-```csharp
-Host.CreateDefaultBuilder(args)
-    .ConfigureAppConfiguration((hostingContext, config) =>
-    {
-        config.Sources.Clear();
-        // Add providers here
-    })
-    ...
-```
 
 ::: moniker-end
 
@@ -302,6 +290,18 @@ To provide app configuration that can be overridden with command-line arguments,
 {
     // Call other providers here
     config.AddCommandLine(args);
+})
+```
+
+### Remove providers added by CreateDefaultBuilder
+
+To remove the providers added by `CreateDefaultBuilder`, call [Clear](xref:System.Collections.Generic.ICollection*) on the [IConfigurationBuilder.Sources](xref:Microsoft.Extensions.Configuration.IConfigurationBuilder.Sources) first:
+
+```csharp
+.ConfigureAppConfiguration((hostingContext, config) =>
+{
+    config.Sources.Clear();
+    // Add providers here
 })
 ```
 


### PR DESCRIPTION
Addresses #15370

Added an example that shows how to clear the default configuration sources provided by `Host.CreateDefaultBuilder` to the _Default configuration_ section.