### PR TITLE
gRPC Channel is disposed of after use

### DIFF
--- a/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/Program.cs
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/Program.cs
@@ -13,13 +13,10 @@ namespace GrpcGreeterClient
         static async Task Main(string[] args)
         {
             // The port number(5001) must match the port of the gRPC server.
-            var channel = GrpcChannel.ForAddress("https://localhost:5001");
+            using var channel = GrpcChannel.ForAddress("https://localhost:5001");
             var client =  new Greeter.GreeterClient(channel);
             var reply = await client.SayHelloAsync(
                               new HelloRequest { Name = "GreeterClient" });
-
-            channel.Dispose();
-
             Console.WriteLine("Greeting: " + reply.Message);
             Console.WriteLine("Press any key to exit...");
             Console.ReadKey();

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/Program.cs
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/Program.cs
@@ -17,6 +17,9 @@ namespace GrpcGreeterClient
             var client =  new Greeter.GreeterClient(channel);
             var reply = await client.SayHelloAsync(
                               new HelloRequest { Name = "GreeterClient" });
+
+            channel.Dispose();
+
             Console.WriteLine("Greeting: " + reply.Message);
             Console.WriteLine("Press any key to exit...");
             Console.ReadKey();


### PR DESCRIPTION
In the sample snippet code in page [gRPC services with C#](https://docs.microsoft.com/en-us/aspnet/core/grpc/basics?view=aspnetcore-3.1):

```csharp
static async Task Main(string[] args)
{
    // The port number(5001) must match the port of the gRPC server.
    var channel = GrpcChannel.ForAddress("https://localhost:5001");
    var client =  new Greeter.GreeterClient(channel);
    var reply = await client.SayHelloAsync(
                      new HelloRequest { Name = "GreeterClient" });
    Console.WriteLine("Greeting: " + reply.Message);
    Console.WriteLine("Press any key to exit...");
    Console.ReadKey();
}
```

the gRPC channel `channel` instance is not disposed of. It should be, as `Grpc.Net.Client.GrpcChannel` is a `IDisposable` resource.

This PR fixes this, adding a call to `Dispose()`:

```csharp
static async Task Main(string[] args)
{
    // The port number(5001) must match the port of the gRPC server.
    var channel = GrpcChannel.ForAddress("https://localhost:5001");
    var client =  new Greeter.GreeterClient(channel);
    var reply = await client.SayHelloAsync(
                      new HelloRequest { Name = "GreeterClient" });
    channel.Dispose();

    Console.WriteLine("Greeting: " + reply.Message);
    Console.WriteLine("Press any key to exit...");
    Console.ReadKey();
}
```

I think it's less cumbersome than a `using` statement:

```csharp
static async Task Main(string[] args)
{
    // The port number(5001) must match the port of the gRPC server.
    using(var channel = GrpcChannel.ForAddress("https://localhost:5001"))
    {
        var client =  new Greeter.GreeterClient(channel);
        var reply = await client.SayHelloAsync(
                          new HelloRequest { Name = "GreeterClient" });
        Console.WriteLine("Greeting: " + reply.Message);
        Console.WriteLine("Press any key to exit...");
        Console.ReadKey();
    }
}
```
