### PR TITLE
Update Azure CLI command syntax

### DIFF
--- a/aspnetcore/security/key-vault-configuration.md
+++ b/aspnetcore/security/key-vault-configuration.md
@@ -5,7 +5,7 @@ description: Learn how to use the Azure Key Vault Configuration Provider to conf
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/14/2019
+ms.date: 12/16/2019
 uid: security/key-vault-configuration
 ---
 # Azure Key Vault Configuration Provider in ASP.NET Core
@@ -84,7 +84,7 @@ The instructions provided by the [Quickstart: Set and retrieve a secret from Azu
 1. Create a key vault in the resource group with the following command, where `{KEY VAULT NAME}` is the name for the new key vault and `{LOCATION}` is the Azure region (datacenter):
 
    ```azure-cli
-   az keyvault create --name "{KEY VAULT NAME}" --resource-group "{RESOURCE GROUP NAME}" --location {LOCATION}
+   az keyvault create --name {KEY VAULT NAME} --resource-group "{RESOURCE GROUP NAME}" --location {LOCATION}
    ```
 
 1. Create secrets in the key vault as name-value pairs.
@@ -94,8 +94,8 @@ The instructions provided by the [Quickstart: Set and retrieve a secret from Azu
    The following secrets are for use with the sample app. The values include a `_prod` suffix to distinguish them from the `_dev` suffix values loaded in the Development environment from User Secrets. Replace `{KEY VAULT NAME}` with the name of the key vault that you created in the prior step:
 
    ```azure-cli
-   az keyvault secret set --vault-name "{KEY VAULT NAME}" --name "SecretName" --value "secret_value_1_prod"
-   az keyvault secret set --vault-name "{KEY VAULT NAME}" --name "Section--SecretName" --value "secret_value_2_prod"
+   az keyvault secret set --vault-name {KEY VAULT NAME} --name "SecretName" --value "secret_value_1_prod"
+   az keyvault secret set --vault-name {KEY VAULT NAME} --name "Section--SecretName" --value "secret_value_2_prod"
    ```
 
 ## Use Application ID and X.509 certificate for non-Azure-hosted apps
@@ -184,7 +184,7 @@ An app deployed to Azure App Service is automatically registered with Azure AD w
 Using Azure CLI and the app's Object ID, provide the app with `list` and `get` permissions to access the key vault:
 
 ```azure-cli
-az keyvault set-policy --name '{KEY VAULT NAME}' --object-id {OBJECT ID} --secret-permissions get list
+az keyvault set-policy --name {KEY VAULT NAME} --object-id {OBJECT ID} --secret-permissions get list
 ```
 
 **Restart the app** using Azure CLI, PowerShell, or the Azure portal.
@@ -298,8 +298,8 @@ When this approach is implemented:
 1. Secrets are saved in Azure Key Vault using the following Azure CLI commands:
 
    ```azure-cli
-   az keyvault secret set --vault-name "{KEY VAULT NAME}" --name "5000-AppSecret" --value "5.0.0.0_secret_value_prod"
-   az keyvault secret set --vault-name "{KEY VAULT NAME}" --name "5100-AppSecret" --value "5.1.0.0_secret_value_prod"
+   az keyvault secret set --vault-name {KEY VAULT NAME} --name "5000-AppSecret" --value "5.0.0.0_secret_value_prod"
+   az keyvault secret set --vault-name {KEY VAULT NAME} --name "5100-AppSecret" --value "5.1.0.0_secret_value_prod"
    ```
 
 1. When the app is run, the key vault secrets are loaded. The string secret for `5000-AppSecret` is matched to the app's version specified in the app's project file (`5.0.0.0`).


### PR DESCRIPTION
Fixes #16117

* Unquoting the key vault name in Azure CLI command option values.
  * Originally, it worked. It followed the Azure doc :point_right: https://docs.microsoft.com/en-us/azure/key-vault/tutorial-net-windows-virtual-machine#assign-permissions-to-the-vm-identity
  * Unquoted (on this PR) follows a different Azure doc :point_right: https://docs.microsoft.com/en-us/azure/key-vault/quick-create-net#give-the-service-principal-access-to-your-key-vault
* I've alerted the Azure doc cats about the discrepancy in two Azure topics :point_right: https://github.com/MicrosoftDocs/azure-docs/issues/44749

Thanks @jeroenwo! 🎷