### PR TITLE
BackgroundService enhancements

### DIFF
--- a/aspnetcore/fundamentals/host/hosted-services.md
+++ b/aspnetcore/fundamentals/host/hosted-services.md
@@ -100,7 +100,7 @@ The hosted service is activated once at app startup and gracefully shut down at 
 
 [ExecuteAsync(CancellationToken)](xref:Microsoft.Extensions.Hosting.BackgroundService.ExecuteAsync*) is called to run the background service. The implementation returns a <xref:System.Threading.Tasks.Task> that represents the entire lifetime of the background service. No further services are started until [ExecuteAsync becomes asynchronous](https://github.com/aspnet/Extensions/issues/2149), such as by calling `await`. Avoid performing long, blocking initialization work in `ExecuteAsync`. The host blocks in [StopAsync(CancellationToken)](xref:Microsoft.Extensions.Hosting.BackgroundService.StopAsync*) waiting for `ExecuteAsync` to complete.
 
-The cancellation token is triggered when [IHostedService.StopAsync](xref:Microsoft.Extensions.Hosting.IHostedService.StopAsync*) is called and `ExecuteAsync` either finishes gracefully or ungracefully at the shutdown timeout.
+The cancellation token is triggered when [IHostedService.StopAsync](xref:Microsoft.Extensions.Hosting.IHostedService.StopAsync*) is called. `ExecuteAsync` finishes promptly either gracefully or ungracefully at the shutdown timeout.
 
 ## Timed background tasks
 

--- a/aspnetcore/fundamentals/host/hosted-services.md
+++ b/aspnetcore/fundamentals/host/hosted-services.md
@@ -5,7 +5,7 @@ description: Learn how to implement background tasks with hosted services in ASP
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/18/2019
+ms.date: 11/19/2019
 uid: fundamentals/host/hosted-services
 ---
 # Background tasks with hosted services in ASP.NET Core
@@ -100,7 +100,7 @@ The hosted service is activated once at app startup and gracefully shut down at 
 
 [ExecuteAsync(CancellationToken)](xref:Microsoft.Extensions.Hosting.BackgroundService.ExecuteAsync*) is called to run the background service. The implementation returns a <xref:System.Threading.Tasks.Task> that represents the entire lifetime of the background service. No further services are started until [ExecuteAsync becomes asynchronous](https://github.com/aspnet/Extensions/issues/2149), such as by calling `await`. Avoid performing long, blocking initialization work in `ExecuteAsync`. The host blocks in [StopAsync(CancellationToken)](xref:Microsoft.Extensions.Hosting.BackgroundService.StopAsync*) waiting for `ExecuteAsync` to complete.
 
-The cancellation token is triggered when [IHostedService.StopAsync](xref:Microsoft.Extensions.Hosting.IHostedService.StopAsync*) is called and `ExecuteAsync` finishes.
+The cancellation token is triggered when [IHostedService.StopAsync](xref:Microsoft.Extensions.Hosting.IHostedService.StopAsync*) is called and `ExecuteAsync` either finishes gracefully or ungracefully at the shutdown timeout.
 
 ## Timed background tasks
 

--- a/aspnetcore/fundamentals/host/hosted-services.md
+++ b/aspnetcore/fundamentals/host/hosted-services.md
@@ -80,7 +80,7 @@ The <xref:Microsoft.Extensions.Hosting.IHostedService> interface defines two met
 
   The cancellation token has a default five second timeout to indicate that the shutdown process should no longer be graceful. When cancellation is requested on the token:
 
-  * Any remaining background operations that the app is performing in `ExceuteAsync` should be aborted.
+  * Any remaining background operations that the app is performing should be aborted.
   * Any methods called in `StopAsync` should return promptly.
 
   However, tasks aren't abandoned after cancellation is requested&mdash;the caller awaits all tasks to complete.

--- a/aspnetcore/fundamentals/host/hosted-services.md
+++ b/aspnetcore/fundamentals/host/hosted-services.md
@@ -102,7 +102,7 @@ The hosted service is activated once at app startup and gracefully shut down at 
 
 No further services are started until `StartAsync` completes. `StartAsync` is blocked from completing until either:
 
-* `await` is called in  `ExecuteAsync`. For more information, see [BackgroundService blocked the execution of whole host (aspnet/Extensions #2149)](https://github.com/aspnet/Extensions/issues/2149).
+* `await` is called in `ExecuteAsync`. For more information, see [BackgroundService blocked the execution of whole host (aspnet/Extensions #2149)](https://github.com/aspnet/Extensions/issues/2149).
 * `ExecuteAsync` completes.
 
 If `StartAsync` is overridden to run startup code for your service, you **must** call (and `await`) the base class method to ensure the service starts properly.

--- a/aspnetcore/fundamentals/host/hosted-services.md
+++ b/aspnetcore/fundamentals/host/hosted-services.md
@@ -5,7 +5,7 @@ description: Learn how to implement background tasks with hosted services in ASP
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/16/2019
+ms.date: 11/18/2019
 uid: fundamentals/host/hosted-services
 ---
 # Background tasks with hosted services in ASP.NET Core
@@ -96,18 +96,11 @@ The hosted service is activated once at app startup and gracefully shut down at 
 
 ## BackgroundService base class
 
-<xref:Microsoft.Extensions.Hosting.BackgroundService> is a base class for implementing a long running <xref:Microsoft.Extensions.Hosting.IHostedService>. `BackgroundService` provides the [ExecuteAsync(CancellationToken)](xref:Microsoft.Extensions.Hosting.BackgroundService.ExecuteAsync*) abstract method to contain the service's logic. The cancellation token is triggered when [IHostedService.StopAsync](xref:Microsoft.Extensions.Hosting.IHostedService.StopAsync*) is called.
+<xref:Microsoft.Extensions.Hosting.BackgroundService> is a base class for implementing a long running <xref:Microsoft.Extensions.Hosting.IHostedService>.
 
-[StartAsync(CancellationToken)](xref:Microsoft.Extensions.Hosting.BackgroundService.StartAsync*) is called to start the background service. The cancellation token is signalled if the startup process is interrupted. The implementation returns a `Task` that represents the startup process for the service.
+[ExecuteAsync(CancellationToken)](xref:Microsoft.Extensions.Hosting.BackgroundService.ExecuteAsync*) is called to run the background service. The implementation returns a <xref:System.Treading.Tasks.Task> that represents the entire lifetime of the background service. No further services are started until [ExecuteAsync becomes asynchronous](https://github.com/aspnet/Extensions/issues/2149), such as by calling `await`. Avoid performing long, blocking initialization work in `ExecuteAsync`. The host blocks in [StopAsync(CancellationToken)](xref:Microsoft.Extensions.Hosting.BackgroundService.StopAsync*) waiting for `ExecuteAsync` to complete.
 
-No further services are started until `StartAsync` completes. `StartAsync` is blocked from completing until either:
-
-* `await` is called in `ExecuteAsync`. For more information, see [BackgroundService blocked the execution of whole host (aspnet/Extensions #2149)](https://github.com/aspnet/Extensions/issues/2149).
-* `ExecuteAsync` completes.
-
-If `StartAsync` is overridden to run startup code for your service, you **must** call (and `await`) the base class method to ensure the service starts properly.
-
-[StopAsync(CancellationToken)](xref:Microsoft.Extensions.Hosting.BackgroundService.StopAsync*) is called when the application host is performing a graceful shutdown. The cancellation token is signalled when the host decides to forcibly terminate the service. If this method is overridden to run shutdown code for your service, you **must** call (and `await`) the base class method to ensure the service shuts down properly.
+The cancellation token is triggered when [IHostedService.StopAsync](xref:Microsoft.Extensions.Hosting.IHostedService.StopAsync*) is called and `ExecuteAsync` finishes.
 
 ## Timed background tasks
 

--- a/aspnetcore/fundamentals/host/hosted-services.md
+++ b/aspnetcore/fundamentals/host/hosted-services.md
@@ -80,7 +80,7 @@ The <xref:Microsoft.Extensions.Hosting.IHostedService> interface defines two met
 
   The cancellation token has a default five second timeout to indicate that the shutdown process should no longer be graceful. When cancellation is requested on the token:
 
-  * Any remaining background operations that the app is performing should be aborted.
+  * Any remaining background operations that the app is performing in `ExceuteAsync` should be aborted.
   * Any methods called in `StopAsync` should return promptly.
 
   However, tasks aren't abandoned after cancellation is requested&mdash;the caller awaits all tasks to complete.
@@ -100,7 +100,7 @@ The hosted service is activated once at app startup and gracefully shut down at 
 
 [ExecuteAsync(CancellationToken)](xref:Microsoft.Extensions.Hosting.BackgroundService.ExecuteAsync*) is called to run the background service. The implementation returns a <xref:System.Threading.Tasks.Task> that represents the entire lifetime of the background service. No further services are started until [ExecuteAsync becomes asynchronous](https://github.com/aspnet/Extensions/issues/2149), such as by calling `await`. Avoid performing long, blocking initialization work in `ExecuteAsync`. The host blocks in [StopAsync(CancellationToken)](xref:Microsoft.Extensions.Hosting.BackgroundService.StopAsync*) waiting for `ExecuteAsync` to complete.
 
-The cancellation token is triggered when [IHostedService.StopAsync](xref:Microsoft.Extensions.Hosting.IHostedService.StopAsync*) is called. `ExecuteAsync` finishes promptly either gracefully or ungracefully at the shutdown timeout.
+The cancellation token is triggered when [IHostedService.StopAsync](xref:Microsoft.Extensions.Hosting.IHostedService.StopAsync*) is called. Your implementation of `ExecuteAsync` should finish promptly when the cancellation token is fired in order to gracefully shut down the service. Otherwise, the service ungracefully shuts down at the shutdown timeout. For more information, see the [IHostedService interface](#ihostedservice-interface) section.
 
 ## Timed background tasks
 

--- a/aspnetcore/fundamentals/host/hosted-services.md
+++ b/aspnetcore/fundamentals/host/hosted-services.md
@@ -98,7 +98,7 @@ The hosted service is activated once at app startup and gracefully shut down at 
 
 <xref:Microsoft.Extensions.Hosting.BackgroundService> is a base class for implementing a long running <xref:Microsoft.Extensions.Hosting.IHostedService>.
 
-[ExecuteAsync(CancellationToken)](xref:Microsoft.Extensions.Hosting.BackgroundService.ExecuteAsync*) is called to run the background service. The implementation returns a <xref:System.Treading.Tasks.Task> that represents the entire lifetime of the background service. No further services are started until [ExecuteAsync becomes asynchronous](https://github.com/aspnet/Extensions/issues/2149), such as by calling `await`. Avoid performing long, blocking initialization work in `ExecuteAsync`. The host blocks in [StopAsync(CancellationToken)](xref:Microsoft.Extensions.Hosting.BackgroundService.StopAsync*) waiting for `ExecuteAsync` to complete.
+[ExecuteAsync(CancellationToken)](xref:Microsoft.Extensions.Hosting.BackgroundService.ExecuteAsync*) is called to run the background service. The implementation returns a <xref:System.Threading.Tasks.Task> that represents the entire lifetime of the background service. No further services are started until [ExecuteAsync becomes asynchronous](https://github.com/aspnet/Extensions/issues/2149), such as by calling `await`. Avoid performing long, blocking initialization work in `ExecuteAsync`. The host blocks in [StopAsync(CancellationToken)](xref:Microsoft.Extensions.Hosting.BackgroundService.StopAsync*) waiting for `ExecuteAsync` to complete.
 
 The cancellation token is triggered when [IHostedService.StopAsync](xref:Microsoft.Extensions.Hosting.IHostedService.StopAsync*) is called and `ExecuteAsync` finishes.
 


### PR DESCRIPTION
Fixes #15701

Set of updates seeking to:

* Generally improve layout and coverage (e.g., bullets to paragraphs, xref API cross-links).
* Surface that either `ExecuteAsync` must complete or yield for `StartupAsync` to complete. Trying to minimally capture the main point in [BackgroundService blocked the execution of whole host (aspnet/Extensions #2149)](https://github.com/aspnet/Extensions/issues/2149) and cross-link the engineering issue for the reader's further understanding.

❓ ... do you want it to specifically call out `await Task.Yield()` for the top of `ExecuteAsync` for scenarios where `StartupAsync` will be blocking? ... or should we let the cross-linked engineering issue capture that concept for the reader if they need to dig deeper? ... or even just wait until the engineering issue is addressed further for a future release?

❓ If we do call out `await Task.Yield()`, what do you want to say about 'an additional state machine is created (one per service)'? For example, do you want to surface any negative side effects?

**EDIT** ... and another ❓ ... do you want us to react to #14156 here as well, or save that for another day? 🏃😅

I'll add a note to the sample update tracking issue to check to see if this section should be modified and the cross-link pulled at some future release. **EDIT ... _Done!_**

cc: @bobbydog - thanks for opening the issue.