### PR TITLE
Apply no-loc metadata for "SignalR"

### DIFF
--- a/aspnetcore/blazor/index.md
+++ b/aspnetcore/blazor/index.md
@@ -5,8 +5,8 @@ description: Explore ASP.NET Core Blazor, a way to build interactive client-side
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: "mvc, seoapril2019"
-ms.date: 10/31/2019
-no-loc: [Blazor]
+ms.date: 11/12/2019
+no-loc: [Blazor, SignalR]
 uid: blazor/index
 ---
 # Introduction to ASP.NET Core Blazor

--- a/aspnetcore/client-side/libman/libman-cli.md
+++ b/aspnetcore/client-side/libman/libman-cli.md
@@ -4,7 +4,8 @@ author: scottaddie
 description: Learn how to use the LibMan command-line interface (CLI) in an ASP.NET Core project.
 ms.author: scaddie
 ms.custom: mvc
-ms.date: 08/30/2018
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: client-side/libman/libman-cli
 ---
 # Use the LibMan command-line interface (CLI) with ASP.NET Core

--- a/aspnetcore/client-side/using-browserlink.md
+++ b/aspnetcore/client-side/using-browserlink.md
@@ -4,7 +4,8 @@ author: ncarandini
 description: Explains how Browser Link is a Visual Studio feature that links the development environment with one or more web browsers.
 ms.author: riande
 ms.custom: H1Hack27Feb2017
-ms.date: 09/22/2017
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: client-side/using-browserlink
 ---
 # Browser Link in ASP.NET Core

--- a/aspnetcore/fundamentals/app-state.md
+++ b/aspnetcore/fundamentals/app-state.md
@@ -5,7 +5,8 @@ description: Discover approaches to preserve session and app state between reque
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 03/12/2019
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: fundamentals/app-state
 ---
 # Session and app state in ASP.NET Core

--- a/aspnetcore/fundamentals/choose-aspnet-framework.md
+++ b/aspnetcore/fundamentals/choose-aspnet-framework.md
@@ -4,7 +4,8 @@ author: rick-anderson
 description: Explains ASP.NET Core vs. ASP.NET 4.x and how to choose between them.
 ms.author: riande
 ms.custom: "mvc, seodec18"
-ms.date: 07/15/2019
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: fundamentals/choose-between-aspnet-and-aspnetcore
 ---
 # Choose between ASP.NET 4.x and ASP.NET Core

--- a/aspnetcore/fundamentals/websockets.md
+++ b/aspnetcore/fundamentals/websockets.md
@@ -5,7 +5,8 @@ description: Learn how to get started with WebSockets in ASP.NET Core.
 monikerRange: '>= aspnetcore-1.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/10/2019
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: fundamentals/websockets
 ---
 # WebSockets support in ASP.NET Core

--- a/aspnetcore/grpc/clientfactory.md
+++ b/aspnetcore/grpc/clientfactory.md
@@ -4,7 +4,8 @@ author: jamesnk
 description: Learn how to create gRPC clients using the client factory.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: jamesnk
-ms.date: 08/21/2019
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: grpc/clientfactory
 ---
 # gRPC client factory integration in .NET Core

--- a/aspnetcore/grpc/comparison.md
+++ b/aspnetcore/grpc/comparison.md
@@ -4,7 +4,8 @@ author: jamesnk
 description: Learn how gRPC compares with HTTP APIs and what it's recommend scenarios are.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: jamesnk
-ms.date: 09/25/2019
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: grpc/comparison
 ---
 # Compare gRPC services with HTTP APIs

--- a/aspnetcore/host-and-deploy/blazor/server.md
+++ b/aspnetcore/host-and-deploy/blazor/server.md
@@ -5,8 +5,8 @@ description: Learn how to host and deploy a Blazor Server app using ASP.NET Core
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/05/2019
-no-loc: [Blazor]
+ms.date: 11/12/2019
+no-loc: [Blazor, SignalR]
 uid: host-and-deploy/blazor/server
 ---
 # Host and deploy Blazor Server

