### PR TITLE
remove useless config `xrefservice`

### DIFF
--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -43,9 +43,6 @@
     ],
     "overwrite": [],
     "externalReference": [],
-    "xrefService": [
-      "https://xref.docs.microsoft.com/query?uid={uid}"
-    ],
     "globalMetadata": {
       "_navPath": "/foo",
       "_navRel": "/foo",


### PR DESCRIPTION
As mentioned in PR #15907 ,  the config is not needed now.
@scottaddie Please help to review and merge the PR