### PR TITLE
Add an authentication overview doc

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -232,7 +232,7 @@
         }, 
         {   
             "source_path": "aspnetcore/security/authentication/index.md", 
-            "redirect_url": "/aspnet/core/security/authentication/identity", 
+            "redirect_url": "/aspnet/core/security/authentication/index", 
             "redirect_document_id": false 
         }, 
         {   

--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -229,12 +229,7 @@
             "source_path": "aspnetcore/azure/index.md", 
             "redirect_url": "/aspnet/core/azure/devops", 
             "redirect_document_id": false 
-        }, 
-        {   
-            "source_path": "aspnetcore/security/authentication/index.md", 
-            "redirect_url": "/aspnet/core/security/authentication/index", 
-            "redirect_document_id": false 
-        }, 
+        },         
         {   
             "source_path": "aspnetcore/security/authorization/index.md", 
             "redirect_url": "/aspnet/core/security/authorization/introduction", 

--- a/aspnetcore/security/authentication/index.md
+++ b/aspnetcore/security/authentication/index.md
@@ -33,7 +33,9 @@ services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 
 The `AddAuthentication` parameter `JwtBearerDefaults.AuthenticationScheme` is the name of the scheme to use by default if a specific one isn't requested when authenticating or authorizing in the application. In the preceding code, JWT bearer authentication is used by default.
 
-In some cases, the call to `AddAuthentication` is automatically made by other extension methods. For example, when using [ASP.NET Core Identity](xref:security/authentication/identity),`AddAuthentication` is called. If multiple schemes are used, authorization policies (or authorization attributes) can [specify the authentication scheme (or schemes)](xref:security/authorization/limitingidentitybyscheme) they depend on to authenticate the user. In the example above, the cookie authentication scheme could be used by specifying its name (`CookieAuthenticationDefaults.AuthenticationScheme` by default, though a different name could be provided when calling `AddCookie`).
+If multiple schemes are used, authorization policies (or authorization attributes) can [specify the authentication scheme (or schemes)](xref:security/authorization/limitingidentitybyscheme) they depend on to authenticate the user. In the example above, the cookie authentication scheme could be used by specifying its name (`CookieAuthenticationDefaults.AuthenticationScheme` by default, though a different name could be provided when calling `AddCookie`).
+
+In some cases, the call to `AddAuthentication` is automatically made by other extension methods. For example, when using [ASP.NET Core Identity](xref:security/authentication/identity),`AddAuthentication` is called internally. 
 
 The Authentication middleware is added in `Startup.Configure` by calling the <xref:Microsoft.AspNetCore.Builder.AuthAppBuilderExtensions.UseAuthentication*> extension method on the app's `IApplicationBuilder`. This registers the  middleware which uses the previously registered authentication schemes. Call `UseAuthentication` before any middleware that depends on users being authenticated. When using endpoint routing, the call to `UseAuthentication` must go:
 
@@ -72,7 +74,7 @@ Based on the authentication scheme's configuration and the incoming request cont
 
 ### Challenge
 
-An authentication challenge is the action an authentication scheme takes when an unauthenticated user requests an endpoint that requires authentication. An authentication challenge is issued, for example, on a request to a restricted resource. Authentication challenge examples include:
+An authentication challenge is invoked by Authorization when an unauthenticated user requests an endpoint that requires authentication. An authentication challenge is issued, for example, when an anonymous user requests a restricted resource or clicks on a login link. Authorization invokes a challenge using the specified authentication scheme(s), or the default if none is specified. See HttpContext.ChallengeAsync. Authentication challenge examples include:
 
 * A cookie authentication scheme redirecting the user to a login page.
 * A JWT bearer scheme returning a 401 result with a `www-authenticate: bearer` header.
@@ -81,7 +83,7 @@ A challenge action should let the user know what authentication mechanism to use
 
 ### Forbid
 
-An authentication handler's forbid action is used when an authenticated user attempts to access a resource they are not permitted to access. Authentication forbid examples include:
+An authentication scheme's forbid action is called by Authorization when an authenticated user attempts to access a resource they are not permitted to access. See HttpContext.ForbidAsync. Authentication forbid examples include:
 * A cookie authentication scheme redirecting the user to a page indicating access was forbidden.
 * A JWT bearer scheme returning a 403 result.
 * A custom authentication scheme redirecting to a page where the user can request access to the resource.

--- a/aspnetcore/security/authentication/index.md
+++ b/aspnetcore/security/authentication/index.md
@@ -16,11 +16,11 @@ Authentication is the process of determining a user's identity. [Authorization](
 * Authenticating a user.
 * Responding when an unauthenticated user tries to access a restricted resource.
 
-The registered authentication handlers and their configuration options, are called "schemes".
+The registered authentication handlers and their configuration options are called "schemes".
 
-Authentication schemes are specified by registering authentication services in `Startup.ConfigureServices`. This is done by:
+Authentication schemes are specified by registering authentication services in `Startup.ConfigureServices`:
 
-* Calling a scheme-specific extension method after a call to `services.AddAuthentication` (such as `AddJwtBearer` or `AddCookie`, for example). These extension methods use [AuthenticationBuilder.AddScheme](xref:Microsoft.AspNetCore.Authentication.AuthenticationBuilder.AddScheme*) to register schemes with appropriate settings.
+* By calling a scheme-specific extension method after a call to `services.AddAuthentication` (such as `AddJwtBearer` or `AddCookie`, for example). These extension methods use [AuthenticationBuilder.AddScheme](xref:Microsoft.AspNetCore.Authentication.AuthenticationBuilder.AddScheme*) to register schemes with appropriate settings.
 * Less commonly, by calling [AuthenticationBuilder.AddScheme](xref:Microsoft.AspNetCore.Authentication.AuthenticationBuilder.AddScheme*) directly.
 
 For example, the following code registers authentication services and handlers for cookie and JWT bearer authentication schemes:
@@ -31,13 +31,17 @@ services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme, options => Configuration.Bind("CookieSettings", options));
 ```
 
-The `AddAuthentication` parameter `JwtBearerDefaults.AuthenticationScheme` is the name of the scheme to use by default if a specific one isn't requested when authenticating or authorizing in the application. In the preceding code, JWT bearer authentication is used by default.
+The `AddAuthentication` parameter `JwtBearerDefaults.AuthenticationScheme` is the name of the scheme to use by default if:
+
+* A specific scheme isn't requested when authenticating or authorizing.
+
+In the preceding code, JWT bearer authentication is used by default.
 
 If multiple schemes are used, authorization policies (or authorization attributes) can [specify the authentication scheme (or schemes)](xref:security/authorization/limitingidentitybyscheme) they depend on to authenticate the user. In the example above, the cookie authentication scheme could be used by specifying its name (`CookieAuthenticationDefaults.AuthenticationScheme` by default, though a different name could be provided when calling `AddCookie`).
 
-In some cases, the call to `AddAuthentication` is automatically made by other extension methods. For example, when using [ASP.NET Core Identity](xref:security/authentication/identity),`AddAuthentication` is called internally. 
+In some cases, the call to `AddAuthentication` is automatically made by other extension methods. For example, when using [ASP.NET Core Identity](xref:security/authentication/identity),`AddAuthentication` is called internally.
 
-The Authentication middleware is added in `Startup.Configure` by calling the <xref:Microsoft.AspNetCore.Builder.AuthAppBuilderExtensions.UseAuthentication*> extension method on the app's `IApplicationBuilder`. This registers the  middleware which uses the previously registered authentication schemes. Call `UseAuthentication` before any middleware that depends on users being authenticated. When using endpoint routing, the call to `UseAuthentication` must go:
+The Authentication middleware is added in `Startup.Configure` by calling the <xref:Microsoft.AspNetCore.Builder.AuthAppBuilderExtensions.UseAuthentication*> extension method on the app's `IApplicationBuilder`. Calling `UseAuthentication` registers the middleware which uses the previously registered authentication schemes. Call `UseAuthentication` before any middleware that depends on users being authenticated. When using endpoint routing, the call to `UseAuthentication` must go:
 
 * After `UseRouting`, so that route information is available for authentication decisions.
 * Before `UseEndpoints`, so that users are authenticated before accessing the endpoints.
@@ -48,10 +52,10 @@ The Authentication middleware is added in `Startup.Configure` by calling the <xr
 
 An authentication scheme is a name which corresponds to:
 
-* An authentication handler. 
-* Options for configuring that specific instance of the handler. 
- 
-Schemes are useful as a mechanism for easily referring to the authentication, challenge, and forbid behaviors of the associated handler. For example, an authorization policy can specify by name which authorization scheme (or schemes) should be used to authenticate the user. When configuring authentication, it's common to specify the default authentication scheme. The default scheme is used unless a resource requests a specific scheme. It's also possible to:
+* An authentication handler.
+* Options for configuring that specific instance of the handler.
+
+Schemes are useful as a mechanism for referring to the authentication, challenge, and forbid behaviors of the associated handler. For example, an authorization policy can specify by name which authorization scheme (or schemes) should be used to authenticate the user. When configuring authentication, it's common to specify the default authentication scheme. The default scheme is used unless a resource requests a specific scheme. It's also possible to:
 
 * Specify different default schemes to use for authenticate, challenge, and forbid actions.
 * Combine multiple schemes into one using [policy schemes](xref:security/authentication/policyschemes).

--- a/aspnetcore/security/authentication/index.md
+++ b/aspnetcore/security/authentication/index.md
@@ -27,8 +27,8 @@ For example, the following code registers authentication services and handlers f
 
 ```csharp
 services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-    .AddJwtBearer(options => Configuration.Bind("JwtSettings", options))
