### PR TITLE
Apply no-loc for "Blazor" to topics

### DIFF
--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -6,6 +6,7 @@ monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
 ms.date: 10/15/2019
+no-loc: [Blazor]
 uid: blazor/call-web-api
 ---
 # Call a web API from ASP.NET Core Blazor

--- a/aspnetcore/blazor/class-libraries.md
+++ b/aspnetcore/blazor/class-libraries.md
@@ -6,6 +6,7 @@ monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
 ms.date: 09/23/2019
+no-loc: [Blazor]
 uid: blazor/class-libraries
 ---
 # ASP.NET Core Razor components class libraries

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -6,6 +6,7 @@ monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
 ms.date: 10/15/2019
+no-loc: [Blazor]
 uid: blazor/debug
 ---
 # Debug ASP.NET Core Blazor

--- a/aspnetcore/blazor/dependency-injection.md
+++ b/aspnetcore/blazor/dependency-injection.md
@@ -6,6 +6,7 @@ monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
 ms.date: 10/15/2019
+no-loc: [Blazor]
 uid: blazor/dependency-injection
 ---
 # ASP.NET Core Blazor dependency injection

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -6,6 +6,7 @@ monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
 ms.date: 11/07/2019
+no-loc: [Blazor]
 uid: blazor/get-started
 ---
 # Get started with ASP.NET Core Blazor

--- a/aspnetcore/blazor/index.md
+++ b/aspnetcore/blazor/index.md
@@ -6,6 +6,7 @@ monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: "mvc, seoapril2019"
 ms.date: 10/31/2019
+no-loc: [Blazor]
 uid: blazor/index
 ---
 # Introduction to ASP.NET Core Blazor

--- a/aspnetcore/blazor/javascript-interop.md
+++ b/aspnetcore/blazor/javascript-interop.md
@@ -6,6 +6,7 @@ monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
 ms.date: 10/16/2019
+no-loc: [Blazor]
 uid: blazor/javascript-interop
 ---
 # ASP.NET Core Blazor JavaScript interop

--- a/aspnetcore/blazor/layouts.md
+++ b/aspnetcore/blazor/layouts.md
@@ -6,6 +6,7 @@ monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
 ms.date: 09/23/2019
+no-loc: [Blazor]
 uid: blazor/layouts
 ---
 # ASP.NET Core Blazor layouts

--- a/aspnetcore/blazor/routing.md
+++ b/aspnetcore/blazor/routing.md
@@ -6,6 +6,7 @@ monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
 ms.date: 10/15/2019
+no-loc: [Blazor]
 uid: blazor/routing
 ---
 # ASP.NET Core Blazor routing

--- a/aspnetcore/blazor/state-management.md
+++ b/aspnetcore/blazor/state-management.md
@@ -6,6 +6,7 @@ monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
 ms.date: 10/15/2019
+no-loc: [Blazor]
 uid: blazor/state-management
 ---
 # ASP.NET Core Blazor state management

--- a/aspnetcore/blazor/supported-platforms.md
+++ b/aspnetcore/blazor/supported-platforms.md
@@ -6,6 +6,7 @@ monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
 ms.date: 10/15/2019
+no-loc: [Blazor]
 uid: blazor/supported-platforms
 ---
 # ASP.NET Core Blazor supported platforms

--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -54,7 +54,6 @@
       "feedback_product_url": "https://github.com/aspnet/Home/blob/master/CONTRIBUTING.md",
       "feedback_system": "GitHub",
       "ms.prod": "aspnet-core",
