### PR TITLE
Blazor WebAssembly debugging update

### DIFF
--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -6,7 +6,7 @@ monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
 ms.date: 12/19/2019
-no-loc: [Blazor, SignalR, "blazor.webassembly.js"]
+no-loc: [Blazor, SignalR]
 uid: blazor/debug
 ---
 # Debug ASP.NET Core Blazor

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -107,8 +107,7 @@ Blazor provides a debugging proxy that implements the [Chrome DevTools Protocol]
 
 ## Attach to process in Visual Studio
 
-> [!WARNING]
-> Attaching to the app's process in Visual Studio is a *temporary* debugging scenario for Blazor WebAssembly while **F5** debugging is in development.
+Attaching to the app's process in Visual Studio is a *temporary* debugging scenario for Blazor WebAssembly while **F5** debugging is in development.
 
 To attach the running app's process to Visual Studio:
 

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -15,7 +15,10 @@ uid: blazor/debug
 
 [!INCLUDE[](~/includes/blazorwasm-preview-notice.md)]
 
-*Early* support exists for debugging Blazor WebAssembly using the browser dev tools in Chromium-based browsers (Chrome/Edge), and work is in progress to enable debugging with Visual Studio and Visual Studio Code.
+*Early* support exists for debugging Blazor WebAssembly using the browser dev tools in Chromium-based browsers (Chrome/Edge). Work is in progress to:
+
+* Fully enable debugging in Visual Studio.
+* Enable debugging in Visual Studio Code.
 
 Debugger capabilities are limited. Available scenarios include:
 
@@ -47,7 +50,7 @@ Debugging requires either of the following browsers:
 # [Visual Studio](#tab/visual-studio)
 
 > [!WARNING]
-> Debugging support in Visual Studio is at an early stage of development.
+> Debugging support in Visual Studio is at an early stage of development. **F5** debugging isn't currently supported.
 
 1. Run a Blazor WebAssembly app in `Debug` configuration without debugging (**Ctrl**+**F5** instead of **F5**).
 1. Open the Debug properties of the app (last entry in the **Debug** menu) and copy the HTTP **App URL**. Browse to the HTTP address (not the HTTPS address) of the app using a Chromium-based browser (Edge Beta or Chrome).
@@ -68,12 +71,7 @@ Debugging requires either of the following browsers:
        * `Shift+Cmd+D` on macOS
    4\. The **DevTools** tab opens in the browser. **Reselect the app's tab in the browser window.**
 
-1. In Visual Studio, select **Debug** > **Attach to Process**.
-1. For the **Connection type**, select **Chrome devtools protocol websocket (no authentication)**.
-1. For the **Connection target**, paste in the HTTP address (not the HTTPS address) of the app.
-1. Select **Refresh** to refresh the entries under **Available processes**.
-1. Select the browser process to debug and select **Attach**.
-1. In the **Select Code Type** dialog, select the code type for the specific browser you're attaching to (Edge or Chrome) and then select **OK**.
+   To attach the app to Visual Studio, see the [Attach to process in Visual Studio](#attach-to-process-in-visual-studio) section.
 
 # [.NET Core CLI](#tab/netcore-cli/)
 
@@ -107,11 +105,25 @@ Once Chrome is running with remote debugging enabled, the debugging keyboard sho
 
 Blazor provides a debugging proxy that implements the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) and augments the protocol with .NET-specific information. When debugging keyboard shortcut is pressed, Blazor points the Chrome DevTools at the proxy. The proxy connects to the browser window you're seeking to debug (hence the need to enable remote debugging).
 
+## Attach to process in Visual Studio
+
+> [!WARNING]
+> Attaching to the app's process in Visual Studio is a *temporary* debugging scenario for Blazor WebAssembly while **F5** debugging is in development.
+
+To attach the running app's process to Visual Studio:
+
+1. In Visual Studio, select **Debug** > **Attach to Process**.
+1. For the **Connection type**, select **Chrome devtools protocol websocket (no authentication)**.
+1. For the **Connection target**, paste in the HTTP address (not the HTTPS address) of the app.
+1. Select **Refresh** to refresh the entries under **Available processes**.
+1. Select the browser process to debug and select **Attach**.
+1. In the **Select Code Type** dialog, select the code type for the specific browser you're attaching to (Edge or Chrome) and then select **OK**.
+
 ## Browser source maps
 
 Browser source maps allow the browser to map compiled files back to their original source files and are commonly used for client-side debugging. However, Blazor doesn't currently map C# directly to JavaScript/WASM. Instead, Blazor does IL interpretation within the browser, so source maps aren't relevant.
 
-## Troubleshooting tip
+## Troubleshoot
 
 If you're running into errors, the following tip may help:
 

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -15,7 +15,7 @@ uid: blazor/debug
 
 [!INCLUDE[](~/includes/blazorwasm-preview-notice.md)]
 