-    .AddCookie(options => Configuration.Bind("CookieSettings", options));
+    .AddJwtBearer(JwtBearerDefaults.AuthenticationScheme, options => Configuration.Bind("JwtSettings", options))
+    .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme, options => Configuration.Bind("CookieSettings", options));
 ```
 
 The `AddAuthentication` parameter `JwtBearerDefaults.AuthenticationScheme` is the name of the scheme to use by default if a specific one isn't requested when authenticating or authorizing in the application. In the preceding code, JWT bearer authentication is used by default.

--- a/aspnetcore/security/authentication/index.md
+++ b/aspnetcore/security/authentication/index.md
@@ -1,0 +1,46 @@
+---
+title: Overview of ASP.NET Core Authentication
+author: mjrousos
+description: Learn about authentication in ASP.NET Core.
+ms.author: 
+ms.custom: mvc
+ms.date: 11/15/2019
+uid: security/authentication/index
+---
+# Overview of ASP.NET Core authentication
+
+Authentication is the process of determining a user's identity (as opposed to [authorization](xref:security/authorization/introduction), which is the process of determining whether a user has access to certain resources). In ASP.NET Core, authentication is handled by authentication [middleware](xref:fundamentals/middleware/index). The authentication middleware uses registered authentication handlers (which, along with their configuration options, are called "schemes") to complete authentication-related actions (like authenticating a user or responding when an unauthenticated user tries to access a restricted resource).
+
+Authentication schemes are specified when registering authentication services in the startup file's `ConfigureServices` method. This is done by calling `AuthenticationBuilder.AddScheme` or, more commonly, with scheme-specific extension methods that call `AddScheme` automatically with appropriate settings. For example, this code registers authentication services including handlers for both cookie and JWT bearer authentication schemes:
+
+```CSharp
+// AddAuthentication's parameter is the name of the scheme to use by default
+// (if a specific one isn't requested)
+services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options => Configuration.Bind("JwtSettings", options))
+    .AddCookie(options => Configuration.Bind("CookieSettings", options));
+```
+
+In some cases (such as when using [ASP.NET Core Identity](xref:security/authentication/identity)), the call to `AddAuthentication` is automatically made by other extension methods. Note that if multiple schemes are used, authorization policies (or authorization attributes) can [specify the authentication scheme (or schemes)](xref:security/authorization/limitingidentitybyscheme) they depend on to authenticate the user.
+
+Authentication middleware is added in the startup file's `Configure` method by calling the `UseAuthentication` extension method on the app's `IApplicationBuilder`. This registers the  middleware which uses the previously-registered authentication schemes. Be sure to call `UseAuthentication` before any middleware that depends on users being authenticated. When using endpoint routing, the call to `UseAuthentication` should go after `UseRouting` (so that route information is available for authentication decisions) and before `UseEndpoints` (so that users are authenticated before accessing the endpoints).
+
+## Authentication Concepts
+
+### Authentication scheme
+
+An authentication scheme is a way of authenticating a user (and how to proceed if a user isn't authenticated). In ASP.NET Core, an authentication scheme consists of an authentication handler and options for configuring that specific instance of the handler. Authentication schemes have names so that they can be easily referenced elsewhere (for example, by an authorization policy that wants to specify which authorization scheme (or schemes) should be used to authenticate the user). When configuring authentication, it's common to specify the default authentication scheme to use (if a particular resource doesn't request a specific scheme). It's also possible to specify different default schemes to use for authenticate, challenge, and forbid actions, or to combine multiple schemes into one using [policy schemes](xref:security/authentication/policyschemes).
+
+### Authentication handler
+
+An authentication handler is a type (derived from `IAuthenticationHandler`) that implements the behavior of a scheme. An authentication handler's primary responsibility is to authenticate users. Based on the authentication scheme's configuration and the incoming request context, authentication handlers construct `AuthenticationTicket` objects representing the user's identity. Alternatively, authentication handlers can return 'no result' or 'failure' if authentication is unsuccessful.
+
+In addition to authenticating, authentication handlers have methods for challenge and forbid actions for when users attempt to access resources they are unauthenticated or unauthorized to access.
+
+### Challenge
+
+An authentication challenge is the action an authentication scheme takes when an unauthenticated user requires authentication (to access a restricted resource, for example). Some examples of this would be the cookie authentication scheme redirecting the user to a login page or the JWT bearer scheme returning a 401 result. A challenge action should let the user know that they need to be authenticated to access a given resource.
+
+### Forbid
+
+An authentication handler's forbid action is used when an authenticated user attempts to access a resource they are not permitted to access. A forbid action usually returns a 403 result. In some custom authentication schemes, though, forbid could result in a redirect to a page where the user can request access to the resource in question from an admin or something like that. A forbid action should let the user know that although they are authenticated, the currently authenticated user is not permitted to access a particular resource.

--- a/aspnetcore/security/authentication/index.md
+++ b/aspnetcore/security/authentication/index.md
@@ -61,7 +61,7 @@ Schemes are useful as a mechanism for referring to the authentication, challenge
 An authentication handler:
 
 * Is a type that implements the behavior of a scheme.
-* Is derived from <xref:Microsoft.AspNetCore.Authentication.IAuthenticationHandler> or <xref:Microsoft.AspNetCore.Authentication.AuthenticationHandler>.
+* Is derived from <xref:Microsoft.AspNetCore.Authentication.IAuthenticationHandler> or <xref:Microsoft.AspNetCore.Authentication.AuthenticationHandler`1>.
 * Has the primary responsibility to authenticate users.
 
 Based on the authentication scheme's configuration and the incoming request context, authentication handlers:

