### PR TITLE
Adding no-loc metadata

### DIFF
--- a/aspnetcore/signalr/scale.md
+++ b/aspnetcore/signalr/scale.md
@@ -7,6 +7,7 @@ ms.author: bradyg
 ms.custom: mvc
 ms.date: 11/28/2018
 uid: signalr/scale
+no-loc: [SignalR]
 ---
 
 # ASP.NET Core SignalR hosting and scaling


### PR DESCRIPTION
Adding no-loc metadata to prevent the term "SignalR" from being over-localized.