### PR TITLE
Blazor content for What's New 3.1 topic

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-3.1.md
+++ b/aspnetcore/release-notes/aspnetcore-3.1.md
@@ -51,7 +51,7 @@ For more information, see [Prevent default actions](xref:blazor/components#preve
 
 ## Stop event propagation in Blazor apps
 
-Use the `@on{EVENT}:stopPropagation` directive attribute to stop event propagation. In the following example, selecting the check box prevents click events from the second child `<div>` from propagating to the parent `<div>`:
+Use the `@on{EVENT}:stopPropagation` directive attribute to stop event propagation. In the following example, selecting the check box prevents click events from the child `<div>` from propagating to the parent `<div>`:
 
 ```razor
 <div @onclick="OnSelectParentDiv">

--- a/aspnetcore/release-notes/aspnetcore-3.1.md
+++ b/aspnetcore/release-notes/aspnetcore-3.1.md
@@ -14,20 +14,20 @@ This article highlights the most significant changes in ASP.NET Core 3.1 with li
 
 ## Partial class support for Razor components
 
-Razor components are now generated as partial classes. Code for a Razor component can be written using a code-behind file defined as a partial class rather than defining all the code for the component in a single file. For more information, see [Partial class support](xref:blazor/components#partial-class-support)
+Razor components are now generated as partial classes. Code for a Razor component can be written using a code-behind file defined as a partial class rather than defining all the code for the component in a single file. For more information, see [Partial class support](xref:blazor/components#partial-class-support).
 
 ## Blazor Apps can pass parameters to top-level components
 
 Blazor Server apps can now pass parameters to top-level components during the initial render. Previously you could only pass parameters to a top-level component with [RenderMode.Static](xref:Microsoft.AspNetCore.Mvc.Rendering.RenderMode.Static). With this release, both [RenderMode.Server](xref:Microsoft.AspNetCore.Mvc.Rendering.RenderMode.Server) and [RenderModel.ServerPrerendered](xref:Microsoft.AspNetCore.Mvc.Rendering.RenderMode.ServerPrerendered) are supported. Any specified parameter values are serialized as JSON and included in the initial response.
 
-For example, you could prerender a `Counter` component with a specific current count like this:
+For example, prerender a `Counter` component with an increment amount (`IncrementAmount`):
 
-```Razor
-@(await Html.RenderComponentAsync<Counter>(RenderMode.ServerPrerendered,
-                                           new { CurrentCount = 123 }))
+```razor
+<component type="typeof(Counter)" render-mode="ServerPrerendered" 
+    param-IncrementAmount="10" />
 ```
 
-For more information, see [Integrate components into Razor Pages and MVC apps](xref:blazor/components#integrate-components-into-razor-pages-and-mvc-apps)
+For more information, see [Integrate components into Razor Pages and MVC apps](xref:blazor/components#integrate-components-into-razor-pages-and-mvc-apps).
 
 ## Support for shared queues in HTTP.sys
 
@@ -39,11 +39,35 @@ For more information, see [Integrate components into Razor Pages and MVC apps](x
 ## Breaking changes for SameSite cookies
 -->
 
-<!-- GuardRex owns the following: 
 ## Prevent default actions for events in Blazor apps
+
+Use the `@on{EVENT}:preventDefault` directive attribute to prevent the default action for an event. In the following example, the default action of displaying the key's character in the text box is prevented:
+
+```razor
+<input value="@_count" @onkeypress="KeyHandler" @onkeypress:preventDefault />
+```
+
+For more information, see [Prevent default actions](xref:blazor/components#prevent-default-actions).
 
 ## Stop event propagation in Blazor apps
 
+Use the `@on{EVENT}:stopPropagation` directive attribute to stop event propagation. In the following example, selecting the check box prevents click events from the second child `<div>` from propagating to the parent `<div>`:
+
+```razor
+<div @onclick="OnSelectParentDiv">
+    <div @onclick="OnSelectChildDiv" @onclick:stopPropagation="_stopPropagation">
+        ...
+    </div>
+</div>
+```
+
+For more information, see [Stop event propagation](xref:blazor/components#stop-event-propagation).
+
 ## Detailed errors during Blazor app development
 
--->
+When a Blazor app isn't functioning properly during development, receiving detailed error information from the app assists in troubleshooting and fixing the issue. When an error occurs, Blazor apps display a gold bar at the bottom of the screen:
+
+* During development, the gold bar directs you to the browser console, where you can see the exception.
+* In production, the gold bar notifies the user that an error has occurred and recommends refreshing the browser.
+
+For more information, see [Detailed errors during development](xref:blazor/handle-errors#detailed-errors-during-development).

--- a/aspnetcore/release-notes/aspnetcore-3.1.md
+++ b/aspnetcore/release-notes/aspnetcore-3.1.md
@@ -54,11 +54,17 @@ For more information, see [Prevent default actions](xref:blazor/components#preve
 Use the `@on{EVENT}:stopPropagation` directive attribute to stop event propagation. In the following example, selecting the check box prevents click events from the child `<div>` from propagating to the parent `<div>`:
 
 ```razor
+<input @bind="_stopPropagation" type="checkbox" />
+
 <div @onclick="OnSelectParentDiv">
     <div @onclick="OnSelectChildDiv" @onclick:stopPropagation="_stopPropagation">
         ...
     </div>
 </div>
+
+@code {
+    private bool _stopPropagation = false;
+}
 ```
 
 For more information, see [Stop event propagation](xref:blazor/components#stop-event-propagation).

--- a/aspnetcore/release-notes/aspnetcore-3.1.md
+++ b/aspnetcore/release-notes/aspnetcore-3.1.md
@@ -16,7 +16,15 @@ This article highlights the most significant changes in ASP.NET Core 3.1 with li
 
 Razor components are now generated as partial classes. Code for a Razor component can be written using a code-behind file defined as a partial class rather than defining all the code for the component in a single file. For more information, see [Partial class support](xref:blazor/components#partial-class-support).
 
-## Blazor Apps can pass parameters to top-level components
+## Blazor Component Tag Helper and pass parameters to top-level components
+
+In Blazor with ASP.NET Core 3.0, components were rendered into pages and views using an HTML Helper (`Html.RenderComponentAsync`). In ASP.NET Core 3.1, render a component from a page or view with the new Component Tag Helper:
+
+```razor
+<component type="typeof(Counter)" render-mode="ServerPrerendered" />
+```
+
+The HTML Helper remains supported in ASP.NET Core 3.1, but the Component Tag Helper is recommended.
 
 Blazor Server apps can now pass parameters to top-level components during the initial render. Previously you could only pass parameters to a top-level component with [RenderMode.Static](xref:Microsoft.AspNetCore.Mvc.Rendering.RenderMode.Static). With this release, both [RenderMode.Server](xref:Microsoft.AspNetCore.Mvc.Rendering.RenderMode.Server) and [RenderModel.ServerPrerendered](xref:Microsoft.AspNetCore.Mvc.Rendering.RenderMode.ServerPrerendered) are supported. Any specified parameter values are serialized as JSON and included in the initial response.
 


### PR DESCRIPTION
Addresses #15958 

@scottaddie Do you want "Razor" or "razor" code language? "Razor" makes me think of Razor syntax. "razor" perhaps leans more toward Razor component (i.e., *.razor* file extension). This PR currently uses `razor`.