### PR TITLE
Remove link the SMS 2FA, no longer recommended

### DIFF
--- a/aspnetcore/security/authentication/individual.md
+++ b/aspnetcore/security/authentication/individual.md
@@ -55,6 +55,5 @@ If Windows Authentication is selected, the app is configured to use the [Windows
 
 The following articles show how to use the code generated in ASP.NET Core templates that use individual user accounts:
 
-* [Two-factor authentication with SMS](xref:security/authentication/2fa)
 * [Account confirmation and password recovery in ASP.NET Core](xref:security/authentication/accconfirm)
 * [Create an ASP.NET Core app with user data protected by authorization](xref:security/authorization/secure-data)


### PR DESCRIPTION
Remove link the SMS 2FA, SMS 2FA is no longer recommended

https://docs.microsoft.com/en-us/aspnet/core/security/authentication/individual?view=aspnetcore-3.0