### PR TITLE
Inconsistent use of @microsoft/signalr vs @aspnet/signalr

### DIFF
--- a/aspnetcore/tutorials/signalr-typescript-webpack/sample/2.x/snippets/index2.ts
+++ b/aspnetcore/tutorials/signalr-typescript-webpack/sample/2.x/snippets/index2.ts
@@ -1,7 +1,7 @@
 ﻿// This code exists only for inclusion in the associated doc.
 // <snippet_IndexTsPhase2File>
 import "./css/main.css";
-import * as signalR from "@aspnet/signalr";
+import * as signalR from "@microsoft/signalr";
 
 const divMessages: HTMLDivElement = document.querySelector("#divMessages");
 const tbMessage: HTMLInputElement = document.querySelector("#tbMessage");


### PR DESCRIPTION
This page section suggests installing `@microsoft/signalr` but down below the `@aspnet/signalr` is imported in the code snippet which leads to TypeScript code that does not compile.

https://docs.microsoft.com/en-us/aspnet/core/tutorials/signalr-typescript-webpack?view=aspnetcore-2.2&tabs=visual-studio#enable-client-and-server-communication-1