### PR TITLE
Enhance logging in Program example

### DIFF
--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -5,7 +5,7 @@ description: Learn how to use the logging framework provided by the Microsoft.Ex
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/19/2019
+ms.date: 12/04/2019
 uid: fundamentals/logging/index
 ---
 # Logging in .NET Core and ASP.NET Core
@@ -123,7 +123,7 @@ In the following ASP.NET Core and console app examples, the logger is used to cr
 
 To write logs in the `Program` class of an ASP.NET Core app, get an `ILogger` instance from DI after building the host:
 
-[!code-csharp[](index/samples/3.x/TodoApiSample/Program.cs?name=snippet_LogFromMain&highlight=9,10)]
+[!code-csharp[](index/samples_snapshot/3.x/TodoApiSample/Program.cs?highlight=9,10)]
 
 Logging during host construction isn't directly supported. However, a separate logger can be used. In the following example, a [Serilog](https://serilog.net/) logger is used to log in `CreateHostBuilder`. `AddSerilog` uses the static configuration specified in `Log.Logger`:
 

--- a/aspnetcore/fundamentals/logging/index/samples_snapshot/3.x/TodoApiSample/Program.cs
+++ b/aspnetcore/fundamentals/logging/index/samples_snapshot/3.x/TodoApiSample/Program.cs
@@ -1,0 +1,23 @@
+﻿public static void Main(string[] args)
+{
+    var host = CreateHostBuilder(args).Build();
+
+    var todoRepository = host.Services.GetRequiredService<ITodoRepository>();
+    todoRepository.Add(new Core.Model.TodoItem() { Name = "Feed the dog" });
+    todoRepository.Add(new Core.Model.TodoItem() { Name = "Walk the dog" });
+
+    var logger = host.Services.GetRequiredService<ILogger<Program>>();
+    logger.LogInformation("Seeded the database.");
+
+    IMyService myService = host.Services.GetRequiredService<IMyService>();
+    myService.WriteLog("Logged from MyService.");
+
+    host.Run();
+}
+
+public static IHostBuilder CreateHostBuilder(string[] args) =>
+    Host.CreateDefaultBuilder(args)
+        .ConfigureWebHostDefaults(webBuilder =>
+        {
+            webBuilder.UseStartup<Startup>();
+        });


### PR DESCRIPTION
Fixes #16005

[Internal Review Topic (links to *Create logs in the Program class* section)](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/index?view=aspnetcore-2.1&branch=pr-en-us-16018#create-logs-in-the-program-class)

* I couldn't merely extend the snippet: The `CreateHostBuilder` method in the 3.x sample app is used as a snippet for another example and shows more than is needed to make the point. Therefore, I use a snapshot file for this.
* This update is for the 3.x content only. We're good on 2.x ... that example was able to wrap the `CreateWebHostBuilder` method into its snippet for display.

Thanks @MV10! :rocket: Your approach is fine for scenarios that don't want to use `CreateHostBuilder`, but we need to stick with it as much as possible due to (for example) EF Core tools that need to find the `CreateHostBuilder` method to configure the host without running the app.