### PR TITLE
Fix google authentication main code fragment missing

### DIFF
--- a/aspnetcore/security/authentication/social/google-logins.md
+++ b/aspnetcore/security/authentication/social/google-logins.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: This tutorial demonstrates the integration of Google account user authentication into an existing ASP.NET Core app.
 ms.author: riande
 ms.custom: "mvc, seodec18"
-ms.date: 10/28/2019
+ms.date: 10/30/2019
 uid: security/authentication/google-logins
 ---
 # Google external login setup in ASP.NET Core
@@ -39,7 +39,7 @@ You can manage your API credentials and usage in the [API Console](https://conso
 
 Add the Google service to `Startup.ConfigureServices`:
 
-[!code-csharp[](~/security/authentication/social/social-code/3.x/StartupGoogle3x.cs?name=snippet_ConfigureServices&highlight=10-18)]
+[!code-csharp[](~/security/authentication/social/social-code/3.x/StartupGoogle3x.cs?highlight=10-19)]
 
 [!INCLUDE [default settings configuration](includes/default-settings2-2.md)]
 

--- a/aspnetcore/security/authentication/social/google-logins.md
+++ b/aspnetcore/security/authentication/social/google-logins.md
@@ -39,7 +39,7 @@ You can manage your API credentials and usage in the [API Console](https://conso
 
 Add the Google service to `Startup.ConfigureServices`:
 
-[!code-csharp[](~/security/authentication/social/social-code/3.x/StartupGoogle3x.cs?highlight=10-19)]
+[!code-csharp[](~/security/authentication/social/social-code/3.x/StartupGoogle3x.cs?highlight=11-19)]
 
 [!INCLUDE [default settings configuration](includes/default-settings2-2.md)]
 

--- a/aspnetcore/security/authentication/social/social-code/3.x/StartupGoogle3x.cs
+++ b/aspnetcore/security/authentication/social/social-code/3.x/StartupGoogle3x.cs
@@ -3,8 +3,9 @@ public void ConfigureServices(IServiceCollection services)
     services.AddDbContext<ApplicationDbContext>(options =>
         options.UseSqlServer(
             Configuration.GetConnectionString("DefaultConnection")));
-    services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = true)
-        .AddEntityFrameworkStores<ApplicationDbContext>();
+    services.AddDefaultIdentity<IdentityUser>(options =>
+        options.SignIn.RequireConfirmedAccount = true)
+            .AddEntityFrameworkStores<ApplicationDbContext>();
     services.AddRazorPages();
 
     services.AddAuthentication()
@@ -16,5 +17,4 @@ public void ConfigureServices(IServiceCollection services)
             options.ClientId = googleAuthNSection["ClientId"];
             options.ClientSecret = googleAuthNSection["ClientSecret"];
         });
-
 }


### PR DESCRIPTION
Fixes #15388

Referenced snippet was missing, given the size of the target file I've removed the reference rather than adding the snippet.

`StartupGoogle3x.cs` line 6 was a bit too long and wrapped halfway through a statement so I've dropped it down a line.