### PR TITLE
Tag Helper navigation

### DIFF
--- a/aspnetcore/includes/built-in-TH.md
+++ b/aspnetcore/includes/built-in-TH.md
@@ -8,11 +8,9 @@
 
 **[Environment Tag Helper](xref:mvc/views/tag-helpers/builtin-th/environment-tag-helper)**
 
-**[FormActionTagHelper](xref:mvc/views/working-with-forms#the-form-action-tag-helper)**
+**[Form Action Tag Helper](xref:mvc/views/working-with-forms#the-form-action-tag-helper)**
 
 **[Form Tag Helper](xref:mvc/views/working-with-forms#the-form-tag-helper)**
-
-**[Form Action Tag Helper](xref:mvc/views/working-with-forms#the-form-action-tag-helper)**
 
 **[Image Tag Helper](xref:mvc/views/tag-helpers/builtin-th/image-tag-helper)**
 
@@ -20,13 +18,13 @@
 
 **[Label Tag Helper](xref:mvc/views/working-with-forms#the-label-tag-helper)**
 
-**[LinkTagHelper](xref:mvc/views/tag-helpers/builtin-th/link-tag-helper)**
+**[Link Tag Helper](xref:mvc/views/tag-helpers/builtin-th/link-tag-helper)**
 
-[comment]: **[OptionTagHelper](xref:mvc/views/tag-helpers/builtin-th/option-tag-helper)**
-
-**[ScriptTagHelper](xref:mvc/views/tag-helpers/builtin-th/script-tag-helper)**
+[comment]: **[Option Tag Helper](xref:mvc/views/tag-helpers/builtin-th/option-tag-helper)**
 
 **[Partial Tag Helper](xref:mvc/views/tag-helpers/builtin-th/partial-tag-helper)**
+
+**[Script Tag Helper](xref:mvc/views/tag-helpers/builtin-th/script-tag-helper)**
 
 **[Select Tag Helper](xref:mvc/views/working-with-forms#the-select-tag-helper)**
 

--- a/aspnetcore/includes/built-in-TH.md
+++ b/aspnetcore/includes/built-in-TH.md
@@ -8,9 +8,9 @@
 
 **[Environment Tag Helper](xref:mvc/views/tag-helpers/builtin-th/environment-tag-helper)**
 
-**[Form Action Tag Helper](xref:mvc/views/working-with-forms#the-form-action-tag-helper)**
-
 **[Form Tag Helper](xref:mvc/views/working-with-forms#the-form-tag-helper)**
+
+**[Form Action Tag Helper](xref:mvc/views/working-with-forms#the-form-action-tag-helper)**
 
 **[Image Tag Helper](xref:mvc/views/tag-helpers/builtin-th/image-tag-helper)**
 

--- a/aspnetcore/includes/built-in-TH.md
+++ b/aspnetcore/includes/built-in-TH.md
@@ -20,8 +20,6 @@
 
 **[Link Tag Helper](xref:mvc/views/tag-helpers/builtin-th/link-tag-helper)**
 
-[comment]: **[Option Tag Helper](xref:mvc/views/tag-helpers/builtin-th/option-tag-helper)**
-
 **[Partial Tag Helper](xref:mvc/views/tag-helpers/builtin-th/partial-tag-helper)**
 
 **[Script Tag Helper](xref:mvc/views/tag-helpers/builtin-th/script-tag-helper)**

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -382,7 +382,7 @@
             - name: Form
               href: mvc/views/working-with-forms.md#the-form-tag-helper
             - name: Form Action
-              href: mvc/views/working-with-forms#the-form-action-tag-helper
+              href: mvc/views/working-with-forms.md#the-form-action-tag-helper
             - name: Image
               uid: mvc/views/tag-helpers/builtin-th/image-tag-helper
             - name: Input

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -381,6 +381,8 @@
               uid: mvc/views/tag-helpers/builtin-th/environment-tag-helper
             - name: Form
               href: mvc/views/working-with-forms.md#the-form-tag-helper
+            - name: Form Action
+              uid: mvc/views/working-with-forms#the-form-action-tag-helper
             - name: Image
               uid: mvc/views/tag-helpers/builtin-th/image-tag-helper
             - name: Input

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -387,8 +387,12 @@
               href: mvc/views/working-with-forms.md#the-input-tag-helper
             - name: Label
               href: mvc/views/working-with-forms.md#the-label-tag-helper
+            - name: Link
+              uid: mvc/views/tag-helpers/builtin-th/link-tag-helper
             - name: Partial
               uid: mvc/views/tag-helpers/builtin-th/partial-tag-helper
+            - name: Script
+              uid: mvc/views/tag-helpers/builtin-th/script-tag-helper
             - name: Select
               href: mvc/views/working-with-forms.md#the-select-tag-helper
             - name: Textarea

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -382,7 +382,7 @@
             - name: Form
               href: mvc/views/working-with-forms.md#the-form-tag-helper
             - name: Form Action
-              uid: mvc/views/working-with-forms#the-form-action-tag-helper
+              href: mvc/views/working-with-forms#the-form-action-tag-helper
             - name: Image
               uid: mvc/views/tag-helpers/builtin-th/image-tag-helper
             - name: Input


### PR DESCRIPTION
Fixes #15724

~Note to self: `[comment]: ` ... nice trick. I could'a used that a few times. :+1:~
The build is choking on that Options Tag Helper `[comment]:` placeholder. It's warning that the UID isn't there, which is true. Let's just add that topic when/if it becomes a thing.

Thanks @richardcox13! :rocket: ... do you spot any that I missed?