### PR TITLE
Expand 2.2->3.0 migration guidance

### DIFF
--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -954,6 +954,14 @@ services.AddMvc(options =>
     options.SuppressAsyncSuffixInActionNames = false);
 ```
 
+#### Changes to link generation
+
+As explained in documentation on [differences from earlier versions of routing](xref:fundamentals/routing#differences-from-earlier-versions-of-routing), there are some differences in link generation (using `Url.Link` and similar APIs, for example). These include:
+
+* By default, when using endpoint routing, casing of route parameters in generated URIs is not necessarily preserved. This behavior can be controlled with the `IOutboundParameterTransformer` interface.
+* Generating a URI for an invalid route (a controller/action or page that doesn't exist) will produce an empty string under endpoint routing instead of producing an invalid URI.
+* Ambient values (route parameters from the current context) are not automatically used in link generation with endpoint routing. Previously, when generating a link to another action (or page), unspecified route values would be inferred from the *current* routes ambient values. When using endpoint routing, all route parameters must be specified explicitly during link generation.
+
 ### Razor Pages
 
 Mapping Razor Pages now takes place inside `UseEndpoints`.

--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -836,6 +836,12 @@ public void Configure(IApplicationBuilder app)
 
 Protection is implemented for some scenarios. Endpoints Middleware throws an exception if an authorization or CORS policy is skipped due to missing middleware. Analyzer support to provide additional feedback about misconfiguration is in progress.
 
+#### Custom authorization handlers
+
+If the app uses custom [authorization handlers](xref:security/authorization/policies#authorization-handlers), be aware that endpoint routing passes a different resource type to handlers than MVC. Handlers that expect the authorization handler context resource to be of type <xref:Microsoft.AspNetCore.Mvc.Filters.AuthorizationFilterContext> (the resource type [provided by MVC filters](xref:security/authorization/policies#accessing-mvc-request-context-in-handlers)) will need to be updated to handle resources of type <xref:Microsoft.AspNetCore.Routing.RouteEndpoint> (the resource type given to authorization handlers by endpoint routing).
+
+MVC still uses `AuthorizationFilterContext` resources, so if the app uses MVC authorization filters along with endpoint routing authorization, it may be necessary to handle both types of resources.
+
 ### SignalR
 
 Mapping of SignalR hubs now takes place inside `UseEndpoints`.

--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -420,7 +420,7 @@ For more information, see [Put request trailers in a separate collection (aspnet
 
 `AllowSynchronousIO` enables or disables synchronous IO APIs, such as `HttpRequest.Body.Read`, `HttpResponse.Body.Write`, and `Stream.Flush`. These APIs are a source of thread starvation leading to app crashes. In 3.0, `AllowSynchronousIO` is disabled by default. For more information, see [the Synchronous IO section in the Kestrel article](/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-3.0#synchronous-io).
 
-In addition to enabling `AllowSynchronousIO` with `ConfigureKestrel`'s options, synchronous IO can also be overridden on a per-request basis as a temporary mitigation:
+If synchronous IO is needed, it can be enabled by configuring the `AllowSynchronousIO` option on the server being used (when calling `ConfigureKestrel`, for example, if using Kestrel). Note that servers (Kestrel, HttpSys, TestServer, etc.) all have their own `AllowSynchronousIO` option which won't affect other servers. Synchronous IO can be enabled for all servers on a per-request basis using the `IHttpBodyControlFeature.AllowSynchronousIO` option:
 
 ```csharp
 var syncIOFeature = HttpContext.Features.Get<IHttpBodyControlFeature>();


### PR DESCRIPTION
I recently helped a customer migrate an ASP.NET Core 2.1 app to 3.0. Most of the breaks we ran into were documented, but a few were not. 

This PR adds some additional text around a few areas that were unclear to the customer based on current docs (changes to custom authorization handlers based on endpoint routing differences, URL.Link changes, and that AllowSynchronousIO settings must be made per-server (or per-request)).