### PR TITLE
Update trustCertVS.md

### DIFF
--- a/aspnetcore/includes/trustCertVS.md
+++ b/aspnetcore/includes/trustCertVS.md
@@ -11,7 +11,6 @@ The following dialog is displayed:
 
 Select **Yes** if you agree to trust the development certificate.
 
-See [Trust the ASP.NET Core HTTPS development certificate](xref:security/enforcing-ssl#trust-the-aspnet-core-https-development-certificate-on-windows-and-macos) for more information.
 ::: moniker-end
 
 ::: moniker range="< aspnetcore-3.0"
@@ -27,5 +26,4 @@ The following dialog is displayed:
 
 Select **Yes** if you agree to trust the development certificate.
 
-See [Trust the ASP.NET Core HTTPS development certificate](xref:security/enforcing-ssl#trust-the-aspnet-core-https-development-certificate-on-windows-and-macos) for more information.
 ::: moniker-end

--- a/aspnetcore/includes/trustCertVS.md
+++ b/aspnetcore/includes/trustCertVS.md
@@ -1,19 +1,3 @@
-::: moniker range=">= aspnetcore-3.0"
-Visual Studio displays the following dialog:
-
-![This project is configured to use SSL. To avoid SSL warnings in the browser you can choose to trust the self-signed certificate that ASP.NET Core has generated. Would you like to trust the ASP.NET Core SSL certificate?](~/getting-started/_static/trustCert-3x.png)
-
-Select **Yes** if you trust the ASP.NET Core SSL certificate.
-
-The following dialog is displayed:
-
-![Security warning dialog](~/getting-started/_static/cert.png)
-
-Select **Yes** if you agree to trust the development certificate.
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-3.0"
 Visual Studio displays the following dialog:
 
 ![This project is configured to use SSL. To avoid SSL warnings in the browser you can choose to trust the self-signed certificate that IIS Express has generated. Would you like to trust the IIS Express SSL certificate?](~/getting-started/_static/trustCert.png)
@@ -25,5 +9,3 @@ The following dialog is displayed:
 ![Security warning dialog](~/getting-started/_static/cert.png)
 
 Select **Yes** if you agree to trust the development certificate.
-
-::: moniker-end


### PR DESCRIPTION
@wadepickett 

'the ASP.NET Core SSL certificate.` is used by Kestel, not IIS Express
This didn't change in 3.0