### PR TITLE
New include ConnectId security warning & applied to hubs.md for SignalR

### DIFF
--- a/aspnetcore/includes/connectionid-signalr.md
+++ b/aspnetcore/includes/connectionid-signalr.md
@@ -1,0 +1,2 @@
+> [!WARNING]
+> Security - Exposing `ConnectionID` can lead to malicious impersonation if the SignalR server or the SignalR client is using a version previous to ASP.NET Core 3.0.

--- a/aspnetcore/includes/connectionid-signalr.md
+++ b/aspnetcore/includes/connectionid-signalr.md
@@ -1,2 +1,2 @@
 > [!WARNING]
-> Security - Exposing `ConnectionID` can lead to malicious impersonation if the SignalR server or the SignalR client is using a version previous to ASP.NET Core 3.0.
+> Security warning: Exposing `ConnectionID` can lead to malicious impersonation if the SignalR server or client version is ASP.NET Core 2.2 or earlier.

--- a/aspnetcore/includes/connectionid-signalr.md
+++ b/aspnetcore/includes/connectionid-signalr.md
@@ -1,2 +1,2 @@
 > [!WARNING]
-> Security warning: Exposing `ConnectionID` can lead to malicious impersonation if the SignalR server or client version is ASP.NET Core 2.2 or earlier.
+> Security warning: Exposing `ConnectionId` can lead to malicious impersonation if the SignalR server or client version is ASP.NET Core 2.2 or earlier.

--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -5,7 +5,7 @@ description: Learn how to use hubs in ASP.NET Core SignalR.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 11/12/2019
+ms.date: 01/16/2020
 no-loc: [SignalR]
 uid: signalr/hubs
 ---
@@ -167,6 +167,8 @@ The SignalR Hubs API provides the `OnConnectedAsync` and `OnDisconnectedAsync` v
 Override the `OnDisconnectedAsync` virtual method to perform actions when a client disconnects. If the client disconnects intentionally (by calling `connection.stop()`, for example), the `exception` parameter will be `null`. However, if the client is disconnected due to an error (such as a network failure), the `exception` parameter will contain an exception describing the failure.
 
 [!code-csharp[Handle disconnection](hubs/sample/hubs/chathub.cs?name=OnDisconnectedAsync)]
+
+[!INCLUDE[](~/includes/connectionid-signalr.md)]
 
 ## Handle errors
 

--- a/aspnetcore/signalr/security.md
+++ b/aspnetcore/signalr/security.md
@@ -105,9 +105,9 @@ In ASP.NET Core 2.1 and later, header validation can be achieved using a custom 
 
 ::: moniker-end
 
-## ConnectionID
+## ConnectionId
 
-Exposing `ConnectionID` can lead to malicious impersonation if the SignalR server or client version is ASP.NET Core 2.2 or earlier. If the SignalR server and client version are ASP.NET Core 3.0 or later, the `ConnectionToken` rather than the `ConnectionID` must be kept secret. The `ConnectionToken` is purposely not exposed in any API.  It can be difficult to ensure that older SignalR clients aren't connecting to the server, so even if your SignalR server version is ASP.NET Core 3.0 or later, the `ConnectionID` shouldn't be exposed.
+Exposing `ConnectionId` can lead to malicious impersonation if the SignalR server or client version is ASP.NET Core 2.2 or earlier. If the SignalR server and client version are ASP.NET Core 3.0 or later, the `ConnectionToken` rather than the `ConnectionId` must be kept secret. The `ConnectionToken` is purposely not exposed in any API.  It can be difficult to ensure that older SignalR clients aren't connecting to the server, so even if your SignalR server version is ASP.NET Core 3.0 or later, the `ConnectionId` shouldn't be exposed.
 
 ## Access token logging
 

--- a/aspnetcore/signalr/security.md
+++ b/aspnetcore/signalr/security.md
@@ -5,7 +5,7 @@ description: Learn how to use authentication and authorization in ASP.NET Core S
 monikerRange: '>= aspnetcore-2.1'
 ms.author: anurse
 ms.custom: mvc
