### PR TITLE
Adding HttpClient examples to send the certificate (cert_auth.md)

### DIFF
--- a/aspnetcore/security/authentication/certauth.md
+++ b/aspnetcore/security/authentication/certauth.md
@@ -230,7 +230,7 @@ The `AddCertificateForwarding` method is used to specify:
 * The client header name.
 * How the certificate is to be loaded (using the `HeaderConverter` property).
 
-In custom web proxies, the certificate is passed as a custom request header for example `X-SSL-CERT`. To use it, configure certificate forwarding in `Startup.ConfigureServices`:
+In custom web proxies, the certificate is passed as a custom request header, for example `X-SSL-CERT`. To use it, configure certificate forwarding in `Startup.ConfigureServices`:
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)

--- a/aspnetcore/security/authentication/certauth.md
+++ b/aspnetcore/security/authentication/certauth.md
@@ -389,49 +389,6 @@ private async Task<JsonDocument> GetApiDataWithNamedClient()
 }
 ```
 
-#### Implement an HttpClient using a certificate and the X-ARR-ClientCert HTTP Header
-
-The web API client uses an `HttpClient`, which was created using an `IHttpClientFactory` instance. This doesn't provide a way to define a handler for the `HttpClient`, so use an `HttpRequestMessage` to add the certificate to the `X-ARR-ClientCert` request header. The certificate is added as a string using the `GetRawCertDataString` method. 
-
-```csharp
-private async Task<JsonDocument> GetApiDataAsync()
-{
-    try
-    {
-        // Do not hardcode passwords in production code
-        // Use thumbprint or key vault
-        var cert = new X509Certificate2(
-            Path.Combine(_environment.ContentRootPath, 
-                "sts_dev_cert.pfx"), "1234");
-        var client = _clientFactory.CreateClient();
-        var request = new HttpRequestMessage()
-        {
-            RequestUri = new Uri("https://localhost:44379/api/values"),
-            Method = HttpMethod.Get,
-        };
-
-        request.Headers.Add("X-ARR-ClientCert", cert.GetRawCertDataString());
-        var response = await client.SendAsync(request);
-
-        if (response.IsSuccessStatusCode)
-        {
-            var responseContent = await response.Content.ReadAsStringAsync();
-            var data = JsonDocument.Parse(responseContent);
-
-            return data;
-        }
-
-        throw new ApplicationException(
-            $"Status code: {response.StatusCode}, " +
-            $"Error: {response.ReasonPhrase}");
-    }
-    catch (Exception e)
-    {
-        throw new ApplicationException($"Exception {e}");
-    }
-}
-```
-
 If the correct certificate is sent to the server, the data is returned. If no certificate or the wrong certificate is sent, an HTTP 403 status code is returned.
 
 ### Create certificates in PowerShell

--- a/aspnetcore/security/authentication/certauth.md
+++ b/aspnetcore/security/authentication/certauth.md
@@ -223,6 +223,9 @@ See the [host and deploy documentation](xref:host-and-deploy/proxy-load-balancer
 
 No forwarding configuration is required for Azure. This is already setup in the certificate forwarding middleware.
 
+> [!NOTE]
+> This requires that the CertificateForwardingMiddleware is present.
+
 ### Use certificate authentication in custom web proxies
 
 The `AddCertificateForwarding` method is used to specify:

--- a/aspnetcore/security/authentication/certauth.md
+++ b/aspnetcore/security/authentication/certauth.md
@@ -240,26 +240,13 @@ public void ConfigureServices(IServiceCollection services)
 	    
             if(!string.IsNullOrWhiteSpace(headerValue))
             {
-                byte[] bytes = StringToByteArray(headerValue);
+                byte[] bytes = Convert.FromBase64String(headerValue); 
                 clientCertificate = new X509Certificate2(bytes);
             }
 
             return clientCertificate;
         };
     });
-}
-
-private static byte[] StringToByteArray(string hex)
-{
-    int NumberChars = hex.Length;
-    byte[] bytes = new byte[NumberChars / 2];
-
-    for (int i = 0; i < NumberChars; i += 2)
-    {
-        bytes[i / 2] = Convert.ToByte(hex.Substring(i, 2), 16);
-    }
-
-    return bytes;
 }
 ```
 

