### PR TITLE
C150960: Adding missing backticks at end of code

### DIFF
--- a/aspnetcore/web-api/http-repl.md
+++ b/aspnetcore/web-api/http-repl.md
@@ -572,6 +572,7 @@ To issue an HTTP PUT request:
         "data": "Strawberry"
       }
     ]
+    ```
 
 1. Run the `put` command on an endpoint that supports it:
 


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
Description of the source issue: Lack of a backticks at the end of code-block is preventing following content to be localized
