### PR TITLE
[SignalR] Update to streaming sample

### DIFF
--- a/aspnetcore/signalr/streaming/samples/3.0/Hubs/AsyncEnumerableHub.cs
+++ b/aspnetcore/signalr/streaming/samples/3.0/Hubs/AsyncEnumerableHub.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
@@ -11,6 +12,7 @@ namespace SignalRChat.Hubs
         public async IAsyncEnumerable<int> Counter(
             int count,
             int delay,
+            [EnumeratorCancellation]
             CancellationToken cancellationToken)
         {
             for (var i = 0; i < count; i++)

--- a/aspnetcore/signalr/streaming/samples/3.0/Hubs/StreamHub.cs
+++ b/aspnetcore/signalr/streaming/samples/3.0/Hubs/StreamHub.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -31,7 +30,6 @@ namespace SignalRChat.Hubs
             ChannelWriter<int> writer,
             int count,
             int delay,
-            [EnumeratorCancellation]
             CancellationToken cancellationToken)
         {
             Exception localException = null;

--- a/aspnetcore/signalr/streaming/samples/3.0/Hubs/StreamHub.cs
+++ b/aspnetcore/signalr/streaming/samples/3.0/Hubs/StreamHub.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -30,6 +31,7 @@ namespace SignalRChat.Hubs
             ChannelWriter<int> writer,
             int count,
             int delay,
+            [EnumeratorCancellation]
             CancellationToken cancellationToken)
         {
             Exception localException = null;


### PR DESCRIPTION
Adds the EnumeratorCancellationAttribute to the sample to prevent warnings when users add CancellationTokens. It also allows the server-side code to use `await foreach` with cancellation (i.e. in unit tests).

Fixes #16202

[Internal Review Link](https://review.docs.microsoft.com/en-us/aspnet/core/signalr/streaming?view=aspnetcore-3.0)