### PR TITLE
fix missing header in pre-3.0 version of signalr tutorial

### DIFF
--- a/aspnetcore/tutorials/signalr-typescript-webpack.md
+++ b/aspnetcore/tutorials/signalr-typescript-webpack.md
@@ -264,6 +264,8 @@ Confirm that the app works with the following steps.
 
 ::: moniker range="< aspnetcore-3.0"
 
+## Prerequisites
+
 # [Visual Studio](#tab/visual-studio)
 
 * [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019) with the **ASP.NET and web development** workload


### PR DESCRIPTION
Noticed this while doing a check over some SignalR docs :). If you go to https://docs.microsoft.com/en-us/aspnet/core/tutorials/signalr-typescript-webpack and toggle the version selector to a version below 3.0, the `Prerequisites` header just disappears :). It wasn't duplicated when the doc was duplicated across monikers.