### PR TITLE
update(scale-out): docs for redis backplane

### DIFF
--- a/aspnetcore/signalr/scale.md
+++ b/aspnetcore/signalr/scale.md
@@ -84,7 +84,10 @@ The Redis backplane is the recommended scale-out approach for apps hosted on you
 
 The Azure SignalR Service advantages noted earlier are disadvantages for the Redis backplane:
 
-* Sticky sessions, also known as [client affinity](/iis/extensions/configuring-application-request-routing-arr/http-load-balancing-using-application-request-routing#step-3---configure-client-affinity), is required; unless all clients are configured to **only** use WebSockets, **and** the [SkipNegotiation setting](xref:signalr/configuration#configure-additional-options) is enabled in the client configuration. Once a connection is initiated on a server, the connection has to stay on that server.
+* Sticky sessions, also known as [client affinity](/iis/extensions/configuring-application-request-routing-arr/http-load-balancing-using-application-request-routing#step-3---configure-client-affinity), is required, except when:
+  * All clients are configured to **only** use WebSockets.
+  * The [SkipNegotiation setting](xref:signalr/configuration#configure-additional-options) is enabled in the client configuration. 
+   Once a connection is initiated on a server, the connection has to stay on that server.
 * A SignalR app must scale out based on number of clients even if few messages are being sent.
 * A SignalR app uses significantly more connection resources than a web app without SignalR.
 

--- a/aspnetcore/signalr/scale.md
+++ b/aspnetcore/signalr/scale.md
@@ -84,7 +84,7 @@ The Redis backplane is the recommended scale-out approach for apps hosted on you
 
 The Azure SignalR Service advantages noted earlier are disadvantages for the Redis backplane:
 
-* Sticky sessions, also known as [client affinity](/iis/extensions/configuring-application-request-routing-arr/http-load-balancing-using-application-request-routing#step-3---configure-client-affinity), is required, except when:
+* Sticky sessions, also known as [client affinity](/iis/extensions/configuring-application-request-routing-arr/http-load-balancing-using-application-request-routing#step-3---configure-client-affinity), is required, except when **both** of the below are true:
   * All clients are configured to **only** use WebSockets.
   * The [SkipNegotiation setting](xref:signalr/configuration#configure-additional-options) is enabled in the client configuration. 
    Once a connection is initiated on a server, the connection has to stay on that server.

--- a/aspnetcore/signalr/scale.md
+++ b/aspnetcore/signalr/scale.md
@@ -84,7 +84,7 @@ The Redis backplane is the recommended scale-out approach for apps hosted on you
 
 The Azure SignalR Service advantages noted earlier are disadvantages for the Redis backplane:
 
-* Sticky sessions, also known as [client affinity](/iis/extensions/configuring-application-request-routing-arr/http-load-balancing-using-application-request-routing#step-3---configure-client-affinity), is required. Once a connection is initiated on a server, the connection has to stay on that server.
+* Sticky sessions, also known as [client affinity](/iis/extensions/configuring-application-request-routing-arr/http-load-balancing-using-application-request-routing#step-3---configure-client-affinity), is required; unless all clients are configured to **only** use WebSockets, **and** the [SkipNegotiation setting](xref:signalr/configuration#configure-additional-options) is enabled in the client configuration. Once a connection is initiated on a server, the connection has to stay on that server.
 * A SignalR app must scale out based on number of clients even if few messages are being sent.
 * A SignalR app uses significantly more connection resources than a web app without SignalR.
 

--- a/aspnetcore/signalr/scale.md
+++ b/aspnetcore/signalr/scale.md
@@ -84,7 +84,7 @@ The Redis backplane is the recommended scale-out approach for apps hosted on you
 
 The Azure SignalR Service advantages noted earlier are disadvantages for the Redis backplane:
 
-* Sticky sessions, also known as [client affinity](/iis/extensions/configuring-application-request-routing-arr/http-load-balancing-using-application-request-routing#step-3---configure-client-affinity), is required, except when **both** of the below are true:
+* Sticky sessions, also known as [client affinity](/iis/extensions/configuring-application-request-routing-arr/http-load-balancing-using-application-request-routing#step-3---configure-client-affinity), is required, except when **both** of the following are true:
   * All clients are configured to **only** use WebSockets.
   * The [SkipNegotiation setting](xref:signalr/configuration#configure-additional-options) is enabled in the client configuration. 
    Once a connection is initiated on a server, the connection has to stay on that server.


### PR DESCRIPTION
The sticky session was a little bit vague so that one might think even if they use just WebSocket for all the clients and turn off negotiations on clients, and use Redis backplane they still might need "sticky sessions". There was a clarification by @davidfowl [here](https://twitter.com/davidfowl/status/1212068926676275202?s=20)



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->