### PR TITLE
Customizing the System.Text.Json-based Input Formatter

### DIFF
--- a/aspnetcore/mvc/models/model-binding.md
+++ b/aspnetcore/mvc/models/model-binding.md
@@ -448,6 +448,24 @@ To use the built-in XML input formatters:
 
   For more information, see [Introducing XML Serialization](/dotnet/standard/serialization/introducing-xml-serialization).
 
+### Customize model binding with input formatters
+
+An input formatter takes full responsibility for reading data from the request body. To customize this process, configure the APIs used by the input formatter. This section describes how to customize the `System.Text.Json` based input formatter to understand a custom type named `ObjectId`. 
+
+Consider the following model, which contains a custom `ObjectId` property named `Id`:
+
+[!code-csharp[](model-binding/samples/3.x/ModelBindingSample/Models/ModelWithObjectId.cs?name=snippet_Class&highlight=3)]
+
+To customize the model binding process when using `System.Text.Json`, create a class which subclasses <xref:System.Text.Json.Serialization.JsonConverter`1>:
+
+[!code-csharp[](model-binding/samples/3.x/ModelBindingSample/JsonConverters/ObjectIdConverter.cs?name=snippet_Class)]
+
+To use a custom converter, apply the <xref:System.Text.Json.Serialization.JsonConverterAttribute> attribute to the type. In the following example, the `ObjectId` type is configured with `ObjectIdConverter` as its custom converter:
+
+[!code-csharp[](model-binding/samples/3.x/ModelBindingSample/Models/ObjectId.cs?name=snippet_Class&highlight=1)]
+
+For more information, see [How to write custom converters](/dotnet/standard/serialization/system-text-json-converters-how-to).
+
 ## Exclude specified types from model binding
 
 The model binding and validation systems' behavior is driven by [ModelMetadata](/dotnet/api/microsoft.aspnetcore.mvc.modelbinding.modelmetadata). You can customize `ModelMetadata` by adding a details provider to [MvcOptions.ModelMetadataDetailsProviders](xref:Microsoft.AspNetCore.Mvc.MvcOptions.ModelMetadataDetailsProviders). Built-in details providers are available for disabling model binding or validation for specified types.

--- a/aspnetcore/mvc/models/model-binding.md
+++ b/aspnetcore/mvc/models/model-binding.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn how model binding in ASP.NET Core works and how to customize its behavior.
 ms.assetid: 0be164aa-1d72-4192-bd6b-192c9c301164
 ms.author: riande
-ms.date: 12/17/2019
+ms.date: 12/18/2019
 uid: mvc/models/model-binding
 ---
 
@@ -456,7 +456,7 @@ Consider the following model, which contains a custom `ObjectId` property named 
 
 [!code-csharp[](model-binding/samples/3.x/ModelBindingSample/Models/ModelWithObjectId.cs?name=snippet_Class&highlight=3)]
 
-To customize the model binding process when using `System.Text.Json`, create a class derived from <xref:System.Text.Json.Serialization.JsonConverter`1>:
+To customize the model binding process when using `System.Text.Json`, create a class derived from <xref:System.Text.Json.Serialization.JsonConverter%601>:
 
 [!code-csharp[](model-binding/samples/3.x/ModelBindingSample/JsonConverters/ObjectIdConverter.cs?name=snippet_Class)]
 

--- a/aspnetcore/mvc/models/model-binding.md
+++ b/aspnetcore/mvc/models/model-binding.md
@@ -450,13 +450,13 @@ To use the built-in XML input formatters:
 
 ### Customize model binding with input formatters
 
-An input formatter takes full responsibility for reading data from the request body. To customize this process, configure the APIs used by the input formatter. This section describes how to customize the `System.Text.Json` based input formatter to understand a custom type named `ObjectId`. 
+An input formatter takes full responsibility for reading data from the request body. To customize this process, configure the APIs used by the input formatter. This section describes how to customize the `System.Text.Json`-based input formatter to understand a custom type named `ObjectId`. 
 
 Consider the following model, which contains a custom `ObjectId` property named `Id`:
 
 [!code-csharp[](model-binding/samples/3.x/ModelBindingSample/Models/ModelWithObjectId.cs?name=snippet_Class&highlight=3)]
 
-To customize the model binding process when using `System.Text.Json`, create a class which subclasses <xref:System.Text.Json.Serialization.JsonConverter`1>:
+To customize the model binding process when using `System.Text.Json`, create a class derived from <xref:System.Text.Json.Serialization.JsonConverter`1>:
 
 [!code-csharp[](model-binding/samples/3.x/ModelBindingSample/JsonConverters/ObjectIdConverter.cs?name=snippet_Class)]
 

--- a/aspnetcore/mvc/models/model-binding/samples/3.x/ModelBindingSample/Controllers/CustomJsonController.cs
+++ b/aspnetcore/mvc/models/model-binding/samples/3.x/ModelBindingSample/Controllers/CustomJsonController.cs
@@ -3,6 +3,7 @@ using ModelBindingSample.Models;
 
 namespace ModelBindingSample.Controllers
 {
+    #region snippet_Class
     [ApiController]
     [Route("[controller]")]
     public class CustomJsonController : ControllerBase
@@ -11,4 +12,5 @@ namespace ModelBindingSample.Controllers
         public IActionResult Post(ModelWithObjectId model) =>
             Ok(model);
     }
