### PR TITLE
Configuration key (case) enhancement

### DIFF
--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -1183,7 +1183,7 @@ Create a class that implements <xref:Microsoft.Extensions.Configuration.IConfigu
 
 [!code-csharp[](index/samples/3.x/ConfigurationSample/EFConfigurationProvider/EFConfigurationSource.cs?name=snippet1)]
 
-Create the custom configuration provider by inheriting from <xref:Microsoft.Extensions.Configuration.ConfigurationProvider>. The configuration provider initializes the database when it's empty.
+Create the custom configuration provider by inheriting from <xref:Microsoft.Extensions.Configuration.ConfigurationProvider>. The configuration provider initializes the database when it's empty. The dictionary used to initialize the database is created with [StringComparer.OrdinalIgnoreCase](xref:System.StringComparer.OrdinalIgnoreCase), which makes keys case insensitive to match how ordinary configuration keys are matched.
 
 *EFConfigurationProvider/EFConfigurationProvider.cs*:
 

--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -5,7 +5,7 @@ description: Learn how to use the Configuration API to configure an ASP.NET Core
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/29/2019
+ms.date: 11/04/2019
 uid: fundamentals/configuration/index
 ---
 # Configuration in ASP.NET Core

--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -1183,7 +1183,7 @@ Create a class that implements <xref:Microsoft.Extensions.Configuration.IConfigu
 
 [!code-csharp[](index/samples/3.x/ConfigurationSample/EFConfigurationProvider/EFConfigurationSource.cs?name=snippet1)]
 
-Create the custom configuration provider by inheriting from <xref:Microsoft.Extensions.Configuration.ConfigurationProvider>. The configuration provider initializes the database when it's empty. The dictionary used to initialize the database is created with [StringComparer.OrdinalIgnoreCase](xref:System.StringComparer.OrdinalIgnoreCase), which makes keys case insensitive to match how ordinary configuration keys are matched.
+Create the custom configuration provider by inheriting from <xref:Microsoft.Extensions.Configuration.ConfigurationProvider>. The configuration provider initializes the database when it's empty. Since [configuration keys are case-insensitive](#keys), the dictionary used to initialize the database is created with the case-insensitive comparer ([StringComparer.OrdinalIgnoreCase](xref:System.StringComparer.OrdinalIgnoreCase)).
 
 *EFConfigurationProvider/EFConfigurationProvider.cs*:
 

--- a/aspnetcore/fundamentals/configuration/index/samples/2.x/ConfigurationSample/EFConfigurationProvider/EFConfigurationProvider.cs
+++ b/aspnetcore/fundamentals/configuration/index/samples/2.x/ConfigurationSample/EFConfigurationProvider/EFConfigurationProvider.cs
@@ -39,7 +39,8 @@ namespace ConfigurationSample.EFConfigurationProvider
         {
             // Quotes (c)2005 Universal Pictures: Serenity
             // https://www.uphe.com/movies/serenity
-            var configValues = new Dictionary<string, string>
+            var configValues = 
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                 {
                     { "quote1", "I aim to misbehave." },
                     { "quote2", "I swallowed a bug." },

--- a/aspnetcore/fundamentals/configuration/index/samples/2.x/ConfigurationSample/Pages/Index.cshtml
+++ b/aspnetcore/fundamentals/configuration/index/samples/2.x/ConfigurationSample/Pages/Index.cshtml
@@ -143,12 +143,13 @@ TvShow = tvShow;</code></pre>
                 <h2 class="panel-title">Custom Entity Framework Configuration Provider</h2>
             </div>
             <div class="panel-body">
-                <p>This sample app demonstrates how to create a basic configuration provider, <code>EFConfigurationProviver</code>, that reads configuration key-value pairs from a database using <a href="https://docs.microsoft.com/ef/core/">Entity Framework (EF) Core</a>.</p>
+                <p>This sample app demonstrates how to create a basic configuration provider, <code>EFConfigurationProviver</code>, that reads configuration key-value pairs from a database using <a href="https://docs.microsoft.com/ef/core/">Entity Framework (EF) Core</a>. Keys are case insensitive.</p>
                 <p>The following quotes are stored in configuration using the custom provider and rendered here:</p>
                 <ul>
                     <li>Quote1: @Configuration["quote1"]</li>
                     <li>Quote2: @Configuration["quote2"]</li>
-                    <li>Quote3: @Configuration["quote3"]</li>
+                    <li>Quote3 (key: &quot;quote3&quot;): @Configuration["quote3"]</li>
+                    <li>Quote3 (key: &quot;QuOtE3&quot;): @Configuration["QuOtE3"]</li>
                 </ul>
                 <p>Quotes &copy;2005 Universal Pictures: <a href="https://www.uphe.com/movies/serenity">Serenity</a></p>
             </div>

--- a/aspnetcore/fundamentals/configuration/index/samples/3.x/ConfigurationSample/EFConfigurationProvider/EFConfigurationProvider.cs
+++ b/aspnetcore/fundamentals/configuration/index/samples/3.x/ConfigurationSample/EFConfigurationProvider/EFConfigurationProvider.cs
@@ -39,7 +39,8 @@ namespace ConfigurationSample.EFConfigurationProvider
         {
             // Quotes (c)2005 Universal Pictures: Serenity
             // https://www.uphe.com/movies/serenity
-            var configValues = new Dictionary<string, string>
+            var configValues = 
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                 {
                     { "quote1", "I aim to misbehave." },
                     { "quote2", "I swallowed a bug." },

--- a/aspnetcore/fundamentals/configuration/index/samples/3.x/ConfigurationSample/Pages/Index.cshtml
+++ b/aspnetcore/fundamentals/configuration/index/samples/3.x/ConfigurationSample/Pages/Index.cshtml
@@ -143,12 +143,13 @@ TvShow = tvShow;</code></pre>
                 <h2 class="panel-title">Custom Entity Framework Configuration Provider</h2>
             </div>
             <div class="panel-body">
-                <p>This sample app demonstrates how to create a basic configuration provider, <code>EFConfigurationProviver</code>, that reads configuration key-value pairs from a database using <a href="https://docs.microsoft.com/ef/core/">Entity Framework (EF) Core</a>.</p>
+                <p>This sample app demonstrates how to create a basic configuration provider, <code>EFConfigurationProviver</code>, that reads configuration key-value pairs from a database using <a href="https://docs.microsoft.com/ef/core/">Entity Framework (EF) Core</a>. Keys are case insensitive.</p>
                 <p>The following quotes are stored in configuration using the custom provider and rendered here:</p>
                 <ul>
                     <li>Quote1: @Configuration["quote1"]</li>
                     <li>Quote2: @Configuration["quote2"]</li>
-                    <li>Quote3: @Configuration["quote3"]</li>
+                    <li>Quote3 (key: &quot;quote3&quot;): @Configuration["quote3"]</li>
+                    <li>Quote3 (key: &quot;QuOtE3&quot;): @Configuration["QuOtE3"]</li>
                 </ul>
                 <p>Quotes &copy;2005 Universal Pictures: <a href="https://www.uphe.com/movies/serenity">Serenity</a></p>
             </div>


### PR DESCRIPTION
Fixes #15119

* Makes the `EFConfigurationProvider` example dict with case insensitive keys.
* Rolled right into the Index page display, too.

Nice one @tfabraham! :rocket::guitar::racing_car::beers: Would you like to review this before I ping engineering?