### PR TITLE
L166242: removing extra comma

### DIFF
--- a/aspnetcore/web-api/jsonpatch/samples/2.2/JSON/remove.json
+++ b/aspnetcore/web-api/jsonpatch/samples/2.2/JSON/remove.json
@@ -5,6 +5,6 @@
   },
   {
     "op": "remove",
-    "path": "/orders/0",
+    "path": "/orders/0"
   }
 ]


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: There is an extra comma which is causing the JSON file to have an invalid format