-*Early* support exists for debugging Blazor WebAssembly apps running on WebAssembly in Chrome.
+*Early* support exists for debugging Blazor WebAssembly using the browser dev tools in Chromium-based browsers (Chrome/Edge), and work is in progress to enable debugging with Visual Studio and Visual Studio Code.
 
 Debugger capabilities are limited. Available scenarios include:
 
@@ -46,11 +46,15 @@ Debugging requires either of the following browsers:
 
 # [Visual Studio](#tab/visual-studio)
 
+> [!WARNING]
+> Debugging support in Visual Studio is at an early stage of development.
+
 1. Run a Blazor WebAssembly app in `Debug` configuration without debugging (**Ctrl**+**F5** instead of **F5**).
-1. Open the Debug properties (last entry in the **Debug** menu) of the app and copy the HTTP **App URL**. Browse to the HTTP address (not the HTTPS address) of the app using a Chromium based browser (Edge Beta or Chrome).
+1. Open the Debug properties of the app (last entry in the **Debug** menu) and copy the HTTP **App URL**. Browse to the HTTP address (not the HTTPS address) of the app using a Chromium-based browser (Edge Beta or Chrome).
 1. Place the keyboard focus on the app in the browser window, not the developer tools panel. It's best to keep the developer tools panel closed for this procedure. After debugging has started, you can re-open the developer tools panel.
 1. Select the following Blazor-specific keyboard shortcut:
