### PR TITLE
change component devlang to cshtml

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-3.1.md
+++ b/aspnetcore/release-notes/aspnetcore-3.1.md
@@ -30,7 +30,7 @@ Blazor Server apps can now pass parameters to top-level components during the in
 
 For example, prerender a `Counter` component with an increment amount (`IncrementAmount`):
 
-```razor
+```cshtml
 <component type="typeof(Counter)" render-mode="ServerPrerendered" 
     param-IncrementAmount="10" />
 ```


### PR DESCRIPTION
The Component Tag Helper will be used within a CSHTML file. Updating the devlang from `razor` to `cshtml`.