### PR TITLE
Derive status from allocated < options.Threshold

### DIFF
--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/MemoryHealthCheck.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/MemoryHealthCheck.cs
@@ -39,9 +39,11 @@ namespace SampleApp
                 { "Gen1Collections", GC.CollectionCount(1) },
                 { "Gen2Collections", GC.CollectionCount(2) },
             };
+            var status = (allocated < options.Threshold) ? 
+                HealthStatus.Healthy : context.Registration.FailureStatus;
 
             return Task.FromResult(new HealthCheckResult(
-                context.Registration.FailureStatus,
+                status,
                 description: "Reports degraded status if allocated bytes " +
                     $">= {options.Threshold} bytes.",
                 exception: null,


### PR DESCRIPTION
Entirely possible I've missed something obvious, but when trying this sample as-is I noticed it seemed to always report the failure state (degraded) even when the memory threshold hadn't been hit.