+    #endregion
 }

--- a/aspnetcore/mvc/models/model-binding/samples/3.x/ModelBindingSample/Controllers/CustomJsonController.cs
+++ b/aspnetcore/mvc/models/model-binding/samples/3.x/ModelBindingSample/Controllers/CustomJsonController.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Mvc;
+using ModelBindingSample.Models;
+
+namespace ModelBindingSample.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class CustomJsonController : ControllerBase
+    {
+        [HttpPost]
+        public IActionResult Post(ModelWithObjectId model) =>
+            Ok(model);
+    }
+}

--- a/aspnetcore/mvc/models/model-binding/samples/3.x/ModelBindingSample/JsonConverters/ObjectIdConverter.cs
+++ b/aspnetcore/mvc/models/model-binding/samples/3.x/ModelBindingSample/JsonConverters/ObjectIdConverter.cs
@@ -5,12 +5,20 @@ using ModelBindingSample.Models;
 
 namespace ModelBindingSample.Converters
 {
+    #region snippet_Class
     internal class ObjectIdConverter : JsonConverter<ObjectId>
     {
-        public override ObjectId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
-            new ObjectId(JsonSerializer.Deserialize<int>(ref reader, options));
+        public override ObjectId Read(
+            ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return new ObjectId(JsonSerializer.Deserialize<int>(ref reader, options));
+        }
 
-        public override void Write(Utf8JsonWriter writer, ObjectId value, JsonSerializerOptions options) =>
+        public override void Write(
+            Utf8JsonWriter writer, ObjectId value, JsonSerializerOptions options)
+        {
             writer.WriteNumberValue(value.Id);
+        }
     }
+    #endregion
 }

--- a/aspnetcore/mvc/models/model-binding/samples/3.x/ModelBindingSample/JsonConverters/ObjectIdConverter.cs
+++ b/aspnetcore/mvc/models/model-binding/samples/3.x/ModelBindingSample/JsonConverters/ObjectIdConverter.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ModelBindingSample.Models;
+
+namespace ModelBindingSample.Converters
+{
+    internal class ObjectIdConverter : JsonConverter<ObjectId>
+    {
+        public override ObjectId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+            new ObjectId(JsonSerializer.Deserialize<int>(ref reader, options));
+
+        public override void Write(Utf8JsonWriter writer, ObjectId value, JsonSerializerOptions options) =>
+            writer.WriteNumberValue(value.Id);
+    }
+}

--- a/aspnetcore/mvc/models/model-binding/samples/3.x/ModelBindingSample/Models/ModelWithObjectId.cs
+++ b/aspnetcore/mvc/models/model-binding/samples/3.x/ModelBindingSample/Models/ModelWithObjectId.cs
@@ -1,7 +1,9 @@
 namespace ModelBindingSample.Models
 {
+    #region snippet_Class
     public class ModelWithObjectId
     {
-        public ObjectId ObjectId { get; set; }
+        public ObjectId Id { get; set; }
     }
+    #endregion
 }

--- a/aspnetcore/mvc/models/model-binding/samples/3.x/ModelBindingSample/Models/ModelWithObjectId.cs
+++ b/aspnetcore/mvc/models/model-binding/samples/3.x/ModelBindingSample/Models/ModelWithObjectId.cs
@@ -1,0 +1,7 @@
+namespace ModelBindingSample.Models
+{
+    public class ModelWithObjectId
+    {
+        public ObjectId ObjectId { get; set; }
+    }
+}

--- a/aspnetcore/mvc/models/model-binding/samples/3.x/ModelBindingSample/Models/ObjectId.cs
+++ b/aspnetcore/mvc/models/model-binding/samples/3.x/ModelBindingSample/Models/ObjectId.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+using ModelBindingSample.Converters;
+
+namespace ModelBindingSample.Models
+{
+    [JsonConverter(typeof(ObjectIdConverter))]
+    public struct ObjectId
+    {
+        public ObjectId(int id) =>
+            Id = id;
+
+        public int Id { get; }
+    }
+}

--- a/aspnetcore/mvc/models/model-binding/samples/3.x/ModelBindingSample/Models/ObjectId.cs
+++ b/aspnetcore/mvc/models/model-binding/samples/3.x/ModelBindingSample/Models/ObjectId.cs
@@ -3,6 +3,7 @@ using ModelBindingSample.Converters;
 
 namespace ModelBindingSample.Models
 {
+    #region snippet_Class
     [JsonConverter(typeof(ObjectIdConverter))]
     public struct ObjectId
     {
@@ -11,4 +12,5 @@ namespace ModelBindingSample.Models
 
         public int Id { get; }
     }
+    #endregion
 }

--- a/aspnetcore/mvc/models/model-binding/samples/3.x/ModelBindingSample/Startup.cs
+++ b/aspnetcore/mvc/models/model-binding/samples/3.x/ModelBindingSample/Startup.cs
@@ -43,6 +43,7 @@ namespace ModelBindingSample
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapRazorPages();
+                endpoints.MapControllers();
             });
         }
     }


### PR DESCRIPTION
Fixes #15705.

[Customize model binding with input formatters](https://review.docs.microsoft.com/en-us/aspnet/core/mvc/models/model-binding?view=aspnetcore-3.1&branch=pr-en-us-16261#customize-model-binding-with-input-formatters)