### PR TITLE
Health Checks sample 3.1 updates

### DIFF
--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -531,7 +531,7 @@ app.UseEndpoints(endpoints =>
 }
 ```
 
-A `WriteResponse` delegate formats the `CompositeHealthCheckResult` into a JSON object and yields JSON output for the health check response. For more information, see the [Customize output](#customize-output) section.
+The `WriteResponse` delegate formats the `CompositeHealthCheckResult` into a JSON object and yields JSON output for the health check response. For more information, see the [Customize output](#customize-output) section.
 
 To run the metric-based probe with custom response writer output using the sample app, execute the following command from the project's folder in a command shell:
 

--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -5,7 +5,7 @@ description: Learn how to set up health checks for ASP.NET Core infrastructure, 
 monikerRange: '>= aspnetcore-2.2'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/13/2019
+ms.date: 12/15/2019
 uid: host-and-deploy/health-checks
 ---
 # Health checks in ASP.NET Core
@@ -294,9 +294,7 @@ app.UseEndpoints(endpoints =>
 
 ### Customize output
 
-The <xref:Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions.ResponseWriter> option gets or sets a delegate used to write the response.
-
-In `Startup.Configure`:
+In `Startup.Configure`, set the [HealthCheckOptions.ResponseWriter](xref:Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions.ResponseWriter) option to a delegate for writing the response:
 
 ```csharp
 app.UseEndpoints(endpoints =>
@@ -308,27 +306,19 @@ app.UseEndpoints(endpoints =>
 });
 ```
 
-The default delegate writes a minimal plaintext response with the string value of [HealthReport.Status](xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthReport.Status). The following custom delegate, `WriteResponse`, outputs a custom JSON response:
+The default delegate writes a minimal plaintext response with the string value of [HealthReport.Status](xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthReport.Status). The following custom delegates output a custom JSON response.
 
-```csharp
-private static Task WriteResponse(HttpContext httpContext, HealthReport result)
-{
-    httpContext.Response.ContentType = "application/json";
+The first example from the sample app demonstrates how to use <xref:System.Text.Json?displayProperty=fullName>:
 
-    var json = new JObject(
-        new JProperty("status", result.Status.ToString()),
-        new JProperty("results", new JObject(result.Entries.Select(pair =>
-            new JProperty(pair.Key, new JObject(
-                new JProperty("status", pair.Value.Status.ToString()),
-                new JProperty("description", pair.Value.Description),
-                new JProperty("data", new JObject(pair.Value.Data.Select(
-                    p => new JProperty(p.Key, p.Value))))))))));
-    return httpContext.Response.WriteAsync(
-        json.ToString(Formatting.Indented));
-}
-```
+[!code-csharp[](health-checks/samples/3.x/HealthChecksSample/CustomWriterStartup.cs?name=snippet_WriteResponse_SystemTextJson)]
 
-The health checks system doesn't provide built-in support for complex JSON return formats because the format is specific to your choice of monitoring system. Feel free to customize the `JObject` in the preceding example as necessary to meet your needs.
+The second example demonstrates how to use [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/):
+
+[!code-csharp[](health-checks/samples/3.x/HealthChecksSample/CustomWriterStartup.cs?name=snippet_WriteResponse_NewtonSoftJson)]
+
+In the sample app, comment out the `SYSTEM_TEXT_JSON` [preprocessor directive](xref:index#preprocessor-directives-in-sample-code) in *CustomWriterStartup.cs* to enable the `Newtonsoft.Json` version of `WriteResponse`.
+
+The health checks API doesn't provide built-in support for complex JSON return formats because the format is specific to your choice of monitoring system. Customize the response in the preceding examples as needed. For more information on JSON serialization with `System.Text.Json`, see [How to serialize and deserialize JSON in .NET](/dotnet/standard/serialization/system-text-json-how-to).
 
 ## Database probe
 
@@ -525,11 +515,11 @@ The sample app demonstrates a memory health check with a custom response writer.
 
 Register health check services with <xref:Microsoft.Extensions.DependencyInjection.HealthCheckServiceCollectionExtensions.AddHealthChecks*> in `Startup.ConfigureServices`. Instead of enabling the health check by passing it to <xref:Microsoft.Extensions.DependencyInjection.HealthChecksBuilderAddCheckExtensions.AddCheck*>, the `MemoryHealthCheck` is registered as a service. All <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck> registered services are available to the health check services and middleware. We recommend registering health check services as Singleton services.
 
-In the sample app (*CustomWriterStartup.cs*):
+In *CustomWriterStartup.cs* of the sample app:
 
 [!code-csharp[](health-checks/samples/3.x/HealthChecksSample/CustomWriterStartup.cs?name=snippet_ConfigureServices&highlight=4)]
 
-A health check endpoint is created by calling `MapHealthChecks` in `Startup.Configure`. A `WriteResponse` delegate is provided to the `ResponseWriter` property to output a custom JSON response when the health check executes:
+A health check endpoint is created by calling `MapHealthChecks` in `Startup.Configure`. A `WriteResponse` delegate is provided to the <Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions.ResponseWriter> property to output a custom JSON response when the health check executes:
 
 ```csharp
 app.UseEndpoints(endpoints =>
@@ -541,9 +531,7 @@ app.UseEndpoints(endpoints =>
 }
 ```
 
-The `WriteResponse` method formats the `CompositeHealthCheckResult` into a JSON object and yields JSON output for the health check response:
-
-[!code-csharp[](health-checks/samples/3.x/HealthChecksSample/CustomWriterStartup.cs?name=snippet_WriteResponse)]
+A `WriteResponse` delegate formats the `CompositeHealthCheckResult` into a JSON object and yields JSON output for the health check response. For more information, see the [Customize output](#customize-output) section.
 
 To run the metric-based probe with custom response writer output using the sample app, execute the following command from the project's folder in a command shell:
 

--- a/aspnetcore/host-and-deploy/health-checks/samples/2.x/HealthChecksSample/CustomWriterStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/2.x/HealthChecksSample/CustomWriterStartup.cs
@@ -48,7 +48,7 @@ namespace SampleApp
         private static Task WriteResponse(HttpContext httpContext, 
             HealthReport result)
         {
-            httpContext.Response.ContentType = "application/json";
+            httpContext.Response.ContentType = "application/json; charset=utf-8";
 
             var json = new JObject(
                 new JProperty("status", result.Status.ToString()),

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/BasicStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/BasicStartup.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/CustomWriterStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/CustomWriterStartup.cs
@@ -1,8 +1,13 @@
-﻿using System.Linq;
+﻿#define SYSTEM_TEXT_JSON
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -49,11 +54,53 @@ namespace SampleApp
             });
         }
 
-        #region snippet_WriteResponse
-        private static Task WriteResponse(HttpContext httpContext, 
-            HealthReport result)
+#if SYSTEM_TEXT_JSON
+        #region snippet_WriteResponse_SystemTextJson
+        private static Task WriteResponse(HttpContext context, HealthReport result)
         {
-            httpContext.Response.ContentType = "application/json";
+            context.Response.ContentType = "application/json";
+
+            var options = new JsonWriterOptions
+            {
+                Indented = true
+            };
+
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(stream, options))
+                {
+                    writer.WriteStartObject();
+                    writer.WriteString("status", result.Status.ToString());
+                    writer.WriteStartObject("results");
+                    foreach (var entry in result.Entries)
+                    {
+                        writer.WriteStartObject(entry.Key);
+                        writer.WriteString("status", entry.Value.Status.ToString());
+                        writer.WriteString("description", entry.Value.Description);
+                        writer.WriteStartObject("data");
+                        foreach (var item in entry.Value.Data)
+                        {
+                            var value = Convert.ToDecimal(item.Value);
+                            writer.WriteNumber(item.Key, value);
+                        }
+                        writer.WriteEndObject();
+                        writer.WriteEndObject();
+                    }
+                    writer.WriteEndObject();
+                    writer.WriteEndObject();
+                }
+
+                var json = Encoding.UTF8.GetString(stream.ToArray());
+
+                return context.Response.WriteAsync(json);
+            }
+        }
+        #endregion
+#else
+        #region snippet_WriteResponse_NewtonSoftJson
+        private static Task WriteResponse(HttpContext context, HealthReport result)
+        {
+            context.Response.ContentType = "application/json";
 
             var json = new JObject(
                 new JProperty("status", result.Status.ToString()),
@@ -63,9 +110,11 @@ namespace SampleApp
                         new JProperty("description", pair.Value.Description),
                         new JProperty("data", new JObject(pair.Value.Data.Select(
                             p => new JProperty(p.Key, p.Value))))))))));
-            return httpContext.Response.WriteAsync(
+
+            return context.Response.WriteAsync(
                 json.ToString(Formatting.Indented));
         }
         #endregion
+#endif
     }
 }

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/CustomWriterStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/CustomWriterStartup.cs
@@ -3,16 +3,20 @@
 using System;
 using System.IO;
 using System.Linq;
+#if SYSTEM_TEXT_JSON
 using System.Text;
 using System.Text.Json;
+#endif
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+#if !SYSTEM_TEXT_JSON
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+#endif
 
 namespace SampleApp
 {

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/CustomWriterStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/CustomWriterStartup.cs
@@ -80,8 +80,10 @@ namespace SampleApp
                         writer.WriteStartObject("data");
                         foreach (var item in entry.Value.Data)
                         {
-                            var value = Convert.ToDecimal(item.Value);
-                            writer.WriteNumber(item.Key, value);
+                            writer.WritePropertyName(item.Key);
+                            JsonSerializer.Serialize(
+                                writer, item.Value, item.Value?.GetType() ?? 
+                                typeof(object));
                         }
                         writer.WriteEndObject();
                         writer.WriteEndObject();

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/CustomWriterStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/CustomWriterStartup.cs
@@ -58,7 +58,7 @@ namespace SampleApp
         #region snippet_WriteResponse_SystemTextJson
         private static Task WriteResponse(HttpContext context, HealthReport result)
         {
-            context.Response.ContentType = "application/json";
+            context.Response.ContentType = "application/json; charset=utf-8";
 
             var options = new JsonWriterOptions
             {

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/DBHealthStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/DBHealthStartup.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/DbContextHealthStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/DbContextHealthStartup.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/LivenessProbeStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/LivenessProbeStartup.cs
@@ -3,9 +3,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Hosting;
 using SampleApp.Services;
 
 namespace SampleApp

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/ManagementPortStartup.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/ManagementPortStartup.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/SampleApp.csproj
+++ b/aspnetcore/host-and-deploy/health-checks/samples/3.x/HealthChecksSample/SampleApp.csproj
@@ -1,15 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
-    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="2.2.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="3.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Addresses #5495 
Addresses #15473

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?view=aspnetcore-2.2&branch=pr-en-us-16204)

* 3.1 sample app confirmed running.
* Let's put the `System.Text.Json` approach in here but also retain the existing `Newtonsoft.Json` approach. A directive in the file makes it easy for the dev to switch back and forth.
* WRT the `System.Text.Json` approach: I couldn't get `WriteNumber` to work with a directly casted object (`(Decimal)item.Value`). I ended up performing the cast on a separate line with (`Convert.ToDecimal`) to make it happy.

cc: @lol768