--- a/aspnetcore/security/authentication/certauth.md
+++ b/aspnetcore/security/authentication/certauth.md
@@ -234,18 +234,6 @@ public void ConfigureServices(IServiceCollection services)
     services.AddCertificateForwarding(options =>
     {
         options.CertificateHeader = "X-ARR-ClientCert";
-        options.HeaderConverter = (headerValue) =>
-        {
-            X509Certificate2 clientCertificate = null;
-	    
-            if(!string.IsNullOrWhiteSpace(headerValue))
-            {
-                byte[] bytes = Convert.FromBase64String(headerValue); 
-                clientCertificate = new X509Certificate2(bytes);
-            }
-
-            return clientCertificate;
-        };
     });
 }
 ```

--- a/aspnetcore/security/authentication/certauth.md
+++ b/aspnetcore/security/authentication/certauth.md
@@ -311,7 +311,85 @@ namespace AspNetCoreCertificateAuthApi
 }
 ```
 
-#### Implement an HttpClient using a certificate
+#### Implement an HttpClient using a certificate and the HttpClientHandler
+
+The HttpClientHandler could be added directly in the constructor of the HttpClient class. Care should be taken when creating instances of the HttpClient. The HttpClient will then send the certificate with each request.
+
+```csharp
+private async Task<JsonDocument> GetApiDataUsingHttpClientHandler()
+{
+    var cert = new X509Certificate2(Path.Combine(_environment.ContentRootPath, "sts_dev_cert.pfx"), "1234");
+    var handler = new HttpClientHandler();
+    handler.ClientCertificates.Add(cert);
+    var client = new HttpClient(handler);
+     
+    var request = new HttpRequestMessage()
+    {
+        RequestUri = new Uri("https://localhost:44379/api/values"),
+        Method = HttpMethod.Get,
+    };
+    var response = await client.SendAsync(request);
+    if (response.IsSuccessStatusCode)
+    {
+        var responseContent = await response.Content.ReadAsStringAsync();
+        var data = JsonDocument.Parse(responseContent);
+        return data;
+    }
+ 
+    throw new ApplicationException($"Status code: {response.StatusCode}, Error: {response.ReasonPhrase}");
+}
+```
+
+#### Implement an HttpClient using a certificate and a named HttpClient from IHttpClientFactory 
+
+In the following example, a client certificate is added to a HttpClientHandler using the ClientCertificates property from the handler. This handler can then be used in a named instance of a HttpClient using the ConfigurePrimaryHttpMessageHandler method. This is setup in the Startup class in the
+ConfigureServices method.
+
+```csharp
+var clientCertificate = 
+    new X509Certificate2(
+      Path.Combine(_environment.ContentRootPath, "sts_dev_cert.pfx"), "1234");
+ 
+var handler = new HttpClientHandler();
+handler.ClientCertificates.Add(clientCertificate);
+ 
+services.AddHttpClient("namedClient", c =>
+{
+}).ConfigurePrimaryHttpMessageHandler(() => handler);
+```
+
+The IHttpClientFactory can then be used to get the named instance with the handler and the certificate. The CreateClient method with the name of the client defined in the Startup class is used to get the instance. The HTTP request can be sent using the client as required.
+
+```csharp
+private readonly IHttpClientFactory _clientFactory;
+ 
+public ApiService(IHttpClientFactory clientFactory)
+{
+    _clientFactory = clientFactory;
+}
+ 
+private async Task<JsonDocument> GetApiDataWithNamedClient()
+{
+    var client = _clientFactory.CreateClient("namedClient");
+ 
+    var request = new HttpRequestMessage()
+    {
+        RequestUri = new Uri("https://localhost:44379/api/values"),
+        Method = HttpMethod.Get,
+    };
+    var response = await client.SendAsync(request);
+    if (response.IsSuccessStatusCode)
+    {
+        var responseContent = await response.Content.ReadAsStringAsync();
+        var data = JsonDocument.Parse(responseContent);
+        return data;
+    }
+ 
+    throw new ApplicationException($"Status code: {response.StatusCode}, Error: {response.ReasonPhrase}");
+}
+```
+
+#### Implement an HttpClient using a certificate and the X-ARR-ClientCert HTTP Header
 
 The web API client uses an `HttpClient`, which was created using an `IHttpClientFactory` instance. This doesn't provide a way to define a handler for the `HttpClient`, so use an `HttpRequestMessage` to add the certificate to the `X-ARR-ClientCert` request header. The certificate is added as a string using the `GetRawCertDataString` method. 
 


### PR DESCRIPTION
Added HttpClient examples, showing different ways to send the certificate in a HttpClient request
Fixes #15974