### PR TITLE
Add missing space to code sample

### DIFF
--- a/aspnetcore/host-and-deploy/proxy-load-balancer.md
+++ b/aspnetcore/host-and-deploy/proxy-load-balancer.md
@@ -320,7 +320,7 @@ app.Run(async (context) =>
         $"Request Path: {context.Request.Path}{Environment.NewLine}");
 
     // Headers
-    await context.Response.WriteAsync($"Request Headers:{Environment.NewLine}");
+    await context.Response.WriteAsync($"Request Headers: {Environment.NewLine}");
 
     foreach (var header in context.Request.Headers)
     {


### PR DESCRIPTION
Would work without the space, but all the other samples have 1, so why not?