### PR TITLE
AddAuthorization not related to Core 3.0 on Azure

### DIFF
--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -1227,4 +1227,3 @@ Review breaking changes:
 ## .NET Core 3.0 on Azure App Service
 
 For progress on the rollout of .NET Core to Azure App Service, see the official [.NET Core on App Service](https://aspnetcoreon.azurewebsites.net/) website. Until .NET Core 3.0 is available on Azure App Service, follow the instructions at [Deploy ASP.NET Core preview release to Azure App Service](xref:host-and-deploy/azure-apps/index#deploy-aspnet-core-preview-release-to-azure-app-service).
-AddAuthorization moved to a different assembly


### PR DESCRIPTION
Looks like an editing mistake. Perhaps intended to go under heading on Breaking API changes above?

Suggest it's removed as it is covered in [section](https://docs.microsoft.com/en-us/aspnet/core/migration/22-to-30?view=aspnetcore-3.0&tabs=visual-studio#addauthorization-moved-to-a-different-assembly) earlier and in 2 of the 3 links under [Breaking API changes](https://docs.microsoft.com/en-us/dotnet/core/compatibility/2.2-3.0).



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->