### PR TITLE
Update docker-https.md

### DIFF
--- a/aspnetcore/security/docker-https.md
+++ b/aspnetcore/security/docker-https.md
@@ -26,7 +26,7 @@ The [.NET Core 2.2 SDK](https://www.microsoft.com/net/download) or later is requ
 
 ## Certificates
 
-A certificate from a [certificate authority](https://en.wikipedia.org/wiki/Certificate_authority) is required for [production hosting](https://blogs.msdn.microsoft.com/webdev/2017/11/29/configuring-https-in-asp-net-core-across-different-platforms/) for a domain.  [Let's Encrypt](https://letsencrypt.org/) is a certificate authority that offers free certificates.
+A certificate from a [certificate authority](https://en.wikipedia.org/wiki/Certificate_authority) is required for [production hosting](https://blogs.msdn.microsoft.com/webdev/2017/11/29/configuring-https-in-asp-net-core-across-different-platforms/) for a domain.  [`Let's Encrypt`](https://letsencrypt.org/) is a certificate authority that offers free certificates.
 
 This document uses [self-signed development certificates](https://en.wikipedia.org/wiki/Self-signed_certificate) for hosting pre-built images over `localhost`. The instructions are similar to using production certificates.
 

--- a/aspnetcore/security/docker-https.md
+++ b/aspnetcore/security/docker-https.md
@@ -6,6 +6,7 @@ monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
 ms.date: 07/05/2019
+no-loc: ["Let's Encrypt"]
 uid: security/docker-https
 ---
 # Hosting ASP.NET Core images with Docker over HTTPS
@@ -26,7 +27,7 @@ The [.NET Core 2.2 SDK](https://www.microsoft.com/net/download) or later is requ
 
 ## Certificates
 
-A certificate from a [certificate authority](https://en.wikipedia.org/wiki/Certificate_authority) is required for [production hosting](https://blogs.msdn.microsoft.com/webdev/2017/11/29/configuring-https-in-asp-net-core-across-different-platforms/) for a domain.  [`Let's Encrypt`](https://letsencrypt.org/) is a certificate authority that offers free certificates.
+A certificate from a [certificate authority](https://wikipedia.org/wiki/Certificate_authority) is required for [production hosting](https://blogs.msdn.microsoft.com/webdev/2017/11/29/configuring-https-in-asp-net-core-across-different-platforms/) for a domain. [Let's Encrypt](https://letsencrypt.org/) is a certificate authority that offers free certificates.
 
 This document uses [self-signed development certificates](https://en.wikipedia.org/wiki/Self-signed_certificate) for hosting pre-built images over `localhost`. The instructions are similar to using production certificates.
 
@@ -35,7 +36,7 @@ For production certs:
 * The `dotnet dev-certs` tool is not required.
 * Certificates do not need to be stored in the location used in the instructions. Any location should work, although storing certs within your site directory is not recommended.
 
-The instructions volume mount certificates into containers. You can add certificates into container images with a `COPY` command in a Dockerfile. Copying certificates into an image is not recommended:
+The instructions volume mount certificates into containers. You can add certificates into container images with a `COPY` command in a *Dockerfile*. Copying certificates into an image isn't recommended for the following reasons:
 
 * It makes difficult to use the same image for testing with developer certificates.
 * It makes difficult to use the same image for Hosting with production certificates.


### PR DESCRIPTION
`[Let's Encrypt]` --> ``[`Let's Encrypt`]``

It's translated in other languages. Add backticks can keep it.