--- a/aspnetcore/security/authentication/index.md
+++ b/aspnetcore/security/authentication/index.md
@@ -72,6 +72,13 @@ Based on the authentication scheme's configuration and the incoming request cont
   * They are unauthorized to access (forbid).
   * When they are unauthenticated (challenge).
 
+### Authenticate
+
+An authentication scheme's authenticate action is responsible for constructing the user's identity based on request context. It returns an <xref:Microsoft.AspNetCore.Authentication.AuthenticateResult> indicating whether authentication was successful and, if so, the user's identity in an authentication ticket. See HttpContext.AuthenticateAsync. Authenticate examples include:
+
+* A cookie authentication scheme constructing the user's identity from cookies.
+* A JWT bearer scheme deserializing and validating a JWT bearer token to construct the user's identity.
+
 ### Challenge
 
 An authentication challenge is invoked by Authorization when an unauthenticated user requests an endpoint that requires authentication. An authentication challenge is issued, for example, when an anonymous user requests a restricted resource or clicks on a login link. Authorization invokes a challenge using the specified authentication scheme(s), or the default if none is specified. See HttpContext.ChallengeAsync. Authentication challenge examples include:

--- a/aspnetcore/security/authentication/index.md
+++ b/aspnetcore/security/authentication/index.md
@@ -31,11 +31,7 @@ services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme, options => Configuration.Bind("CookieSettings", options));
 ```
 
-The `AddAuthentication` parameter `JwtBearerDefaults.AuthenticationScheme` is the name of the scheme to use by default if:
-
-* A specific scheme isn't requested when authenticating or authorizing.
-
-In the preceding code, JWT bearer authentication is used by default.
+The `AddAuthentication` parameter `JwtBearerDefaults.AuthenticationScheme` is the name of the scheme to use by default when a specific scheme isn't requested.
 
 If multiple schemes are used, authorization policies (or authorization attributes) can [specify the authentication scheme (or schemes)](xref:security/authorization/limitingidentitybyscheme) they depend on to authenticate the user. In the example above, the cookie authentication scheme could be used by specifying its name (`CookieAuthenticationDefaults.AuthenticationScheme` by default, though a different name could be provided when calling `AddCookie`).
 

--- a/aspnetcore/security/authentication/index.md
+++ b/aspnetcore/security/authentication/index.md
@@ -11,7 +11,7 @@ uid: security/authentication/index
 
 By [Mike Rousos](https://github.com/mjrousos)
 
-Authentication is the process of determining a user's identity. [Authorization](xref:security/authorization/introduction) is the process of determining whether a user has access to certain resources. In ASP.NET Core, authentication is handled by authentication [middleware](xref:fundamentals/middleware/index). The authentication middleware uses registered authentication handlers to complete authentication-related actions. Examples of authentication-related actions include:
+Authentication is the process of determining a user's identity. [Authorization](xref:security/authorization/introduction) is the process of determining whether a user has access to a resource. In ASP.NET Core, authentication is handled by authentication [middleware](xref:fundamentals/middleware/index). The authentication middleware uses registered authentication handlers to complete authentication-related actions. Examples of authentication-related actions include:
 
 * Authenticating a user.
 * Responding when an unauthenticated user tries to access a restricted resource.
@@ -20,10 +20,10 @@ The registered authentication handlers and their configuration options, are call
 
 Authentication schemes are specified by registering authentication services in `Startup.ConfigureServices`. This is done by:
 
-* Calling [AuthenticationBuilder.AddScheme]((xref:Microsoft.AspNetCore.Authentication.AuthenticationBuilder.AddScheme*)
-* Calling a scheme-specific extension methods that call `AddScheme` automatically with appropriate settings. This approach is more command than calling `AuthenticationBuilder.AddScheme`.
+* Calling [AuthenticationBuilder.AddScheme](xref:Microsoft.AspNetCore.Authentication.AuthenticationBuilder.AddScheme*)
+* Calling a scheme-specific extension methods that call `AddScheme` automatically with appropriate settings. This approach is more common than calling `AuthenticationBuilder.AddScheme`.
 
-For example, the following code registers authentication services including handlers for both cookie and JWT bearer authentication schemes:
+For example, the following code registers authentication services and handlers for cookie and JWT bearer authentication schemes:
 
 ```csharp
 services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
