### PR TITLE
fix duplicate startup compile error

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/start-mvc/sample/MvcMovie3/StartupDevProd.cs
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc/sample/MvcMovie3/StartupDevProd.cs
@@ -1,17 +1,12 @@
-using MvcMovie.Data;
-using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpsPolicy;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using MvcMovie.Data;
 
-namespace MvcMovie
+namespace MvcMovie_Production
 {
     #region snippet_StartupClass
     public class Startup


### PR DESCRIPTION
@scottaddie  normally we change the name of the startup class. In this case the snippet is showing that so need to change the NS so the download project compiles.

Fixes #16594