### PR TITLE
Fixes issue #11860 - confusing RenderSection example

### DIFF
--- a/aspnetcore/mvc/views/layout.md
+++ b/aspnetcore/mvc/views/layout.md
@@ -62,9 +62,9 @@ By default, every layout must call `RenderBody`. Wherever the call to `RenderBod
 A layout can optionally reference one or more *sections*, by calling `RenderSection`. Sections provide a way to organize where certain page elements should be placed. Each call to `RenderSection` can specify whether that section is required or optional:
 
 ```html
-@section Scripts {
-    @RenderSection("Scripts", required: false)
-}
+<script type="text/javascript" src="~/scripts/global.js"></script>
+
+@RenderSection("Scripts", required: false)
 ```
 
 If a required section isn't found, an exception is thrown. Individual views specify the content to be rendered within a section using the `@section` Razor syntax. If a page or view defines a section, it must be rendered (or an error will occur).
@@ -73,7 +73,7 @@ An example `@section` definition in Razor Pages view:
 
 ```html
 @section Scripts {
-     <script type="text/javascript" src="/scripts/main.js"></script>
+     <script type="text/javascript" src="~/scripts/main.js"></script>
 }
 ```
 


### PR DESCRIPTION
As noted in the issue #11860, the RenderSection example is confusing and may create a fallacious impression that RenderSection can be used only inside other section definition. It's overloaded with information that is unnecessary for RenderSection understanding.
Also more appropriate tilde (~) notation/operator is used for resources paths.