### PR TITLE
Update certauth.md

### DIFF
--- a/aspnetcore/security/authentication/certauth.md
+++ b/aspnetcore/security/authentication/certauth.md
@@ -182,7 +182,7 @@ In *Program.cs*, configure Kestrel as follows:
 
 ```csharp
 public static IWebHost BuildWebHost(string[] args) =>
-    WebHost.CreateDefaultBuilder(args)
+    Host.CreateDefaultBuilder(args)
         .UseStartup<Startup>()
         .ConfigureKestrel(options =>
         {


### PR DESCRIPTION
Changed sample code in method BuildWebHost(). Replaced WebHost to Host as in versions of ASP.NET Core earlier than 3.0, the Web Host is used for HTTP workloads. The Web Host is no longer recommended for web apps and remains available only for backward compatibility.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->