### PR TITLE
Azure App Service bitness enhancements

### DIFF
--- a/aspnetcore/host-and-deploy/azure-apps/index.md
+++ b/aspnetcore/host-and-deploy/azure-apps/index.md
@@ -47,7 +47,7 @@ Understand and troubleshoot warnings and errors with ASP.NET Core projects.
 
 ### Platform
 
-The platform architecture (x86/x64) of an App Services app is set in the app's settings in the Azure Portal for apps that are hosted on an A-series compute (Basic) or higher hosting tier. Confirm that the app's publish settings (for example, in the Visual Studio [publish profile (.pubxml)](host-and-deploy/visual-studio-publish-profiles)) match the setting in the app's service configuration in the Azure Portal.
+The platform architecture (x86/x64) of an App Services app is set in the app's settings in the Azure Portal for apps that are hosted on an A-series compute (Basic) or higher hosting tier. Confirm that the app's publish settings (for example, in the Visual Studio [publish profile (.pubxml)](xref:host-and-deploy/visual-studio-publish-profiles)) match the setting in the app's service configuration in the Azure Portal.
 
 ::: moniker range=">= aspnetcore-2.2"
 
@@ -209,7 +209,7 @@ When the operation completes, the latest .NET Core preview is installed. Verify 
    The command returns `True` when the x64 preview runtime is installed.
 
 > [!NOTE]
-> The platform architecture (x86/x64) of an App Services app is set in the app's settings in the Azure Portal for apps that are hosted on an A-series compute (Basic) or higher hosting tier. Confirm that the app's publish settings (for example, in the Visual Studio [publish profile (.pubxml)](host-and-deploy/visual-studio-publish-profiles)) match the setting in the app's service configuration in the Azure portal.
+> The platform architecture (x86/x64) of an App Services app is set in the app's settings in the Azure Portal for apps that are hosted on an A-series compute (Basic) or higher hosting tier. Confirm that the app's publish settings (for example, in the Visual Studio [publish profile (.pubxml)](xref:host-and-deploy/visual-studio-publish-profiles)) match the setting in the app's service configuration in the Azure portal.
 >
 > If the app is run in in-process mode and the platform architecture is configured for 64-bit (x64), the ASP.NET Core Module uses the 64-bit preview runtime, if present. Install the **ASP.NET Core {X.Y} (x64) Runtime** extension using the Azure Portal.
 >

--- a/aspnetcore/host-and-deploy/azure-apps/index.md
+++ b/aspnetcore/host-and-deploy/azure-apps/index.md
@@ -47,7 +47,7 @@ Understand and troubleshoot warnings and errors with ASP.NET Core projects.
 
 ### Platform
 
