### PR TITLE
Added clarifying language for the LIBRARY_NAME

### DIFF
--- a/aspnetcore/razor-pages/ui-class.md
+++ b/aspnetcore/razor-pages/ui-class.md
@@ -121,7 +121,7 @@ To include TypeScript files in an RCL:
 
 ### Consume content from a referenced RCL
 
-The files included in the *wwwroot* folder of the RCL are exposed to the consuming app under the prefix `_content/{LIBRARY NAME}/`. For example, a library named *Razor.Class.Lib* results in a path to static content at `_content/Razor.Class.Lib/`.
+The files included in the *wwwroot* folder of the RCL are exposed to the consuming app under the prefix `_content/{LIBRARY NAME}/`. For example, a library named *Razor.Class.Lib* results in a path to static content at `_content/Razor.Class.Lib/`.  In cases where the assembly name is not the same as the package id, the `{LIBRARY NAME}` will reference the package id instead.
 
 The consuming app references static assets provided by the library with `<script>`, `<style>`, `<img>`, and other HTML tags. The consuming app must have [static file support](xref:fundamentals/static-files) enabled in `Startup.Configure`:
 

--- a/aspnetcore/razor-pages/ui-class.md
+++ b/aspnetcore/razor-pages/ui-class.md
@@ -121,7 +121,7 @@ To include TypeScript files in an RCL:
 
 ### Consume content from a referenced RCL
 
-The files included in the *wwwroot* folder of the RCL are exposed to the consuming app under the prefix `_content/{LIBRARY NAME}/`. For example, a library named *Razor.Class.Lib* results in a path to static content at `_content/Razor.Class.Lib/`.  In cases where the assembly name is not the same as the package id, the `{LIBRARY NAME}` will reference the package id instead.
+The files included in the *wwwroot* folder of the RCL are exposed to the consuming app under the prefix `_content/{LIBRARY NAME}/`. For example, a library named *Razor.Class.Lib* results in a path to static content at `_content/Razor.Class.Lib/`. When producing a NuGet package and the assembly name isn't the same as the package ID, use the the package ID for `{LIBRARY NAME}`.
 
 The consuming app references static assets provided by the library with `<script>`, `<style>`, `<img>`, and other HTML tags. The consuming app must have [static file support](xref:fundamentals/static-files) enabled in `Startup.Configure`:
 


### PR DESCRIPTION
Fixes #16600

The LIBRARY_NAME marker is a reference to the PackageId, which by default is the same as the Assembly Name.  If the PackageId is overridden in the csproj or nuspec file, that PackageId takes precedence

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->