### PR TITLE
Updated prereq to standard 3.1 install include link.

### DIFF
--- a/aspnetcore/getting-started/index.md
+++ b/aspnetcore/getting-started/index.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: A short tutorial that creates and runs a basic Hello World app using ASP.NET Core. 
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/22/2019
+ms.date: 01/07/2020
 uid: getting-started
 ---
 # Tutorial: Get started with ASP.NET Core
@@ -25,7 +25,7 @@ At the end, you'll have a working web app running on your local machine.
 
 ## Prerequisites
 
-[!INCLUDE[](~/includes/3.0-SDK.md)]
+[!INCLUDE[](~/includes/3.1-SDK.md)]
 
 ## Create a web app project
 
@@ -64,7 +64,7 @@ dotnet dev-certs https --trust
 
 The preceding command displays the following message:
 
-*Trusting the HTTPS development certificate was requested. If the certificate is not already trusted we will run the following command:* `'sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain <<certificate>>'`
+*Trusting the HTTPS development certificate was requested. If the certificate is not already trusted, we will run the following command:* `'sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain <<certificate>>'`
 
 This command might prompt you for your password to install the certificate on the system keychain. Enter your password if you agree to trust the development certificate.
 
@@ -93,7 +93,7 @@ Open *Pages/Index.cshtml* and modify and save the page with the following highli
 
 [!code-cshtml[](sample/index.cshtml?highlight=9)]
 
-Browse to [https://localhost:5001](https://localhost:5001), refresh the page and verify the changes are displayed.
+Browse to [https://localhost:5001](https://localhost:5001), refresh the page, and verify the changes are displayed.
 
 ## Next steps
 


### PR DESCRIPTION
[Internal Review](https://review.docs.microsoft.com/en-us/aspnet/core/getting-started/index?view=aspnetcore-1.0&branch=pr-en-us-16453)

Fixes #16450 

Updated prereq section to use standard 3.1 install include link and retested the topic instructions with 3.1.