### PR TITLE
AddTypeActivatedCheck coverage

### DIFF
--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -5,7 +5,7 @@ description: Learn how to set up health checks for ASP.NET Core infrastructure, 
 monikerRange: '>= aspnetcore-2.2'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/03/2019
+ms.date: 11/07/2019
 uid: host-and-deploy/health-checks
 ---
 # Health checks in ASP.NET Core

--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -5,7 +5,7 @@ description: Learn how to set up health checks for ASP.NET Core infrastructure, 
 monikerRange: '>= aspnetcore-2.2'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/07/2019
+ms.date: 11/13/2019
 uid: host-and-deploy/health-checks
 ---
 # Health checks in ASP.NET Core
@@ -174,8 +174,8 @@ services.AddHealthChecks()
     .AddTypeActivatedCheck<TestHealthCheckWithArgs>(
         "test", 
         failureStatus: HealthStatus.Degraded, 
-        tags: new[] { "example", }, 
-        args: new object[] { 5, "string", });
+        tags: new[] { "example" }, 
+        args: new object[] { 5, "string" });
 ```
 
 ## Use Health Checks Routing

--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -144,6 +144,40 @@ services.AddHealthChecks()
         HealthCheckResult.Healthy("Example is OK!"), tags: new[] { "example" });
 ```
 
+Call <xref:Microsoft.Extensions.DependencyInjection.HealthChecksBuilderAddCheckExtensions.AddTypeActivatedCheck*> to pass arugments to a health check implementation. In the following example, `TestHealthCheckWithArgs` accepts an integer and a string for use when <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck.CheckHealthAsync*> is called:
+
+```csharp
+private class TestHealthCheckWithArgs : IHealthCheck
+{
+    public TestHealthCheckWithArgs(int i, string s)
+    {
+        I = i;
+        S = s;
+    }
+
+    public int I { get; set; }
+
+    public string S { get; set; }
+
+    public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, 
+        CancellationToken cancellationToken = default)
+    {
+        ...
+    }
+}
+```
+
+`TestHealthCheckWithArgs` is registered by calling `AddTypeActivatedCheck` with the integer and string passed to the implementation:
+
+```csharp
+services.AddHealthChecks()
+    .AddTypeActivatedCheck<TestHealthCheckWithArgs>(
+        "test", 
+        failureStatus: HealthStatus.Degraded, 
+        tags: new[] { "example", }, 
+        args: new object[] { 5, "string", });
+```
+
 ## Use Health Checks Routing
 
 In `Startup.Configure`, call `MapHealthChecks` on the endpoint builder with the endpoint URL or relative path:


### PR DESCRIPTION
Fixes #12229

There aren't API notes on the purpose, so I *guessed* that it's to pass args (practically speaking).

Recommend in-text only at this time (not in the sample app) due to many high priority doc issues at this time. It's a candidate to roll into the sample app on a future doc+sample update.

Thanks @schummbo! :rocket: ... sorry that it took so long. We've been 🏃😅 for a while now. 