### PR TITLE
Rename parameters to avoid confusion

### DIFF
--- a/aspnetcore/test/integration-tests/samples/3.x/IntegrationTestsSample/tests/RazorPagesProject.Tests/CustomWebApplicationFactory.cs
+++ b/aspnetcore/test/integration-tests/samples/3.x/IntegrationTestsSample/tests/RazorPagesProject.Tests/CustomWebApplicationFactory.cs
@@ -10,7 +10,7 @@ using RazorPagesProject.Data;
 namespace RazorPagesProject.Tests
 {
     #region snippet1
-    public class CustomWebApplicationFactory<TStartup> 
+    public class CustomWebApplicationFactory<TStartup>
         : WebApplicationFactory<TStartup> where TStartup: class
     {
         protected override void ConfigureWebHost(IWebHostBuilder builder)
@@ -19,7 +19,7 @@ namespace RazorPagesProject.Tests
             {
                 // Remove the app's ApplicationDbContext registration.
                 var descriptor = services.SingleOrDefault(
-                    d => d.ServiceType == 
+                    d => d.ServiceType ==
                         typeof(DbContextOptions<ApplicationDbContext>));
 
                 if (descriptor != null)
@@ -28,9 +28,9 @@ namespace RazorPagesProject.Tests
                 }
 
                 // Add ApplicationDbContext using an in-memory database for testing.
-                services.AddDbContext<ApplicationDbContext>((options, context) => 
+                services.AddDbContext<ApplicationDbContext>(options =>
                 {
-                    context.UseInMemoryDatabase("InMemoryDbForTesting");
+                    options.UseInMemoryDatabase("InMemoryDbForTesting");
                 });
 
                 // Build the service provider.


### PR DESCRIPTION
In `AddDbContext<T>((options, context) => { … })`, that `options` is actually the service provider, and `context` is the context options builder.

So this changes that call to be just `AddDbContext<T>(options => { … })` which makes it a bit clearer since it also doesn’t need the service provider.