### PR TITLE
Call out changes to Redis distributed caches

### DIFF
--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -1101,7 +1101,7 @@ If you're using [features of Newtonsoft.Json that aren't supported in System.Tex
 
 ## Redis distributed caches
 
-The [Microsoft.Extensions.Caching.Redis](https://www.nuget.org/packages/Microsoft.Extensions.Caching.Redis/) package is no longer being produced. Replace the package reference with [Microsoft.Extensions.Caching.StackExchangeRedis](https://www.nuget.org/packages/Microsoft.Extensions.Caching.StackExchangeRedis). To learn more, see <xref:performance/caching/distributed>.
+The [Microsoft.Extensions.Caching.Redis](https://www.nuget.org/packages/Microsoft.Extensions.Caching.Redis) package is no longer being produced. Replace the package reference with [Microsoft.Extensions.Caching.StackExchangeRedis](https://www.nuget.org/packages/Microsoft.Extensions.Caching.StackExchangeRedis). To learn more, see <xref:performance/caching/distributed>.
 
 ## Opt in to runtime compilation
 

--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn how to migrate an ASP.NET Core 2.2 project to ASP.NET Core 3.0.
 ms.author: riande
 ms.custom: mvc
-ms.date: 01/13/2020
+ms.date: 01/21/2020
 no-loc: [SignalR]
 uid: migration/22-to-30
 ---
@@ -1101,7 +1101,7 @@ If you're using [features of Newtonsoft.Json that aren't supported in System.Tex
 
 ## Redis distributed caches
 
-The [Microsoft.Extensions.Caching.Redis](https://www.nuget.org/packages/Microsoft.Extensions.Caching.Redis) package is no longer being produced. Replace the package reference with [Microsoft.Extensions.Caching.StackExchangeRedis](https://www.nuget.org/packages/Microsoft.Extensions.Caching.StackExchangeRedis). To learn more, see <xref:performance/caching/distributed>.
+The [Microsoft.Extensions.Caching.Redis](https://www.nuget.org/packages/Microsoft.Extensions.Caching.Redis) package isn't available for ASP.NET Core 3.0 or later apps. Replace the package reference with [Microsoft.Extensions.Caching.StackExchangeRedis](https://www.nuget.org/packages/Microsoft.Extensions.Caching.StackExchangeRedis). For more information, see <xref:performance/caching/distributed>.
 
 ## Opt in to runtime compilation
 

--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -1099,6 +1099,10 @@ new HubConnectionBuilder()
 
 If you're using [features of Newtonsoft.Json that aren't supported in System.Text.Json](/dotnet/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to), you can switch back to `Newtonsoft.Json`. See [Use Newtonsoft.Json in an ASP.NET Core 3.0 SignalR project](#use-newtonsoftjson-in-an-aspnet-core-30-signalr-project) earlier in this article.
 
+## Redis distributed caches
+
+The [Microsoft.Extensions.Caching.Redis](https://www.nuget.org/packages/Microsoft.Extensions.Caching.Redis/) package is no longer being produced. Replace the package reference with [Microsoft.Extensions.Caching.StackExchangeRedis](https://www.nuget.org/packages/Microsoft.Extensions.Caching.StackExchangeRedis). To learn more, see <xref:performance/caching/distributed>.
+
 ## Opt in to runtime compilation
 
 Prior to ASP.NET Core 3.0, runtime compilation of views was an implicit feature of the framework. Runtime compilation supplements build-time compilation of views. It allows the framework to compile Razor views and pages (*.cshtml* files) when the files are modified, without having to rebuild the entire app. This feature supports the scenario of making a quick edit in the IDE and refreshing the browser to view the changes.


### PR DESCRIPTION
I added a note about `Microsoft.Extensions.Caching.Redis` being replaced as of ASP.NET Core 3.0 and added a cross-reference to the article about distributed caching.

Fixes #16476



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->