-      "no-loc": "[Blazor]",
       "uhfHeaderId": "MSDocsHeader-DotNet",
       "searchScope": [
         "ASP.NET Core"

--- a/aspnetcore/host-and-deploy/blazor/configure-linker.md
+++ b/aspnetcore/host-and-deploy/blazor/configure-linker.md
@@ -6,6 +6,7 @@ monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
 ms.date: 10/15/2019
+no-loc: [Blazor]
 uid: host-and-deploy/blazor/configure-linker
 ---
 # Configure the Linker for ASP.NET Core Blazor

--- a/aspnetcore/host-and-deploy/blazor/server.md
+++ b/aspnetcore/host-and-deploy/blazor/server.md
@@ -6,6 +6,7 @@ monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
 ms.date: 10/05/2019
+no-loc: [Blazor]
 uid: host-and-deploy/blazor/server
 ---
 # Host and deploy Blazor Server

--- a/aspnetcore/host-and-deploy/blazor/webassembly.md
+++ b/aspnetcore/host-and-deploy/blazor/webassembly.md
@@ -6,6 +6,7 @@ monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
 ms.date: 10/15/2019
+no-loc: [Blazor]
 uid: host-and-deploy/blazor/webassembly
 ---
 # Host and deploy ASP.NET Core Blazor WebAssembly

--- a/aspnetcore/index.md
+++ b/aspnetcore/index.md
@@ -5,6 +5,7 @@ description: Get an introduction to ASP.NET Core, a cross-platform, high-perform
 ms.author: riande
 ms.custom: mvc
 ms.date: 11/03/2019
+no-loc: [Blazor]
 uid: index
 ---
 # Introduction to ASP.NET Core

--- a/aspnetcore/razor-pages/sdk.md
+++ b/aspnetcore/razor-pages/sdk.md
@@ -6,6 +6,7 @@ monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: "mvc, seodec18"
 ms.date: 08/23/2019
+no-loc: [Blazor]
 uid: razor-pages/sdk
 ---
 # ASP.NET Core Razor SDK

--- a/aspnetcore/release-notes/aspnetcore-3.0.md
+++ b/aspnetcore/release-notes/aspnetcore-3.0.md
@@ -5,6 +5,7 @@ description: Learn about the new features in ASP.NET Core 3.0.
 ms.author: riande
 ms.custom: mvc
 ms.date: 10/31/2019
+no-loc: [Blazor]
 uid: aspnetcore-3.0
 ---
 # What's new in ASP.NET Core 3.0

--- a/aspnetcore/security/blazor/index.md
+++ b/aspnetcore/security/blazor/index.md
@@ -6,6 +6,7 @@ monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
 ms.date: 10/15/2019
+no-loc: [Blazor]
 uid: security/blazor/index
 ---
 # ASP.NET Core Blazor authentication and authorization

--- a/aspnetcore/security/blazor/server.md
+++ b/aspnetcore/security/blazor/server.md
@@ -6,6 +6,7 @@ monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
 ms.date: 09/23/2019
+no-loc: [Blazor]
 uid: security/blazor/server
 ---
 # Secure ASP.NET Core Blazor Server apps

--- a/aspnetcore/signalr/scale.md
+++ b/aspnetcore/signalr/scale.md
@@ -6,8 +6,8 @@ monikerRange: '>= aspnetcore-2.1'
 ms.author: bradyg
 ms.custom: mvc
 ms.date: 11/28/2018
-uid: signalr/scale
 no-loc: [SignalR]
+uid: signalr/scale
 ---
 
 # ASP.NET Core SignalR hosting and scaling

--- a/aspnetcore/tutorials/build-your-first-blazor-app.md
+++ b/aspnetcore/tutorials/build-your-first-blazor-app.md
@@ -6,6 +6,7 @@ monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
 ms.date: 10/31/2019
+no-loc: [Blazor]
 uid: tutorials/first-blazor-app
 ---
 # Build your first Blazor app


### PR DESCRIPTION
Fixes #15614

* Opened a Blazor.Docs project issue to move back to global if/when supported. https://github.com/aspnet/AspNetCore.Docs/issues/15627
* Removes the entry from the *docfx.json* file.
* "Blazor" appears in a handful of ASP.NET Core topics (non-Blazor), so I add the metadata to those topics as well.
* In the SignalR topic, reposition the metadata entry to preserve **_alphabetical order_**. *ei ei ei* ... let's **_NOT_** go back to those messy days. :smile: lol
* I don't extend the "SignalR" entry out to other topics, not even in the Blazor topics. There are ... mmm 🤔 ... perhaps *40-ish topics* that would need a manual change. I'm 🏃 on a lot of priority Blazor issues this weekend; so if you want me to handle the SignalR work, let's work this PR in now and open an issue for SignalR work this week. If someone else is going to handle it, let me know who ... I'll open the issue and assign them.

  Also, let's clarify the multiple-entry scenario. Will they go like this? ...

  ```
  no-loc: ["Blazor", "SignalR"]
  ```

  ... and if that's correct, it seems like 🤔 🦆 the word "Blazor" should be in quotes on this PR (but I note that you didn't do that on the SignalR PR earlier) ...

  ```
  no-loc: ["Blazor"]
  ```

**UPDATE** Going with `no-loc: [Blazor]` (and later, `no-loc: [Blazor, SignalR]`).