### PR TITLE
Host and deploy crosslink updates

### DIFF
--- a/aspnetcore/host-and-deploy/aspnet-core-module.md
+++ b/aspnetcore/host-and-deploy/aspnet-core-module.md
@@ -5,7 +5,7 @@ description: Learn how to configure the ASP.NET Core Module for hosting ASP.NET 
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/07/2019
+ms.date: 01/13/2020
 uid: host-and-deploy/aspnet-core-module
 ---
 # ASP.NET Core Module
@@ -1040,5 +1040,6 @@ The files can be found by searching for *aspnetcore* in the *applicationHost.con
 ## Additional resources
 
 * <xref:host-and-deploy/iis/index>
-* [ASP.NET Core Module GitHub repository (reference source)](https://github.com/aspnet/AspNetCoreModule)
+* <xref:host-and-deploy/azure-apps/index>
+* [ASP.NET Core Module reference source (master branch)](https://github.com/dotnet/aspnetcore/tree/master/src/Servers/IIS/AspNetCoreModuleV2) &ndash; Use the **Branch** drop down list to select a specific release (for example, `release/3.1`).
 * <xref:host-and-deploy/iis/modules>

--- a/aspnetcore/host-and-deploy/iis/development-time-iis-support.md
+++ b/aspnetcore/host-and-deploy/iis/development-time-iis-support.md
@@ -5,7 +5,7 @@ description: Discover support for debugging ASP.NET Core apps when running with 
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/26/2019
+ms.date: 01/13/2020
 uid: host-and-deploy/iis/development-time-iis-support
 ---
 # Development-time IIS support in Visual Studio for ASP.NET Core
@@ -146,6 +146,4 @@ If an untrusted development certificate is used, the browser may require you to 
 ## Additional resources
 
 * [Getting Started with the IIS Manager in IIS](/iis/get-started/getting-started-with-iis/getting-started-with-the-iis-manager-in-iis-7-and-iis-8)
-* <xref:host-and-deploy/iis/index>
-* <xref:host-and-deploy/aspnet-core-module>
 * <xref:security/enforcing-ssl>

--- a/aspnetcore/host-and-deploy/iis/index.md
+++ b/aspnetcore/host-and-deploy/iis/index.md
@@ -5,7 +5,7 @@ description: Learn how to host ASP.NET Core apps on Windows Server Internet Info
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 01/06/2020
+ms.date: 01/13/2020
 uid: host-and-deploy/iis/index
 ---
 # Host ASP.NET Core on Windows with IIS
@@ -765,26 +765,14 @@ To prevent apps hosted [out-of-process](#out-of-process-hosting-model) from timi
 
 ## Deployment resources for IIS administrators
 
-Learn about IIS in-depth in the IIS documentation.  
-[IIS documentation](/iis)
-
-Learn about .NET Core app deployment models.  
-[.NET Core application deployment](/dotnet/core/deploying/)
-
-Learn about the ASP.NET Core Module, including configuration guidance.  
-<xref:host-and-deploy/aspnet-core-module>
-
-Learn about the directory structure of published ASP.NET Core apps.  
-[Directory structure](xref:host-and-deploy/directory-structure)
-
-Discover active and inactive IIS modules for ASP.NET Core apps and how to manage IIS modules.  
-[IIS modules](xref:host-and-deploy/iis/modules)
-
-Learn how to diagnose problems with IIS deployments of ASP.NET Core apps.  
-[Troubleshoot](xref:test/troubleshoot-azure-iis)
-
-Distinguish common errors when hosting ASP.NET Core apps on IIS.  
-[Common errors reference for Azure App Service and IIS](xref:host-and-deploy/azure-iis-errors-reference)
+* [Learn about IIS in-depth in the IIS documentation](/iis)
+* [Getting Started with the IIS Manager in IIS](/iis/get-started/getting-started-with-iis/getting-started-with-the-iis-manager-in-iis-7-and-iis-8)
+* [.NET Core application deployment](/dotnet/core/deploying/)
+* <xref:host-and-deploy/aspnet-core-module>
+* [ASP.NET Core directory structure](xref:host-and-deploy/directory-structure)
+* [IIS modules](xref:host-and-deploy/iis/modules)
+* [Troubleshoot](xref:test/troubleshoot-azure-iis)
+* [Common errors reference for Azure App Service and IIS](xref:host-and-deploy/azure-iis-errors-reference)
 
 ## Additional resources
 

--- a/aspnetcore/host-and-deploy/iis/index.md
+++ b/aspnetcore/host-and-deploy/iis/index.md
@@ -765,19 +765,19 @@ To prevent apps hosted [out-of-process](#out-of-process-hosting-model) from timi
 
 ## Deployment resources for IIS administrators
 
-* [Learn about IIS in-depth in the IIS documentation](/iis)
+* [IIS documentation](/iis)
 * [Getting Started with the IIS Manager in IIS](/iis/get-started/getting-started-with-iis/getting-started-with-the-iis-manager-in-iis-7-and-iis-8)
 * [.NET Core application deployment](/dotnet/core/deploying/)
 * <xref:host-and-deploy/aspnet-core-module>
-* [ASP.NET Core directory structure](xref:host-and-deploy/directory-structure)
-* [IIS modules](xref:host-and-deploy/iis/modules)
-* [Troubleshoot](xref:test/troubleshoot-azure-iis)
-* [Common errors reference for Azure App Service and IIS](xref:host-and-deploy/azure-iis-errors-reference)
+* <xref:host-and-deploy/directory-structure>
+* <xref:host-and-deploy/iis/modules>
+* <xref:test/troubleshoot-azure-iis>
+* <xref:host-and-deploy/azure-iis-errors-reference>
 
 ## Additional resources
 
 * <xref:test/troubleshoot>
-* [Introduction to ASP.NET Core](xref:index)
+* <xref:index>
 * [The Official Microsoft IIS Site](https://www.iis.net/)
 * [Windows Server technical content library](/windows-server/windows-server)
 * [HTTP/2 on IIS](/iis/get-started/whats-new-in-iis-10/http2-on-iis)

--- a/aspnetcore/host-and-deploy/iis/modules.md
+++ b/aspnetcore/host-and-deploy/iis/modules.md
@@ -5,7 +5,7 @@ description: Discover active and inactive IIS modules for ASP.NET Core apps and 
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/12/2019
+ms.date: 01/13/2020
 uid: host-and-deploy/iis/modules
 ---
 # IIS modules with ASP.NET Core
@@ -161,8 +161,7 @@ The HTTP Caching Module (`HttpCacheModule`) implements the IIS output cache and 
 
 ## Additional resources
 
-* <xref:host-and-deploy/iis/index>
 * [Introduction to IIS Architectures: Modules in IIS](/iis/get-started/introduction-to-iis/introduction-to-iis-architecture#modules-in-iis)
 * [IIS Modules Overview](/iis/get-started/introduction-to-iis/iis-modules-overview)
 * [Customizing IIS 7.0 Roles and Modules](https://technet.microsoft.com/library/cc627313.aspx)
-* [IIS `<system.webServer>`](/iis/configuration/system.webServer/)
+* [IIS \<system.webServer>](/iis/configuration/system.webServer/)

--- a/aspnetcore/host-and-deploy/iis/transform-webconfig.md
+++ b/aspnetcore/host-and-deploy/iis/transform-webconfig.md
@@ -5,7 +5,7 @@ description: Learn how to transform the web.config file when publishing an ASP.N
 monikerRange: '>= aspnetcore-2.2'
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/07/2019
+ms.date: 01/13/2020
 uid: host-and-deploy/iis/transform-webconfig
 ---
 # Transform web.config
@@ -176,5 +176,5 @@ dotnet publish /p:IsWebConfigTransformDisabled=true
 
 ## Additional resources
 
-* [Web.config Transformation Syntax for Web Application Project Deployment](https://go.microsoft.com/fwlink/?LinkId=301874)
-* [Web.config Transformation Syntax for Web Project Deployment Using Visual Studio](https://docs.microsoft.com/previous-versions/aspnet/dd465326(v=vs.110))
+* [Web.config Transformation Syntax for Web Application Project Deployment](/previous-versions/dd465326(v=vs.100))
+* [Web.config Transformation Syntax for Web Project Deployment Using Visual Studio](/previous-versions/aspnet/dd465326(v=vs.110))

--- a/aspnetcore/host-and-deploy/index.md
+++ b/aspnetcore/host-and-deploy/index.md
@@ -5,7 +5,7 @@ description: Learn how to set up hosting environments and deploy ASP.NET Core ap
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/07/2019
+ms.date: 01/13/2020
 uid: host-and-deploy/index
 ---
 # Host and deploy ASP.NET Core
@@ -71,6 +71,10 @@ For deployments to Internet Information Services (IIS) with configuration provid
 
 For information on configuration for hosting ASP.NET Core apps in a web farm environment (for example, deployment of multiple instances of your app for scalability), see <xref:host-and-deploy/web-farm>.
 
+## Host on Docker
+
+For more information, see <xref:host-and-deploy/docker/index>.
+
 ::: moniker range=">= aspnetcore-2.2"
 
 ## Perform health checks
@@ -81,7 +85,5 @@ Use Health Check Middleware to perform health checks on an app and its dependenc
 
 ## Additional resources
 
-* <xref:host-and-deploy/docker/index>
 * <xref:test/troubleshoot>
 * [ASP.NET Hosting](https://dotnet.microsoft.com/apps/aspnet/hosting)
-

--- a/aspnetcore/host-and-deploy/web-farm.md
+++ b/aspnetcore/host-and-deploy/web-farm.md
@@ -5,7 +5,7 @@ description: Learn how to host multiple instances of an ASP.NET Core app with sh
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/07/2019
+ms.date: 01/13/2020
 uid: host-and-deploy/web-farm
 ---
 # Host ASP.NET Core in a web farm
@@ -86,3 +86,4 @@ If the web farm apps are capable of responding to requests, obtain request, conn
 ## Additional resources
 
 * [Custom Script Extension for Windows](/azure/virtual-machines/extensions/custom-script-windows) &ndash; Downloads and executes scripts on Azure virtual machines, which is useful for post-deployment configuration and software installation.
+* <xref:host-and-deploy/proxy-load-balancer>


### PR DESCRIPTION
Fixes  #15323

Some touches to cross-linking in the *Host and deploy* node.

There are two old topics virtually defunct from a maintenance standpoint cross-linked in the *Transform web.config* topic that contain useful, valid content for our transform topic ...

* [Web.config Transformation Syntax for Web Application Project Deployment](https://docs.microsoft.com/en-us/previous-versions/dd465326(v=vs.100))
* [Web.config Transformation Syntax for Web Project Deployment Using Visual Studio](https://docs.microsoft.com/en-us/previous-versions/aspnet/dd465326(v=vs.110))

Would you like me to copy the relevant content from those topics that we need&dagger; into our doc and drop those foul cross-links? If so, I'll open an issue to address it. I think I'll have time in February to do the work.

**we need**&dagger; ... I checked with Vijay on that point. We don't have that content anyplace else that turned up in my search and to his knowledge. We need to keep those two topics cross-linked if we're not going to take the relevant bits into our topic.