### PR TITLE
Visual Studio 16.4  should be only in VS 2019

### DIFF
--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -31,7 +31,7 @@ Get started with Blazor:
 
    # [Visual Studio](#tab/visual-studio)
 
-   1\. Install [Visual Studio 16.4 or later](https://visualstudio.microsoft.com/vs/preview/) with the **ASP.NET and web development** workload.
+   1\. Install [Visual Studio 2019 version 16.4 or later](https://visualstudio.microsoft.com/vs/preview/) with the **ASP.NET and web development** workload.
 
    2\. Create a new project.
 


### PR DESCRIPTION
Install Visual Studio 2019 version 16.4 or later with the ASP.NET and web development workload should provide better information than 
Install Visual Studio 16.4 or later with the ASP.NET and web development workload.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->