-   * `Shift+Alt+D` on Windows/Linux
+
+   * `Shift+Alt+D` on Windows
    * `Shift+Cmd+D` on macOS
 
    If you receive the **Unable to find debuggable browser tab**, see [Enable remote debugging](#enable-remote-debugging).
@@ -60,15 +64,16 @@ Debugging requires either of the following browsers:
    1\. A new browser window opens. Close the prior window.
    2\. Place the keyboard focus on the app in the browser window.
    3\. Select the Blazor-specific keyboard shortcut in the new browser window:
-       * `Shift+Alt+D` on Windows/Linux
+       * `Shift+Alt+D` on Windows
        * `Shift+Cmd+D` on macOS
    4\. The **DevTools** tab opens in the browser. **Reselect the app's tab in the browser window.**
+
 1. In Visual Studio, select **Debug** > **Attach to Process**.
 1. For the **Connection type**, select **Chrome devtools protocol websocket (no authentication)**.
 1. For the **Connection target**, paste in the HTTP address (not the HTTPS address) of the app.
 1. Select **Refresh** to refresh the entries under **Available processes**.
-1. Select the browser process you want to debug and select **Attach**.
-1. In the **Select Code Type** dialog, select the code type for the specific browser you are attaching to (Edge or Chrome) and then select **OK**.
+1. Select the browser process to debug and select **Attach**.
+1. In the **Select Code Type** dialog, select the code type for the specific browser you're attaching to (Edge or Chrome) and then select **OK**.
 
 # [.NET Core CLI](#tab/netcore-cli/)
 
@@ -76,7 +81,8 @@ Debugging requires either of the following browsers:
 1. Navigate to the app at the HTTP URL shown in the shell's window.
 1. Place the keyboard focus on the app, not the developer tools panel. It's best to keep the developer tools panel closed for this procedure. After debugging has started, you can re-open the developer tools panel.
 1. Select the following Blazor-specific keyboard shortcut:
-   * `Shift+Alt+D` on Windows/Linux
+
+   * `Shift+Alt+D` on Windows
    * `Shift+Cmd+D` on macOS
 
    If you receive the **Unable to find debuggable browser tab**, see [Enable remote debugging](#enable-remote-debugging).
@@ -86,7 +92,7 @@ Debugging requires either of the following browsers:
    1\. A new browser window opens. Close the prior window.
    2\. Place the keyboard focus on the app in the browser window, not the developer tools panel.
    3\. Select the Blazor-specific keyboard shortcut in the new browser window:
-       * `Shift+Alt+D` on Windows/Linux
+       * `Shift+Alt+D` on Windows
        * `Shift+Cmd+D` on macOS
 
 ---

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -5,7 +5,7 @@ description: Learn how to debug Blazor apps.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/15/2019
+ms.date: 12/10/2019
 no-loc: [Blazor]
 uid: blazor/debug
 ---
@@ -44,16 +44,52 @@ Debugging requires either of the following browsers:
 
 ## Procedure
 
-1. Run a Blazor WebAssembly app in `Debug` configuration. Pass the `--configuration Debug` option to the [dotnet run](/dotnet/core/tools/dotnet-run) command: `dotnet run --configuration Debug`.
-1. Access the app in the browser.
-1. Place the keyboard focus on the app, not the developer tools panel. The developer tools panel can be closed when debugging is initiated.
+# [Visual Studio](#tab/visual-studio)
+
+1. Run a Blazor WebAssembly app in `Debug` configuration without debugging (**Ctrl**+**F5** instead of **F5**).
+1. Open the Debug properties (last entry in the **Debug** menu) of the app and copy the HTTP **App URL**. Browse to the HTTP address (not the HTTPS address) of the app using a Chromium based browser (Edge Beta or Chrome).
+1. Place the keyboard focus on the app in the browser window, not the developer tools panel. It's best to keep the developer tools panel closed for this procedure. After debugging has started, you can re-open the developer tools panel.
 1. Select the following Blazor-specific keyboard shortcut:
    * `Shift+Alt+D` on Windows/Linux
    * `Shift+Cmd+D` on macOS
-1. Follow the steps listed on the screen to restart the browser with remote debugging enabled.
-1. Select the following Blazor-specific keyboard shortcut once again to start the debug session:
+
+   If you receive the **Unable to find debuggable browser tab**, see [Enable remote debugging](#enable-remote-debugging).
+   
+   After enabling remote debugging:
+   
+   1\. A new browser window opens. Close the prior window.
+   2\. Place the keyboard focus on the app in the browser window.
+   3\. Select the Blazor-specific keyboard shortcut in the new browser window:
+       * `Shift+Alt+D` on Windows/Linux
+       * `Shift+Cmd+D` on macOS
+   4\. The **DevTools** tab opens in the browser. **Reselect the app's tab in the browser window.**
+1. In Visual Studio, select **Debug** > **Attach to Process**.
+1. For the **Connection type**, select **Chrome devtools protocol websocket (no authentication)**.
+1. For the **Connection target**, paste in the HTTP address (not the HTTPS address) of the app.
+1. Select **Refresh** to refresh the entries under **Available processes**.
+1. Select the browser process you want to debug and select **Attach**.
+1. In the **Select Code Type** dialog, select the code type for the specific browser you are attaching to (Edge or Chrome) and then select **OK**.
+
+# [.NET Core CLI](#tab/netcore-cli/)
+
+1. Run a Blazor WebAssembly app in `Debug` configuration by passing the `--configuration Debug` option to the [dotnet run](/dotnet/core/tools/dotnet-run) command: `dotnet run --configuration Debug`.
+1. Navigate to the app at the HTTP URL shown in the shell's window.
+1. Place the keyboard focus on the app, not the developer tools panel. It's best to keep the developer tools panel closed for this procedure. After debugging has started, you can re-open the developer tools panel.
+1. Select the following Blazor-specific keyboard shortcut:
    * `Shift+Alt+D` on Windows/Linux
    * `Shift+Cmd+D` on macOS
+
+   If you receive the **Unable to find debuggable browser tab**, see [Enable remote debugging](#enable-remote-debugging).
+   
+   After enabling remote debugging:
+   
+   1\. A new browser window opens. Close the prior window.
+   2\. Place the keyboard focus on the app in the browser window, not the developer tools panel.
+   3\. Select the Blazor-specific keyboard shortcut in the new browser window:
+       * `Shift+Alt+D` on Windows/Linux
+       * `Shift+Cmd+D` on macOS
+
+---
 
 ## Enable remote debugging
 

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -6,7 +6,7 @@ monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
 ms.date: 12/19/2019
-no-loc: [Blazor, SignalR, blazor.webassembly.js]
+no-loc: [Blazor, SignalR, "blazor.webassembly.js"]
 uid: blazor/debug
 ---
 # Debug ASP.NET Core Blazor

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -5,8 +5,8 @@ description: Learn how to debug Blazor apps.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 12/10/2019
-no-loc: [Blazor]
+ms.date: 12/19/2019
+no-loc: [Blazor, SignalR, blazor.webassembly.js]
 uid: blazor/debug
 ---
 # Debug ASP.NET Core Blazor

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -2,7 +2,7 @@
 title: Debug ASP.NET Core Blazor
 author: guardrex
 description: Learn how to debug Blazor apps.
-monikerRange: '>= aspnetcore-3.0'
+monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
 ms.date: 12/10/2019


### PR DESCRIPTION
Fixes #15983
Addresses #16270
Addresses #16273

DR: Most of the discussion below is TL;DR on the `no-loc` situation, which you can probably skip. There's one critical bit (https://github.com/aspnet/AspNetCore.Docs/pull/16123#issuecomment-570317743). Debugging doesn't work on Linux due to the setup in the framework: `Unable to find debuggable browser tab` instructions content always calls `GetLaunchEdgeInstructions` (i.e., on Linux), but `GetLaunchEdgeInstructions` throws for Linux at https://github.com/dotnet/aspnetcore/blob/e72223eaf58a3ee6660a922064d2449e47b78253/src/Components/Blazor/Server/src/MonoDebugProxy/BlazorMonoDebugProxyAppBuilderExtensions.cs#L288.

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/debug?view=aspnetcore-3.0&branch=pr-en-us-16123)

@VILcryo, you can try the updated steps on this PR, or you can wait until we get this reviewed+merged. There's no ETA at the moment tho on when these changes will go live given that the 🎁 *holidays* ⛄️ are on us and things will be mostly shutting down for the period around here.