### PR TITLE
Highlight MapRazorPages() in Startup.cs example

### DIFF
--- a/aspnetcore/razor-pages/index.md
+++ b/aspnetcore/razor-pages/index.md
@@ -59,7 +59,7 @@ Open the generated *.csproj* file from Visual Studio for Mac.
 
 Razor Pages is enabled in *Startup.cs*:
 
-[!code-cs[](index/3.0sample/RazorPagesIntro/Startup.cs?name=snippet_Startup&highlight=12)]
+[!code-cs[](index/3.0sample/RazorPagesIntro/Startup.cs?name=snippet_Startup&highlight=12,36)]
 
 Consider a basic page:
 <a name="OnGet"></a>


### PR DESCRIPTION
The Startup.cs example should also highlight line 36 where MapRazorPages() is called as it's essential to razor page routing.
