### PR TITLE
Update signalr.md

### DIFF
--- a/aspnetcore/tutorials/signalr.md
+++ b/aspnetcore/tutorials/signalr.md
@@ -244,13 +244,6 @@ The SignalR server must be configured to pass SignalR requests to SignalR.
 >   dotnet dev-certs https --trust
 >   ```
 
-## Next steps
-
-To learn more about SignalR, see the introduction:
-
-> [!div class="nextstepaction"]
-> [Introduction to ASP.NET Core SignalR](xref:signalr/introduction)
-
 ::: moniker-end
 
 ::: moniker range="< aspnetcore-3.0"
@@ -481,18 +474,4 @@ The SignalR server must be configured to pass SignalR requests to SignalR.
 ## Additional resources	
 * [Youtube version of this tutorial](https://www.youtube.com/watch?v=iKlVmu-r0JQ)	
 
-## Next steps	
-
-In this tutorial, you learned how to:	
-
-> [!div class="checklist"]	
-> * Create a web app project.	
-> * Add the SignalR client library.	
-> * Create a SignalR hub.	
-> * Configure the project to use SignalR.	
-> * Add code that uses the hub to send messages from any client to all connected clients.	
-To learn more about SignalR, see the introduction:	
-> [!div class="nextstepaction"]	
-> [Introduction to ASP.NET Core SignalR](xref:signalr/introduction)	
 ::: moniker-end
-


### PR DESCRIPTION
Fixes #15607

`In this tutorial, you learned how to:`

That used to be required but it no longer is. It's not required because no one reads that. That's why the previous version that included the long "In this tutorial, you learned how to:	" section, no one noticed the circular ref.