-ms.date: 12/05/2019
+ms.date: 01/16/2020
 no-loc: [SignalR]
 uid: signalr/security
 ---
@@ -28,7 +28,7 @@ For more information on configuring CORS, see [Enable Cross-Origin Requests (COR
 
 * Allow the specific expected origins. Allowing any origin is possible but is **not** secure or recommended.
 * HTTP methods `GET` and `POST` must be allowed.
-* Credentials must be allowed in order for cookie-based sticky sessions to work correctly. They must be enabled even when authentication is not used.
+* Credentials must be allowed in order for cookie-based sticky sessions to work correctly. They must be enabled even when authentication isn't used.
 
 <!--
 ::: moniker range=">= aspnetcore-5.0"  // Moniker here just to make sure this doesn't get missed in the 5.0 version update.
@@ -105,16 +105,20 @@ In ASP.NET Core 2.1 and later, header validation can be achieved using a custom 
 
 ::: moniker-end
 
+## ConnectionID
+
+Exposing `ConnectionID` can lead to malicious impersonation if the SignalR server or client version is ASP.NET Core 2.2 or earlier. If the SignalR server and client version are ASP.NET Core 3.0 or later, the `ConnectionToken` rather than the `ConnectionID` must be kept secret. The `ConnectionToken` is purposely not exposed in any API.  It can be difficult to ensure that older SignalR clients aren't connecting to the server, so even if your SignalR server version is ASP.NET Core 3.0 or later, the `ConnectionID` shouldn't be exposed.
+
 ## Access token logging
 
-When using WebSockets or Server-Sent Events, the browser client sends the access token in the query string. Receiving the access token via query string is generally as secure as using the standard `Authorization` header. You should always use HTTPS to ensure a secure end-to-end connection between the client and the server. Many web servers log the URL for each request, including the query string. Logging the URLs may log the access token. ASP.NET Core logs the URL for each request by default, which will include the query string. For example:
+When using WebSockets or Server-Sent Events, the browser client sends the access token in the query string. Receiving the access token via query string is generally secure as using the standard `Authorization` header. Always use HTTPS to ensure a secure end-to-end connection between the client and the server. Many web servers log the URL for each request, including the query string. Logging the URLs may log the access token. ASP.NET Core logs the URL for each request by default, which will include the query string. For example:
 
 ```
 info: Microsoft.AspNetCore.Hosting.Internal.WebHost[1]
       Request starting HTTP/1.1 GET http://localhost:5000/myhub?access_token=1234
 ```
 
-If you have concerns about logging this data with your server logs, you can disable this logging entirely by configuring the `Microsoft.AspNetCore.Hosting` logger to the `Warning` level or above (these messages are written at `Info` level). See the documentation on [Log Filtering](xref:fundamentals/logging/index#log-filtering) for more information. If you still want to log certain request information, you can [write a middleware](xref:fundamentals/middleware/write) to log the data you require and filter out the `access_token` query string value (if present).
+If you have concerns about logging this data with your server logs, you can disable this logging entirely by configuring the `Microsoft.AspNetCore.Hosting` logger to the `Warning` level or above (these messages are written at `Info` level). For more information, see [Log Filtering](xref:fundamentals/logging/index#log-filtering) for more information. If you still want to log certain request information, you can [write a middleware](xref:fundamentals/middleware/write) to log the data you require and filter out the `access_token` query string value (if present).
 
 ## Exceptions
 


### PR DESCRIPTION
Fixes: #11687 

[Internal Review of hubs.md](https://review.docs.microsoft.com/en-us/aspnet/core/signalr/hubs?view=aspnetcore-3.1&branch=pr-en-us-16573#handle-events-for-a-connection)

[Internal Review of security.md](https://review.docs.microsoft.com/en-us/aspnet/core/signalr/security?view=aspnetcore-3.1&branch=pr-en-us-16573#connectionid)

Created a new include named: connectionid-signalr.md providing a short security warning against exposing ConnectionId.

Updated hubs.md so that it uses the connectionid-signalr.md security warning include where ConnectId is mentioned.