### PR TITLE
Fix ASP.NET Core version for Content-Language header

### DIFF
--- a/aspnetcore/fundamentals/localization.md
+++ b/aspnetcore/fundamentals/localization.md
@@ -271,7 +271,7 @@ The [Accept-Language header](https://www.w3.org/International/questions/qa-accep
 
 6. Tap the language, then tap **Move Up**.
 
-::: moniker range=">= aspnetcore-3.0"
+::: moniker range=">= aspnetcore-3.1"
 ### The Content-Language HTTP header
 
 The [Content-Language](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Language) entity header:
@@ -281,7 +281,7 @@ The [Content-Language](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers
 
 Entity headers are used in both HTTP requests and responses.
 
-In ASP.NET Core 3.0 the `Content-Language` header can be added by setting the property `ApplyCurrentCultureToResponseHeaders`.
+In ASP.NET Core 3.1 the `Content-Language` header can be added by setting the property `ApplyCurrentCultureToResponseHeaders`.
 
 Adding the `Content-Language` header:
 

--- a/aspnetcore/fundamentals/localization.md
+++ b/aspnetcore/fundamentals/localization.md
@@ -281,7 +281,7 @@ The [Content-Language](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers
 
 Entity headers are used in both HTTP requests and responses.
 
-In ASP.NET Core 3.1 the `Content-Language` header can be added by setting the property `ApplyCurrentCultureToResponseHeaders`.
+The `Content-Language` header can be added by setting the property `ApplyCurrentCultureToResponseHeaders`.
 
 Adding the `Content-Language` header:
 


### PR DESCRIPTION
@Rick-Anderson this is a reminder to merge this when ASP.NET Core 3.1 is shipped. A little bit history on this, I created a PR in localization long time ago, I supposed to be merged in 3.0, but the branch has been changed before merge this

After that I wrote a blog post about Localization 3.0, since then I got some feedback that this not working on 3.0, then I realize something goes wrong, until Ryan confirms

For that I pushed this PR, also I will change my blog post