--- a/aspnetcore/index.md
+++ b/aspnetcore/index.md
@@ -4,8 +4,8 @@ author: rick-anderson
 description: Get an introduction to ASP.NET Core, a cross-platform, high-performance, open-source framework for building modern, cloud-based, Internet-connected applications.
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/03/2019
-no-loc: [Blazor]
+ms.date: 11/12/2019
+no-loc: [Blazor, SignalR]
 uid: index
 ---
 # Introduction to ASP.NET Core

--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -4,7 +4,8 @@ author: rick-anderson
 description: Learn how to migrate an ASP.NET Core 2.2 project to ASP.NET Core 3.0.
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/22/2019
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: migration/22-to-30
 ---
 # Migrate from ASP.NET Core 2.2 to 3.0

--- a/aspnetcore/performance/performance-best-practices.md
+++ b/aspnetcore/performance/performance-best-practices.md
@@ -4,7 +4,8 @@ author: mjrousos
 description: Tips for increasing performance in ASP.NET Core apps and avoiding common performance problems.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
-ms.date: 09/26/2019
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: performance/performance-best-practices
 ---
 # ASP.NET Core Performance Best Practices

--- a/aspnetcore/release-notes/aspnetcore-2.1.md
+++ b/aspnetcore/release-notes/aspnetcore-2.1.md
@@ -4,7 +4,8 @@ author: isaac2004
 description: Learn about the new features in ASP.NET Core 2.1.
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/30/2019
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: aspnetcore-2.1
 ---
 # What's new in ASP.NET Core 2.1

--- a/aspnetcore/release-notes/aspnetcore-2.2.md
+++ b/aspnetcore/release-notes/aspnetcore-2.2.md
@@ -4,7 +4,8 @@ author: rick-anderson
 description: Learn about the new features in ASP.NET Core 2.2.
 ms.author: riande
 ms.custom: mvc
-ms.date: 12/18/2018
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: aspnetcore-2.2
 ---
 # What's new in ASP.NET Core 2.2

--- a/aspnetcore/release-notes/aspnetcore-3.0.md
+++ b/aspnetcore/release-notes/aspnetcore-3.0.md
@@ -4,8 +4,8 @@ author: rick-anderson
 description: Learn about the new features in ASP.NET Core 3.0.
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/31/2019
-no-loc: [Blazor]
+ms.date: 11/12/2019
+no-loc: [Blazor, SignalR]
 uid: aspnetcore-3.0
 ---
 # What's new in ASP.NET Core 3.0

--- a/aspnetcore/security/blazor/index.md
+++ b/aspnetcore/security/blazor/index.md
@@ -5,8 +5,8 @@ description: Learn about Blazor authentication and authorization scenarios.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/15/2019
-no-loc: [Blazor]
+ms.date: 11/12/2019
+no-loc: [Blazor, SignalR]
 uid: security/blazor/index
 ---
 # ASP.NET Core Blazor authentication and authorization

--- a/aspnetcore/security/blazor/server.md
+++ b/aspnetcore/security/blazor/server.md
@@ -5,8 +5,8 @@ description: Learn how to mitigate security threats to Blazor Server apps.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/23/2019
-no-loc: [Blazor]
+ms.date: 11/12/2019
+no-loc: [Blazor, SignalR]
 uid: security/blazor/server
 ---
 # Secure ASP.NET Core Blazor Server apps

--- a/aspnetcore/security/data-protection/using-data-protection.md
+++ b/aspnetcore/security/data-protection/using-data-protection.md
@@ -3,7 +3,8 @@ title: Get started with the Data Protection APIs in ASP.NET Core
 author: rick-anderson
 description: Learn how to use the ASP.NET Core data protection APIs for protecting and unprotecting data in an app.
 ms.author: riande
-ms.date: 10/14/2016
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: security/data-protection/using-data-protection
 ---
 # Get started with the Data Protection APIs in ASP.NET Core

--- a/aspnetcore/signalr/api-design.md
+++ b/aspnetcore/signalr/api-design.md
@@ -5,7 +5,8 @@ description: Learn how to design SignalR APIs for compatibility across versions 
 monikerRange: '>= aspnetcore-2.1'
 ms.author: anurse
 ms.custom: mvc
