### PR TITLE
Stream was too long

### DIFF
--- a/aspnetcore/mvc/models/file-uploads.md
+++ b/aspnetcore/mvc/models/file-uploads.md
@@ -5,7 +5,7 @@ description: How to use model binding and streaming to upload files in ASP.NET C
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/31/2019
+ms.date: 11/04/2019
 uid: mvc/models/file-uploads
 ---
 # Upload files in ASP.NET Core
@@ -735,6 +735,10 @@ A connection error and a reset server connection probably indicates that the upl
 
 If the controller is accepting uploaded files using <xref:Microsoft.AspNetCore.Http.IFormFile> but the value is `null`, confirm that the HTML form is specifying an `enctype` value of `multipart/form-data`. If this attribute isn't set on the `<form>` element, the file upload doesn't occur and any bound <xref:Microsoft.AspNetCore.Http.IFormFile> arguments are `null`. Also confirm that the [upload naming in form data matches the app's naming](#match-name-attribute-value-to-parameter-name-of-post-method).
 
+### Stream was too long
+
+The examples in this topic rely upon <xref:System.IO.MemoryStream> to hold the uploaded file's content. The size limit of a `MemoryStream` is `int.MaxValue`. If the app's file upload scenario requires holding file content larger than `int.MaxValue`, use an alternative approach that doesn't rely upon a single `MemoryStream` for holding an uploaded file's content.
+
 ::: moniker-end
 
 ::: moniker range="< aspnetcore-3.0"
@@ -1452,6 +1456,10 @@ A connection error and a reset server connection probably indicates that the upl
 ### Null Reference Exception with IFormFile
 
 If the controller is accepting uploaded files using <xref:Microsoft.AspNetCore.Http.IFormFile> but the value is `null`, confirm that the HTML form is specifying an `enctype` value of `multipart/form-data`. If this attribute isn't set on the `<form>` element, the file upload doesn't occur and any bound <xref:Microsoft.AspNetCore.Http.IFormFile> arguments are `null`. Also confirm that the [upload naming in form data matches the app's naming](#match-name-attribute-value-to-parameter-name-of-post-method).
+
+### Stream was too long
+
+The examples in this topic rely upon <xref:System.IO.MemoryStream> to hold the uploaded file's content. The size limit of a `MemoryStream` is `int.MaxValue`. If the app's file upload scenario requires holding file content larger than `int.MaxValue`, use an alternative approach that doesn't rely upon a single `MemoryStream` for holding an uploaded file's content.
 
 ::: moniker-end
 

--- a/aspnetcore/mvc/models/file-uploads.md
+++ b/aspnetcore/mvc/models/file-uploads.md
@@ -737,7 +737,7 @@ If the controller is accepting uploaded files using <xref:Microsoft.AspNetCore.H
 
 ### Stream was too long
 
-The examples in this topic rely upon <xref:System.IO.MemoryStream> to hold the uploaded file's content. The size limit of a `MemoryStream` is `int.MaxValue`. If the app's file upload scenario requires holding file content larger than `int.MaxValue`, use an alternative approach that doesn't rely upon a single `MemoryStream` for holding an uploaded file's content.
+The examples in this topic rely upon <xref:System.IO.MemoryStream> to hold the uploaded file's content. The size limit of a `MemoryStream` is `int.MaxValue`. If the app's file upload scenario requires holding file content larger than 50 MB, use an alternative approach that doesn't rely upon a single `MemoryStream` for holding an uploaded file's content.
 
 ::: moniker-end
 
@@ -1459,7 +1459,7 @@ If the controller is accepting uploaded files using <xref:Microsoft.AspNetCore.H
 
 ### Stream was too long
 
-The examples in this topic rely upon <xref:System.IO.MemoryStream> to hold the uploaded file's content. The size limit of a `MemoryStream` is `int.MaxValue`. If the app's file upload scenario requires holding file content larger than `int.MaxValue`, use an alternative approach that doesn't rely upon a single `MemoryStream` for holding an uploaded file's content.
+The examples in this topic rely upon <xref:System.IO.MemoryStream> to hold the uploaded file's content. The size limit of a `MemoryStream` is `int.MaxValue`. If the app's file upload scenario requires holding file content larger than 50 MB, use an alternative approach that doesn't rely upon a single `MemoryStream` for holding an uploaded file's content.
 
 ::: moniker-end
 

--- a/aspnetcore/mvc/models/file-uploads/samples/2.x/SampleApp/Pages/Index.cshtml.cs
+++ b/aspnetcore/mvc/models/file-uploads/samples/2.x/SampleApp/Pages/Index.cshtml.cs
@@ -46,10 +46,8 @@ namespace SampleApp.Pages
                 return Page();
             }
 
-            var stream = new MemoryStream(requestFile.Content);
-
             // Don't display the untrusted file name in the UI. HTML-encode the value.
-            return File(stream, MediaTypeNames.Application.Octet, WebUtility.HtmlEncode(requestFile.UntrustedName));
+            return File(requestFile.Content, MediaTypeNames.Application.Octet, WebUtility.HtmlEncode(requestFile.UntrustedName));
         }
 
         public IActionResult OnGetDownloadPhysical(string fileName)

--- a/aspnetcore/mvc/models/file-uploads/samples/3.x/SampleApp/Pages/Index.cshtml.cs
+++ b/aspnetcore/mvc/models/file-uploads/samples/3.x/SampleApp/Pages/Index.cshtml.cs
@@ -46,10 +46,8 @@ namespace SampleApp.Pages
                 return Page();
             }
 
-            var stream = new MemoryStream(requestFile.Content);
-
             // Don't display the untrusted file name in the UI. HTML-encode the value.
-            return File(stream, MediaTypeNames.Application.Octet, WebUtility.HtmlEncode(requestFile.UntrustedName));
+            return File(requestFile.Content, MediaTypeNames.Application.Octet, WebUtility.HtmlEncode(requestFile.UntrustedName));
         }
 
         public IActionResult OnGetDownloadPhysical(string fileName)


### PR DESCRIPTION
Fixes #15337

Thanks @Legends. Given the workload, I don't recommend that we address the sample/topic directly at this time (except I spotted one that we can easily drop). Also, I note that we have chunking on the [File Uploads Tracking issue (aspnet/AspNetCore.Docs \#12285)](https://github.com/aspnet/AspNetCore.Docs/issues/12285) for future work. For now, let's call it out and see if additional community feedback comes in.

Pranav, can we do better than just saying, "use an alternative approach that doesn't rely upon a single `MemoryStream` for holding an uploaded file's content"? Can we offer more specific advice, or do you feel that merely calling this out is fine for the time being?