@@ -31,7 +31,7 @@ services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddCookie(options => Configuration.Bind("CookieSettings", options));
 ```
 
-The `AddAuthentication` parameter is the name of the scheme to use by default if a specific one isn't requested. In the preceding code, JWT bearer authentication is used by default.
+The `AddAuthentication` parameter `JwtBearerDefaults.AuthenticationScheme` is the name of the scheme to use by default if a specific one isn't requested. In the preceding code, JWT bearer authentication is used by default.
 
 In some cases, the call to `AddAuthentication` is automatically made by other extension methods. For example, when using [ASP.NET Core Identity](xref:security/authentication/identity)),`AddAuthentication` is called. If multiple schemes are used, authorization policies (or authorization attributes) can [specify the authentication scheme (or schemes)](xref:security/authorization/limitingidentitybyscheme) they depend on to authenticate the user.
 
@@ -54,7 +54,7 @@ In ASP.NET Core, an authentication scheme consists of:
 * An authentication handler.
 * Options for configuring that specific instance of the handler.
 
-Authentication schemes have names so that they can be referenced in the app. For example, an authorization policy that specifies which authorization scheme (or schemes) should be used to authenticate the user. When configuring authentication, it's common to specify the default authentication scheme. The default scheme is used unless a resource request a specific scheme. It's also possible to:
+Authentication schemes have names so that they can be referenced in the app. For example, an authorization policy that specifies which authorization scheme (or schemes) should be used to authenticate the user. When configuring authentication, it's common to specify the default authentication scheme. The default scheme is used unless a resource requests a specific scheme. It's also possible to:
 
 * Specify different default schemes to use for authenticate, challenge, and forbid actions.
 * Combine multiple schemes into one using [policy schemes](xref:security/authentication/policyschemes).
@@ -77,7 +77,7 @@ Based on the authentication scheme's configuration and the incoming request cont
 
 ### Challenge
 
-An authentication challenge is the action an authentication scheme takes when an unauthenticated user requests an endpoint that requires authentication. For example, to access a restricted resource. Authentication challenge examples include:
+An authentication challenge is the action an authentication scheme takes when an unauthenticated user requests an endpoint that requires authentication. An authentication challenge is issued, for example, on a request to a restricted resource. Authentication challenge examples include:
 
 * Cookie authentication scheme redirecting the user to a login page.
 * The JWT bearer scheme returning a 401 result.
@@ -86,7 +86,11 @@ A challenge action should let the user know that they need to be authenticated t
 
 ### Forbid
 
-An authentication handler's forbid action is used when an authenticated user attempts to access a resource they are not permitted to access. A forbid action usually returns a 403 result. In some custom authentication schemes, forbid could result in a redirect to a page where the user can request access to the resource in question from an admin or something like that. A forbid action should let the user know:
+An authentication handler's forbid action is used when an authenticated user attempts to access a resource they are not permitted to access. A forbid action typically returns a 403 result. In some custom authentication schemes, forbid could result in:
+
+* A redirect to a page where the user can request access to the resource.
+
+For example, the user my request access from an admin. A forbid action should let the user know:
 
 * They are authenticated.
 * They aren't permitted to access the requested resource.
@@ -95,3 +99,9 @@ See the following links for differences between challenge and forbid:
 
 * [Challenge and forbid with an operational resource handler](xref:security/authorization/resourcebased#challenge-and-forbid-with-an-operational-resource-handler).
 * [Differences between challenge and forbid](xref:security/authorization/secure-data#challenge).
+
+## Additional resources
+
+* <xref:security/authorization/limitingidentitybyscheme>
+* <xref:security/authentication/policyschemes>
+* <xref:security/authorization/secure-data>

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -813,6 +813,8 @@
       uid: security/index
     - name: Authentication
       items:
+        - name: Overview
+          uid: security/authentication/index
         - name: Introduction to Identity
           uid: security/authentication/identity
         - name: Identity with SPA


### PR DESCRIPTION
In the ASP.NET Core docs, the security and authorization sections have 'overview' docs that give a high-level view of the topic's concepts.

Authentication docs just dive right into ASP.NET Core Identity, though, and I've worked with a couple customers recently who struggled to get started with ASP.NET Core auth because they didn't understand some of the concepts (what is a 'scheme' and how do you register one?, what does 'challenge' mean in an auth context?).

I've added a doc here meant to be a quick intro to authentication topics for folks who may not be familiar with some of the terms or how ASP.NET Core authentication works at a high level.