### PR TITLE
Blazor Handle Errors language improvement

### DIFF
--- a/aspnetcore/blazor/handle-errors.md
+++ b/aspnetcore/blazor/handle-errors.md
@@ -5,7 +5,7 @@ description: Discover how ASP.NET Core Blazor how Blazor manages unhandled excep
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/23/2019
+ms.date: 12/01/2019
 no-loc: [Blazor, SignalR]
 uid: blazor/handle-errors
 ---
@@ -114,7 +114,7 @@ A circuit fails when any executed constructor or a setter for any `[Inject]` pro
 
 ### Lifecycle methods
 
-During the lifetime of a component, Blazor invokes [lifecycle methods](xref:blazor/lifecycle):
+During the lifetime of a component, Blazor invokes the following [lifecycle methods](xref:blazor/lifecycle):
 
 * `OnInitialized` / `OnInitializedAsync`
 * `OnParametersSet` / `OnParametersSetAsync`


### PR DESCRIPTION
Fixes #15938

* Passing nit for this line ... adding "the following" composes the line better.
* This is written in the sense that they're *always* invoked in the framework because they all override when placed into developer code. Just confirming here that that's the case ... Blazor *always* invokes these *somewhere* ... dev code or framework code.