-ms.date: 11/06/2018
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: signalr/api-design
 ---
 # SignalR API design considerations

--- a/aspnetcore/signalr/authn-and-authz.md
+++ b/aspnetcore/signalr/authn-and-authz.md
@@ -5,7 +5,8 @@ description: Learn how to use authentication and authorization in ASP.NET Core S
 monikerRange: '>= aspnetcore-2.1'
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 10/17/2019
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: signalr/authn-and-authz
 ---
 

--- a/aspnetcore/signalr/background-services.md
+++ b/aspnetcore/signalr/background-services.md
@@ -5,7 +5,8 @@ description: Learn how to send messages to SignalR clients from .NET Core Backgr
 monikerRange: '>= aspnetcore-2.2'
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 02/04/2019
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: signalr/background-services
 ---
 # Host ASP.NET Core SignalR in background services

--- a/aspnetcore/signalr/client-features.md
+++ b/aspnetcore/signalr/client-features.md
@@ -4,7 +4,8 @@ author: bradygaster
 description: Learn which features are supported by the various ASP.NET Core SignalR clients.
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 09/18/2019
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: signalr/client-features
 ---
 # ASP.NET Core SignalR client features

--- a/aspnetcore/signalr/configuration.md
+++ b/aspnetcore/signalr/configuration.md
@@ -5,7 +5,8 @@ description: Learn how to configure ASP.NET Core SignalR apps.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 08/05/2019
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: signalr/configuration
 ---
 # ASP.NET Core SignalR configuration

--- a/aspnetcore/signalr/diagnostics.md
+++ b/aspnetcore/signalr/diagnostics.md
@@ -5,7 +5,8 @@ description: Learn how to gather diagnostics from your ASP.NET Core SignalR app.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: anurse
 ms.custom: signalr
-ms.date: 06/19/2019
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: signalr/diagnostics
 ---
 # Logging and diagnostics in ASP.NET Core SignalR

--- a/aspnetcore/signalr/dotnet-client.md
+++ b/aspnetcore/signalr/dotnet-client.md
@@ -5,7 +5,8 @@ description: Information about the ASP.NET Core SignalR .NET Client
 monikerRange: '>= aspnetcore-2.1'
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 09/13/2019
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: signalr/dotnet-client
 ---
 

--- a/aspnetcore/signalr/groups.md
+++ b/aspnetcore/signalr/groups.md
@@ -5,7 +5,8 @@ description: Overview of ASP.NET Core SignalR User and Group management.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 06/04/2018
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: signalr/groups
 ---
 

--- a/aspnetcore/signalr/hubcontext.md
+++ b/aspnetcore/signalr/hubcontext.md
@@ -5,7 +5,8 @@ description: Learn how to use the ASP.NET Core SignalR HubContext service for se
 monikerRange: '>= aspnetcore-2.1'
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 11/01/2018
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: signalr/hubcontext
 ---
 # Send messages from outside a hub

--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -5,7 +5,8 @@ description: Learn how to use hubs in ASP.NET Core SignalR.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 11/20/2018
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: signalr/hubs
 ---
 

--- a/aspnetcore/signalr/introduction.md
+++ b/aspnetcore/signalr/introduction.md
@@ -5,7 +5,8 @@ description: Learn how the ASP.NET Core SignalR library simplifies adding real-t
 monikerRange: '>= aspnetcore-2.1'
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 04/25/2018
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: signalr/introduction
 ---
 # Introduction to ASP.NET Core SignalR

--- a/aspnetcore/signalr/java-client.md
+++ b/aspnetcore/signalr/java-client.md
@@ -5,7 +5,8 @@ description: Learn how to use the ASP.NET Core SignalR Java client.
 monikerRange: '>= aspnetcore-2.2'
 ms.author: mimengis
 ms.custom: mvc
-ms.date: 06/27/2019
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: signalr/java-client
 ---
 # ASP.NET Core SignalR Java client

--- a/aspnetcore/signalr/javascript-client.md
+++ b/aspnetcore/signalr/javascript-client.md
@@ -5,7 +5,8 @@ description: Overview of ASP.NET Core SignalR JavaScript client.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 06/28/2019
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: signalr/javascript-client
 ---
 # ASP.NET Core SignalR JavaScript client

