### PR TITLE
Clarify that SignalR auto reconnect is opt-in in Core

### DIFF
--- a/aspnetcore/signalr/version-differences.md
+++ b/aspnetcore/signalr/version-differences.md
@@ -33,6 +33,9 @@ ASP.NET Core SignalR isn't compatible with clients or servers for ASP.NET Signal
 In ASP.NET SignalR:
 
 * By default, SignalR attempts to reconnect to the server if the connection is dropped. 
+
+In ASP.NET SignalR Core:
+
 * Automatic reconnects are opt-in with both the [.NET client](xref:signalr/dotnet-client#automatically-reconnect) and the [JavaScript client](xref:signalr/javascript-client#automatically-reconnect):
 
 ```csharp

--- a/aspnetcore/signalr/version-differences.md
+++ b/aspnetcore/signalr/version-differences.md
@@ -34,7 +34,7 @@ In ASP.NET SignalR:
 
 * By default, SignalR attempts to reconnect to the server if the connection is dropped. 
 
-In ASP.NET SignalR Core:
+In ASP.NET Core SignalR:
 
 * Automatic reconnects are opt-in with both the [.NET client](xref:signalr/dotnet-client#automatically-reconnect) and the [JavaScript client](xref:signalr/javascript-client#automatically-reconnect):
 


### PR DESCRIPTION
Fixup for #15703 to clarify that SignalR auto reconnect is opt-in in SignalR Core, not legacy SignalR.