### PR TITLE
Add `xref_query_tags` to resolve xref in docfx v3 build

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -9,6 +9,10 @@
       "moniker_ranges": [
         ">= aspnetcore-1.0"
       ],
+      "xref_query_tags": [
+        "/dotnet",
+        "/aspnet"
+      ],
       "open_to_public_contributors": true,
       "type_mapping": {
         "Conceptual": "Content",


### PR DESCRIPTION
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

In v2, `xrefservice` can be defined in `docfx.json` then the user can query `uid` universally, which will be removed during the migration to v3 and related tags should be added to `.openpublishing.publish.config.json`.

We created this pull request to make the repository ready to migrate to docfx v3. This PR will not change any published pages.