### PR TITLE
Removed preview channel note

### DIFF
--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -78,7 +78,7 @@ Get started with Blazor:
 
    # [Visual Studio for Mac](#tab/visual-studio-mac)
 
-   1\. Install [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/). Switch the [Update channel to Preview](/visualstudio/mac/install-preview).
+   1\. Install [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/).
 
    2\. Select **File** > **New Solution** or create a **New Project**.
 


### PR DESCRIPTION
There is no need to switch to the preview channel on Mac as VS for Mac uses 8.4 as of 8th Jan 2020.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->