### PR TITLE
Customizing the view search path for View Components.

### DIFF
--- a/aspnetcore/mvc/views/view-components.md
+++ b/aspnetcore/mvc/views/view-components.md
@@ -82,11 +82,11 @@ The default view name for a view component is *Default*, which means your view f
 
 We recommend you name the view file *Default.cshtml* and use the *Views/Shared/Components/{View Component Name}/{View Name}* path. The `PriorityList` view component used in this sample uses *Views/Shared/Components/PriorityList/Default.cshtml* for the view component view.
 
-### Customizing the view search path
+### Customize the view search path
 
 To customize the view search path, modify Razor's `ViewLocationFormats` collection. For example, to search for views within the path "/Components/{View Component Name}/{View Name}", add a new item to the collection:
 
-[!code-cshtml[](view-components/samples_snapshot/2.x/Startup.cs?name=snippet_ViewLocationFormats&highlight=4)]
+[!code-cs[](view-components/samples_snapshot/2.x/Startup.cs?name=snippet_ViewLocationFormats&highlight=4)]
 
 In the preceding code, the placeholder "{0}" represents the path "Components/{View Component Name}/{View Name}". For more information, see <xref:Microsoft.AspNetCore.Mvc.Razor.RazorViewEngineOptions.ViewLocationFormats>.
 

--- a/aspnetcore/mvc/views/view-components.md
+++ b/aspnetcore/mvc/views/view-components.md
@@ -84,11 +84,11 @@ We recommend you name the view file *Default.cshtml* and use the *Views/Shared/C
 
 ### Customize the view search path
 
-To customize the view search path, modify Razor's `ViewLocationFormats` collection. For example, to search for views within the path "/Components/{View Component Name}/{View Name}", add a new item to the collection:
+To customize the view search path, modify Razor's <xref:Microsoft.AspNetCore.Mvc.Razor.RazorViewEngineOptions.ViewLocationFormats> collection. For example, to search for views within the path "/Components/{View Component Name}/{View Name}", add a new item to the collection:
 
 [!code-cs[](view-components/samples_snapshot/2.x/Startup.cs?name=snippet_ViewLocationFormats&highlight=4)]
 
-In the preceding code, the placeholder "{0}" represents the path "Components/{View Component Name}/{View Name}". For more information, see <xref:Microsoft.AspNetCore.Mvc.Razor.RazorViewEngineOptions.ViewLocationFormats>.
+In the preceding code, the placeholder "{0}" represents the path "Components/{View Component Name}/{View Name}".
 
 ## Invoking a view component
 

--- a/aspnetcore/mvc/views/view-components.md
+++ b/aspnetcore/mvc/views/view-components.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn how view components are used in ASP.NET Core and how to add them to apps.
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/14/2019
+ms.date: 12/18/2019
 uid: mvc/views/view-components
 ---
 # View components in ASP.NET Core
@@ -81,6 +81,14 @@ The search path applies to projects using controllers + views and Razor Pages.
 The default view name for a view component is *Default*, which means your view file will typically be named *Default.cshtml*. You can specify a different view name when creating the view component result or when calling the `View` method.
 
 We recommend you name the view file *Default.cshtml* and use the *Views/Shared/Components/{View Component Name}/{View Name}* path. The `PriorityList` view component used in this sample uses *Views/Shared/Components/PriorityList/Default.cshtml* for the view component view.
+
+### Customizing the view search path
+
+To customize the view search path, modify Razor's `ViewLocationFormats` collection. For example, to search for views within the path "/Components/{View Component Name}/{View Name}", add a new item to the collection:
+
+[!code-cshtml[](view-components/samples_snapshot/2.x/Startup.cs?name=snippet_ViewLocationFormats&highlight=4)]
+
+In the preceding code, the placeholder "{0}" represents the path "Components/{View Component Name}/{View Name}". For more information, see <xref:Microsoft.AspNetCore.Mvc.Razor.RazorViewEngineOptions.ViewLocationFormats>.
 
 ## Invoking a view component
 

--- a/aspnetcore/mvc/views/view-components/samples_snapshot/2.x/Startup.cs
+++ b/aspnetcore/mvc/views/view-components/samples_snapshot/2.x/Startup.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SampleApp
+{
+    public class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            #region snippet_ViewLocationFormats
+            services.AddMvc()
+                .AddRazorOptions(options =>
+                {
+                    options.ViewLocationFormats.Add("/{0}.cshtml");
+                })
+                .SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+            #endregion
+        }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                app.UseExceptionHandler("/Home/Error");
+            }
+
+            app.UseHttpsRedirection();
+            app.UseStaticFiles();
+
+            app.UseMvcWithDefaultRoute();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #10385.

The topic itself needs some future work:

* 3.1 update.
* There are a few e.g. 1.1 monikers that need cleaning up.
* The current description of the view search path is incomplete. With RP, the page's path is also traversed segment by segment.

These are just points I've noted in passing. I won't address them as part of this PR.