### PR TITLE
Blazor Server detailed errors experience

### DIFF
--- a/aspnetcore/blazor/handle-errors.md
+++ b/aspnetcore/blazor/handle-errors.md
@@ -5,7 +5,7 @@ description: Discover how ASP.NET Core Blazor how Blazor manages unhandled excep
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/12/2019
+ms.date: 11/21/2019
 no-loc: [Blazor, SignalR]
 uid: blazor/handle-errors
 ---
@@ -17,14 +17,24 @@ This article describes how Blazor manages unhandled exceptions and how to develo
 
 ::: moniker range=">= aspnetcore-3.1"
 
-## Detailed errors during Blazor Server app development
+## Detailed errors during Blazor app development
 
-When a Blazor Server app isn't functioning properly during development, receiving detailed error information from the app assists in troubleshooting and fixing the issue. When an error occurs, Blazor Server apps display a gold bar at the bottom of the screen:
+When a Blazor app isn't functioning properly during development, receiving detailed error information from the app assists in troubleshooting and fixing the issue. When an error occurs, Blazor apps display a gold bar at the bottom of the screen:
 
 * During development, the gold bar directs you to the browser console, where you can see the exception.
 * In production, the gold bar notifies the user that an error has occurred and recommends refreshing the browser.
 
-The UI for this error handling experience is part of the Blazor Server project templates. The experience can be customized in the *_Host.cshtml* file:
+The UI for this error handling experience is part of the Blazor project templates. In a Blazor WebAssembly app, customize the experience in the *wwwroot/index.html* file:
+
+```html
+<div id="blazor-error-ui">
+    An unhandled error has occurred.
+    <a href="" class="reload">Reload</a>
+    <a class="dismiss">🗙</a>
+</div>
+```
+
+In a Blazor Server app, customize the experience in the *Pages/_Host.cshtml* file:
 
 ```cshtml
 <div id="blazor-error-ui">

--- a/aspnetcore/blazor/handle-errors.md
+++ b/aspnetcore/blazor/handle-errors.md
@@ -19,11 +19,10 @@ This article describes how Blazor manages unhandled exceptions and how to develo
 
 ## Detailed errors during Blazor Server app development
 
-When a Blazor Server app isn't functioning properly during development, receiving detailed error information from the app assists in troubleshooting and fixing the issue. When an error occurs, Blazor Server apps display a gold bar at the bottom of the screen.
+When a Blazor Server app isn't functioning properly during development, receiving detailed error information from the app assists in troubleshooting and fixing the issue. When an error occurs, Blazor Server apps display a gold bar at the bottom of the screen:
 
-During development, the gold bar directs you to the browser console, where you can see the exception.
-
-In production, the gold bar notifies the user that an error has occurred and recommends refreshing the browser.
+* During development, the gold bar directs you to the browser console, where you can see the exception.
+* In production, the gold bar notifies the user that an error has occurred and recommends refreshing the browser.
 
 The UI for this error handling experience is part of the Blazor Server project templates. The experience can be customized in the *_Host.cshtml* file:
 

--- a/aspnetcore/blazor/handle-errors.md
+++ b/aspnetcore/blazor/handle-errors.md
@@ -5,8 +5,8 @@ description: Discover how ASP.NET Core Blazor how Blazor manages unhandled excep
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/10/2019
-no-loc: [Blazor]
+ms.date: 11/12/2019
+no-loc: [Blazor, SignalR]
 uid: blazor/handle-errors
 ---
 # Handle errors in ASP.NET Core Blazor apps

--- a/aspnetcore/blazor/handle-errors.md
+++ b/aspnetcore/blazor/handle-errors.md
@@ -17,7 +17,7 @@ This article describes how Blazor manages unhandled exceptions and how to develo
 
 ::: moniker range=">= aspnetcore-3.1"
 
-## Detailed errors during Blazor app development
+## Detailed errors during development
 
 When a Blazor app isn't functioning properly during development, receiving detailed error information from the app assists in troubleshooting and fixing the issue. When an error occurs, Blazor apps display a gold bar at the bottom of the screen:
 

--- a/aspnetcore/blazor/handle-errors.md
+++ b/aspnetcore/blazor/handle-errors.md
@@ -49,6 +49,8 @@ In a Blazor Server app, customize the experience in the *Pages/_Host.cshtml* fil
 </div>
 ```
 
+The `blazor-error-ui` element is hidden by the styles included with the Blazor templates and then shown when an error occurs.
+
 ::: moniker-end
 
 ## How the Blazor framework reacts to unhandled exceptions

--- a/aspnetcore/blazor/handle-errors.md
+++ b/aspnetcore/blazor/handle-errors.md
@@ -5,7 +5,8 @@ description: Discover how ASP.NET Core Blazor how Blazor manages unhandled excep
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/31/2019
+ms.date: 11/10/2019
+no-loc: [Blazor]
 uid: blazor/handle-errors
 ---
 # Handle errors in ASP.NET Core Blazor apps
@@ -13,6 +14,33 @@ uid: blazor/handle-errors
 By [Steve Sanderson](https://github.com/SteveSandersonMS)
 
 This article describes how Blazor manages unhandled exceptions and how to develop apps that detect and handle errors.
+
+::: moniker range=">= aspnetcore-3.1"
+
+## Detailed errors during Blazor Server app development
+
+When a Blazor Server app isn't functioning properly during development, receiving detailed error information from the app assists in troubleshooting and fixing the issue. When an error occurs, Blazor Server apps display a gold bar at the bottom of the screen.
+
+During development, the gold bar directs you to the browser console, where you can see the exception.
+
+In production, the gold bar notifies the user that an error has occurred and recommends refreshing the browser.
+
+The UI for this error handling experience is part of the Blazor Server project templates. The experience can be customized in the *_Host.cshtml* file:
+
+```cshtml
+<div id="blazor-error-ui">
+    <environment include="Staging,Production">
+        An error has occurred. This application may no longer respond until reloaded.
+    </environment>
+    <environment include="Development">
+        An unhandled exception has occurred. See browser dev tools for details.
+    </environment>
+    <a href="" class="reload">Reload</a>
+    <a class="dismiss">🗙</a>
+</div>
+```
+
+::: moniker-end
 
 ## How the Blazor framework reacts to unhandled exceptions
 


### PR DESCRIPTION
Fixes  #15624

*Only* Blazor Server, correct? Even if so, I wonder if we need a sister section for Blazor WebAssembly that merely states that the dev should look at the dev tools console. We do say in the live topic ...

> During development, Blazor usually sends the full details of exceptions to the browser's console to aid in debugging. 

... down in the *Log errors with a persistent provider* section.

I'm thinking 🤔 that we should add a short section on this PR at the top near this new section calling that guidance out for Blazor WebAssembly to balance the coverage up there. We can leave that existing line in place ... it's true for both hosting models. Should I do it?