### PR TITLE
Updated broken link for VS for Mac / Azure publish

### DIFF
--- a/aspnetcore/tutorials/publish-to-azure-webapp-using-vs.md
+++ b/aspnetcore/tutorials/publish-to-azure-webapp-using-vs.md
@@ -17,7 +17,7 @@ By [Rick Anderson](https://twitter.com/RickAndMSFT)
 ::: moniker-end
 
 
-See [Publish to Azure from Visual Studio for Mac](https://blog.xamarin.com/publish-azure-visual-studio-mac/) if you are working on macOS.
+See [Publish to Azure from Visual Studio for Mac](https://devblogs.microsoft.com/xamarin/publish-azure-visual-studio-mac/) if you are working on macOS.
 
 To troubleshoot an App Service deployment issue, see <xref:test/troubleshoot-azure-iis>.
 


### PR DESCRIPTION
Fixes broken link to blog post about Azure publish. Link broken due to Xamarin blog migration.