### PR TITLE
Adding a note for a common configuration error in cert Auth

### DIFF
--- a/aspnetcore/security/authentication/certauth.md
+++ b/aspnetcore/security/authentication/certauth.md
@@ -4,7 +4,7 @@ author: blowdart
 description: Learn how to configure certificate authentication in ASP.NET Core for IIS and HTTP.sys.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: bdorrans
-ms.date: 12/09/2019
+ms.date: 01/02/2020
 uid: security/authentication/certauth
 ---
 # Configure certificate authentication in ASP.NET Core
@@ -373,7 +373,7 @@ Export-Certificate -Cert cert:\localMachine\my\"The thumbprint..." -FilePath roo
 ```
 
 > [!NOTE]
-> The -DnsName parameter must match the deployment target of the application, for example "localhost" for development.
+> The `-DnsName` parameter must match the deployment target of the app. For example, "localhost" for development.
 
 #### Install in the trusted root
 

--- a/aspnetcore/security/authentication/certauth.md
+++ b/aspnetcore/security/authentication/certauth.md
@@ -372,6 +372,9 @@ Get-ChildItem -Path cert:\localMachine\my\"The thumbprint..." | Export-PfxCertif
 Export-Certificate -Cert cert:\localMachine\my\"The thumbprint..." -FilePath root_ca_dev_damienbod.crt
 ```
 
+> [!NOTE]
+> The -DnsName parameter must match the deployment target of the application, for example "localhost" for development.
+
 #### Install in the trusted root
 
 The root certificate needs to be trusted on your host system. A root certificate which was not created by a certificate authority won't be trusted by default. The following link explains how this can be accomplished on Windows:

--- a/aspnetcore/security/authentication/certauth.md
+++ b/aspnetcore/security/authentication/certauth.md
@@ -373,7 +373,7 @@ Export-Certificate -Cert cert:\localMachine\my\"The thumbprint..." -FilePath roo
 ```
 
 > [!NOTE]
-> The `-DnsName` parameter must match the deployment target of the app. For example, "localhost" for development.
+> The `-DnsName` parameter value must match the deployment target of the app. For example, "localhost" for development.
 
 #### Install in the trusted root
 


### PR DESCRIPTION
A lot of cert auth errors are caused by incorrect DNS. Just added a note to the docs for this