--- a/aspnetcore/signalr/messagepackhubprotocol.md
+++ b/aspnetcore/signalr/messagepackhubprotocol.md
@@ -5,7 +5,8 @@ description: Add MessagePack Hub Protocol to ASP.NET Core SignalR.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 10/08/2019
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: signalr/messagepackhubprotocol
 ---
 # Use MessagePack Hub Protocol in SignalR for ASP.NET Core

--- a/aspnetcore/signalr/publish-to-azure-web-app.md
+++ b/aspnetcore/signalr/publish-to-azure-web-app.md
@@ -5,7 +5,8 @@ description: Learn how to publish an ASP.NET Core SignalR app to Azure App Servi
 monikerRange: '>= aspnetcore-2.1'
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 06/26/2019
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: signalr/publish-to-azure-web-app
 ---
 # Publish an ASP.NET Core SignalR app to Azure App Service

--- a/aspnetcore/signalr/redis-backplane.md
+++ b/aspnetcore/signalr/redis-backplane.md
@@ -5,7 +5,8 @@ description: Learn how to set up a Redis backplane to enable scale-out for an AS
 monikerRange: '>= aspnetcore-2.1'
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 11/28/2018
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: signalr/redis-backplane
 ---
 

--- a/aspnetcore/signalr/security.md
+++ b/aspnetcore/signalr/security.md
@@ -5,7 +5,8 @@ description: Learn how to use authentication and authorization in ASP.NET Core S
 monikerRange: '>= aspnetcore-2.1'
 ms.author: anurse
 ms.custom: mvc
-ms.date: 11/06/2018
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: signalr/security
 ---
 # Security considerations in ASP.NET Core SignalR

--- a/aspnetcore/signalr/streaming.md
+++ b/aspnetcore/signalr/streaming.md
@@ -5,7 +5,8 @@ description: Learn how to stream data between the client and the server.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 06/05/2019
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: signalr/streaming
 ---
 # Use streaming in ASP.NET Core SignalR

--- a/aspnetcore/signalr/supported-platforms.md
+++ b/aspnetcore/signalr/supported-platforms.md
@@ -5,7 +5,8 @@ description: Learn about the supported platforms for ASP.NET Core SignalR.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 11/01/2019
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: signalr/supported-platforms
 ---
 # ASP.NET Core SignalR supported platforms

--- a/aspnetcore/signalr/version-differences.md
+++ b/aspnetcore/signalr/version-differences.md
@@ -4,7 +4,8 @@ author: bradygaster
 description: Differences between SignalR and ASP.NET Core SignalR
 monikerRange: '>= aspnetcore-2.1'
 ms.author: bradyg
-ms.date: 11/14/2018
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: signalr/version-differences
 ---
 

--- a/aspnetcore/tutorials/signalr-typescript-webpack.md
+++ b/aspnetcore/tutorials/signalr-typescript-webpack.md
@@ -4,7 +4,8 @@ author: ssougnez
 description: In this tutorial, you configure Webpack to bundle and build an ASP.NET Core SignalR web app whose client is written in TypeScript.
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 10/04/2019
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: tutorials/signalr-typescript-webpack
 ---
 # Use ASP.NET Core SignalR with TypeScript and Webpack

--- a/aspnetcore/tutorials/signalr.md
+++ b/aspnetcore/tutorials/signalr.md
@@ -4,7 +4,8 @@ author: bradygaster
 description: In this tutorial, you create a chat app that uses ASP.NET Core SignalR.
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 10/03/2019
+ms.date: 11/12/2019
+no-loc: [SignalR]
 uid: tutorials/signalr
 
 # Customer intent: As a developer, I want to get a quick proof-of-concept app running, so I can get a practical introduction to ASP.NET Core SignalR.


### PR DESCRIPTION
Fixes #15637

* Apply no-loc for "Signal" to all topics with "SignalR" in the text.
* There are about three Blazor topics open on existing PRs that need this, and I'll add this to those open PRs next separately from this.