-The platform architecture (x86/x64) of an App Services app is set in the app's settings in the Azure Portal for apps that are hosted on an A-series compute (Basic) or higher hosting tier. Confirm that the app's publish settings (for example, in the Visual Studio [publish profile (.pubxml)](host-and-deploy/visual-studio-publish-profiles) match the setting in the app's service configuration in the Azure Portal.
+The platform architecture (x86/x64) of an App Services app is set in the app's settings in the Azure Portal for apps that are hosted on an A-series compute (Basic) or higher hosting tier. Confirm that the app's publish settings (for example, in the Visual Studio [publish profile (.pubxml)](host-and-deploy/visual-studio-publish-profiles)) match the setting in the app's service configuration in the Azure Portal.
 
 ::: moniker range=">= aspnetcore-2.2"
 
@@ -209,7 +209,7 @@ When the operation completes, the latest .NET Core preview is installed. Verify 
    The command returns `True` when the x64 preview runtime is installed.
 
 > [!NOTE]
-> The platform architecture (x86/x64) of an App Services app is set in the app's settings in the Azure Portal for apps that are hosted on an A-series compute (Basic) or higher hosting tier. Confirm that the app's publish settings (for example, in the Visual Studio [publish profile (.pubxml)](host-and-deploy/visual-studio-publish-profiles) match the setting in the app's service configuration in the Azure portal.
+> The platform architecture (x86/x64) of an App Services app is set in the app's settings in the Azure Portal for apps that are hosted on an A-series compute (Basic) or higher hosting tier. Confirm that the app's publish settings (for example, in the Visual Studio [publish profile (.pubxml)](host-and-deploy/visual-studio-publish-profiles)) match the setting in the app's service configuration in the Azure portal.
 >
 > If the app is run in in-process mode and the platform architecture is configured for 64-bit (x64), the ASP.NET Core Module uses the 64-bit preview runtime, if present. Install the **ASP.NET Core {X.Y} (x64) Runtime** extension using the Azure Portal.
 >

--- a/aspnetcore/host-and-deploy/azure-apps/index.md
+++ b/aspnetcore/host-and-deploy/azure-apps/index.md
@@ -5,7 +5,7 @@ description: This article contains links to Azure host and deploy resources.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 10/11/2019
+ms.date: 11/07/2019
 uid: host-and-deploy/azure-apps/index
 ---
 # Deploy ASP.NET Core apps to Azure App Service
@@ -46,6 +46,8 @@ Understand and troubleshoot warnings and errors with ASP.NET Core projects.
 ## Application configuration
 
 ### Platform
+
+The platform architecture (x86/x64) of an App Services app is set in the app's settings in the Azure Portal for apps that are hosted on an A-series compute (Basic) or higher hosting tier. Confirm that the app's publish settings (for example, in the Visual Studio [publish profile (.pubxml)](host-and-deploy/visual-studio-publish-profiles) match the setting in the app's service configuration in the Azure Portal.
 
 ::: moniker range=">= aspnetcore-2.2"
 
@@ -207,9 +209,11 @@ When the operation completes, the latest .NET Core preview is installed. Verify 
    The command returns `True` when the x64 preview runtime is installed.
 
 > [!NOTE]
-> The platform architecture (x86/x64) of an App Services app is set in the app's settings in the Azure Portal for apps that are hosted on an A-series compute or better hosting tier. If the app is run in in-process mode and the platform architecture is configured for 64-bit (x64), the ASP.NET Core Module uses the 64-bit preview runtime, if present. Install the **ASP.NET Core {X.Y} (x64) Runtime** extension.
+> The platform architecture (x86/x64) of an App Services app is set in the app's settings in the Azure Portal for apps that are hosted on an A-series compute (Basic) or higher hosting tier. Confirm that the app's publish settings (for example, in the Visual Studio [publish profile (.pubxml)](host-and-deploy/visual-studio-publish-profiles) match the setting in the app's service configuration in the Azure portal.
 >
-> After installing the x64 preview runtime, run the following command in the Kudu PowerShell command window to verify the installation. Substitute the ASP.NET Core runtime version for `{X.Y}` in the command:
+> If the app is run in in-process mode and the platform architecture is configured for 64-bit (x64), the ASP.NET Core Module uses the 64-bit preview runtime, if present. Install the **ASP.NET Core {X.Y} (x64) Runtime** extension using the Azure Portal.
+>
+> After installing the x64 preview runtime, run the following command in the Azure Kudu PowerShell command window to verify the installation. Substitute the ASP.NET Core runtime version for `{X.Y}` in the following command:
 >
 > ```powershell
 > Test-Path D:\home\SiteExtensions\AspNetCoreRuntime.{X.Y}.x64\
@@ -228,16 +232,16 @@ If an ARM template is used to create and deploy apps, the `siteextensions` resou
 
 ## Publish and deploy the app
 
-### Deploy the app framework-dependent
-
 ::: moniker range=">= aspnetcore-2.2"
 
-For a 64-bit [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd):
+For a 64-bit deployment:
 
 * Use a 64-bit .NET Core SDK to build a 64-bit app.
 * Set the **Platform** to **64 Bit** in the App Service's **Configuration** > **General settings**. The app must use a Basic or higher service plan to enable the choice of platform bitness.
 
 ::: moniker-end
+
+### Deploy the app framework-dependent
 
 # [Visual Studio](#tab/visual-studio)
 


### PR DESCRIPTION
Fixes #14000

The way this was originally written it said that the bitness setting only mattered for FDD apps. However, I think now the guidance is to set the platform bitness (in Azure) to match the app. Therefore, I made that part of this content generally apply to both FDD **_and SCD_**. Correct me if I'm mistaken on that point, and I'll revert that change back to *FDD only* for Azure's bitness setting. :ear:

On another point, The "A-series compute" level of Azure is the same as "Basic"? ... is that correct? I add "(Basic)" where mentioning when the Azure platform scenario becomes available to a dev in the portal (i.e., when the swtich is enabled so that they can select 64-bit apps). :ear:

Finally, I call out ...

> Confirm that the app's publish settings (for example, in the Visual Studio [publish profile (.pubxml)](host-and-deploy/visual-studio-publish-profiles) match the setting in the app's service configuration in the Azure portal.

... **_twice_** to try and surface it clearly. I'm suggesting it for both the:

* *Platform* section at the top.
* Actual 'how to publish' bits later.

Let me know if that's overkill. If so, which one do you want to keep? :ear: