### PR TITLE
Blazor templates topic

### DIFF
--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -74,25 +74,25 @@ Get started with Blazor:
 
    7\. In a browser, navigate to `https://localhost:5001`.
 
-   <!--
-
    # [Visual Studio for Mac](#tab/visual-studio-mac)
 
    1\. Install [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/). Switch the [Update channel to Preview](/visualstudio/mac/install-preview).
 
-   2\. Select **File** > **New Solution** or **New Project**.
+   2\. Select **File** > **New Solution** or create a **New Project**.
 
    3\. In the sidebar, select **.NET Core** > **App**.
 
-   4\. For a Blazor Server experience, select the **Blazor Server App** template. For a Blazor WebAssembly experience, select the **Blazor WebAssembly App** template. Select **Next**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>.
+   4\. Select the **Blazor Server App** template. Only the Blazor Server template is available in Visual Studio for Mac at this time. For a Blazor WebAssembly experience, follow the instructions on the **.NET Core CLI** tab. After selecting the Blazor Server template, select **Next**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>.
 
-   5\. The **Target Framework** defaults to **.NET Core 3.0**. Select **Next**.
+   <!-- For a Blazor WebAssembly experience, select the **Blazor WebAssembly App** template. Select **Next**. -->
 
-   6\. In the **Project Name** field, enter `WebApplication1`. Select **Create**.
+   5\. The **Target Framework** defaults to **.NET Core 3.0** (or **.NET Core 3.1** if the 3.1 Preview SDK is installed). Select the framework and select **Next**.
 
-   7\. Select **Run** > **Run Without Debugging** to run the app *without the debugger*. Running with the debugger isn't supported at this time.
+   6\. In the **Project Name** field, name the app `WebApplication1`. Select **Create**.
 
-   -->
+   7\. Select **Run** > **Run Without Debugging** to run the app *without the debugger*. Run the app with **Start Debugging** to run the app *with the debugger*.
+
+       If a prompt appears to trust the development certificate, trust the certificate and continue.
 
    # [.NET Core CLI](#tab/netcore-cli/)
 

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -5,7 +5,7 @@ description: Get started with Blazor by building a Blazor app with the tooling o
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/07/2019
+ms.date: 11/25/2019
 no-loc: [Blazor]
 uid: blazor/get-started
 ---
@@ -179,25 +179,25 @@ Get started with Blazor:
 
    7\. In a browser, navigate to `https://localhost:5001`.
 
-   <!--
-
    # [Visual Studio for Mac](#tab/visual-studio-mac)
 
    1\. Install [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/). Switch the [Update channel to Preview](/visualstudio/mac/install-preview).
 
-   2\. Select **File** > **New Solution** or **New Project**.
+   2\. Select **File** > **New Solution** or create a **New Project**.
 
    3\. In the sidebar, select **.NET Core** > **App**.
 
-   4\. For a Blazor Server experience, select the **Blazor Server App** template. For a Blazor WebAssembly experience, select the **Blazor WebAssembly App** template. Select **Next**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>.
+   4\. Select the **Blazor Server App** template. Only the Blazor Server template is available in Visual Studio for Mac at this time. For a Blazor WebAssembly experience, follow the instructions on the **.NET Core CLI** tab. After selecting the Blazor Server template, select **Next**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>.
 
-   5\. The **Target Framework** defaults to **.NET Core 3.0**. Select **Next**.
+   <!-- For a Blazor WebAssembly experience, select the **Blazor WebAssembly App** template. Select **Next**. -->
 
-   6\. In the **Project Name** field, enter `WebApplication1`. Select **Create**.
+   5\. The **Target Framework** defaults to **.NET Core 3.0** (or **.NET Core 3.1** if the 3.1 Preview SDK is installed). Select the framework and select **Next**.
 
-   7\. Select **Run** > **Run Without Debugging** to run the app *without the debugger*. Running with the debugger isn't supported at this time.
+   6\. In the **Project Name** field, name the app `WebApplication1`. Select **Create**.
 
-   -->
+   7\. Select **Run** > **Run Without Debugging** to run the app *without the debugger*. Run the app with **Start Debugging** to run the app *with the debugger*.
+
+       If a prompt appears to trust the development certificate, trust the certificate and continue.
 
    # [.NET Core CLI](#tab/netcore-cli/)
 

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -279,4 +279,5 @@ Run the app. The `Index` component has its own counter that increments by ten ea
 
 ## Additional resources
 
+* <xref:blazor/templates>
 * <xref:signalr/introduction>

--- a/aspnetcore/blazor/templates.md
+++ b/aspnetcore/blazor/templates.md
@@ -1,0 +1,72 @@
+---
+title: ASP.NET Core Blazor templates
+author: guardrex
+description: Learn about ASP.NET Core Blazor app templates and Blazor project structure.
+monikerRange: '>= aspnetcore-3.0'
+ms.author: riande
+ms.custom: mvc
+ms.date: 11/25/2019
+no-loc: [Blazor, SignalR]
+uid: blazor/templates
+---
+# ASP.NET Core Blazor templates
+
+By [Daniel Roth](https://github.com/danroth27) and [Luke Latham](https://github.com/guardrex)
+
+[!INCLUDE[](~/includes/blazorwasm-preview-notice.md)]
+
+The Blazor framework provides templates to develop apps for each of the Blazor hosting models:
+
+* Blazor WebAssembly (`blazorwasm`)
+* Blazor Server (`blazorserver`)
+
+For more information on Blazor's hosting models, see <xref:blazor/hosting-models>.
+
+For step-by-step instructions on creating a Blazor app from a template, see <xref:blazor/get-started>.
+
+## Blazor project structure
+
+The following files and folders make up a Blazor app generated from a Blazor template:
+
+* *Program.cs* &ndash; The app's entry point that sets up the ASP.NET Core [host](xref:fundamentals/host/generic-host). The code in this file is common to all ASP.NET Core apps generated from ASP.NET Core templates.
+
+* *Startup.cs* &ndash; Contains the app's startup logic. The `Startup` class defines two methods:
+
+  * `ConfigureServices` &ndash; Configures the app's [dependency injection (DI)](xref:fundamentals/dependency-injection) services. In Blazor Server apps, services are added by calling <xref:Microsoft.Extensions.DependencyInjection.ComponentServiceCollectionExtensions.AddServerSideBlazor*>, and the `WeatherForecastService` is added to the service container for use by the example `FetchData` component.
+  * `Configure` &ndash; Configures the app's request handling pipeline:
+    * Blazor WebAssembly &ndash; Adds the `App` component (specified as the `app` DOM element to the `AddComponent` method), which is the root component of the app.
+    * Blazor Server
+      * <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub*> is called to set up an endpoint for the real-time connection with the browser. The connection is created with [SignalR](xref:signalr/introduction), which is a framework for adding real-time web functionality to apps.
+      * [MapFallbackToPage("/_Host")](xref:Microsoft.AspNetCore.Builder.RazorPagesEndpointRouteBuilderExtensions.MapFallbackToPage*) is called to set up the root page of the app (*Pages/_Host.cshtml*) and enable navigation.
+
+* *wwwroot/index.html* (Blazor WebAssembly) &ndash; The root page of the app implemented as an HTML page:
+  * When any page of the app is initially requested, this page is rendered and returned in the response.
+  * The page specifies where the root `App` component is rendered. The `App` component (*App.razor*) is specified as the `app` DOM element to the `AddComponent` method in `Startup.Configure`.
+  * The *_framework/blazor.webassembly.js* JavaScript file is loaded, which:
+    * Downloads the .NET runtime, the app, and the app's dependencies.
+    * Initializes the runtime to run the app.
+
+* *Pages/_Host.cshtml* (Blazor Server) &ndash; The root page of the app implemented as a Razor Page:
+  * When any page of the app is initially requested, this page is rendered and returned in the response.
+  * The *_framework/blazor.server.js* JavaScript file is loaded, which sets up the real-time SignalR connection between the browser and the server.
+  * The Host page specifies where the root `App` component (*App.razor*) is rendered.
+
+* *App.razor* &ndash; The root component of the app that sets up client-side routing using the <xref:Microsoft.AspNetCore.Components.Routing.Router> component. The `Router` component intercepts browser navigation and renders the page that matches the requested address.
+
+* *Pages* folder &ndash; Contains the routable components/pages (*.razor*) that make up the Blazor app. The route for each page is specified using the [@page](xref:mvc/views/razor#page) directive. The template includes the following components:
+  * `Index` (*Index.razor*) &ndash; Implements the Home page.
+  * `Counter` (*Counter.razor*) &ndash; Implements the Counter page.
+  * `Error` (*Error.razor*, Blazor Server app only) &ndash; Rendered when an unhandled exception occurs in the app.
+  * `FetchData` (*FetchData.razor*) &ndash; Implements the Fetch data page.
+
+* *Shared* folder &ndash; Contains other UI components (*.razor*) used by the app:
+  * `MainLayout` (*MainLayout.razor*) &ndash; The app's layout component.
+  * `NavMenu` (*NavMenu.razor*) &ndash; Implements sidebar navigation. Includes the [NavLink component](xref:blazor/routing#navlink-component) (<xref:Microsoft.AspNetCore.Components.Routing.NavLink>), which renders navigation links to other Razor components. The `NavLink` component automatically indicates a selected state when its component is loaded, which helps the user understand which component is currently displayed.
+
+* *_Imports.razor* &ndash; Includes common Razor directives to include in the app's components (*.razor*), such as [@using](xref:mvc/views/razor#using) directives for namespaces.
+
+* *Data* folder (Blazor Server) &ndash; Contains the `WeatherForecast` class and implementation of the `WeatherForecastService` that provide example weather data to the app's `FetchData` component.
+
+* *wwwroot* &ndash; The [Web Root](xref:fundamentals/index#web-root) folder for the app containing the app's public static assets.
+
+* *appsettings.json* (Blazor Server) &ndash; Configuration settings for the app.

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -282,6 +282,8 @@
           uid: blazor/hosting-models
         - name: Build your first app
           uid: tutorials/first-blazor-app
+        - name: Templates
+          uid: blazor/templates
         - name: Components
           uid: blazor/components
         - name: Forms and validation


### PR DESCRIPTION
Fixes #13757
Fixes #15863

Internal Review Topics:

* [Templates](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/templates?view=aspnetcore-3.0&branch=pr-en-us-15862)
* [Get Started](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/get-started?view=aspnetcore-3.0&branch=pr-en-us-15862)

Notes:

* I'm floating a *templates* focus for this *project structure* topic (i.e., the title and URL) because it covers app structure **_and_** affords an opportunity to discuss further details about the templates as needed.
* Looks like :eyes: we can activate the VS4Mac instructions for Blazor Server. In spite of the `blazorwasm` template being installed (and a restart just for good measure), VS4Mac only shows **Blazor Server App** in the list.