### PR TITLE
Update Components_Topic:_Revert_Inherits_Add_Attribute

### DIFF
--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -82,10 +82,7 @@ To render a component from a page or view, use the `Component` Tag Helper:
     param-IncrementAmount="10" />
 ```
 
-Passing parameters (for example, `IncrementAmount` in the preceding example) is supported:
-
-* The component must have a parameterless constructor.
-* The parameter must be a settable property with the `[Parameter]` attribute applied.
+The parameter type must be JSON serializable, which typically means that the type must have a default constructor and settable properties. For example, you can specify a value for `IncrementAmount` because the type of `IncrementAmount` is an `int`, which is a primitive type supported by the JSON serializer.
 
 `RenderMode` configures whether the component:
 
@@ -106,12 +103,7 @@ For more information on how components are rendered, component state, and the `C
 
 ## Tag Helpers aren't used in components
 
-[Tag Helpers](xref:mvc/views/tag-helpers/intro) generate HTML strings for webpages, which isn't a valid approach for rendering content in an SPA framework, such as Blazor. In Blazor apps:
-
-* There's a live Document Object Model (DOM) that's updated via DOM APIs.
-* The abstraction for UI reuse is *components*. Components provide a richer editor experience than Tag Helpers and are designed for performance in an SPA app.
-
-To provide Tag Helper-like functionality in Blazor, create a component with the same functionality as the Tag Helper and use the component instead.
+[Tag Helpers](xref:mvc/views/tag-helpers/intro) aren't supported in Razor components (*.razor* files). To provide Tag Helper-like functionality in Blazor, create a component with the same functionality as the Tag Helper and use the component instead.
 
 ## Use components
 

--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -5,7 +5,7 @@ description: Learn how to create and use Razor components, including how to bind
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 12/28/2019
+ms.date: 01/24/2020
 no-loc: [Blazor, SignalR]
 uid: blazor/components
 ---
@@ -1139,6 +1139,43 @@ using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.AspNetCore.Components.Web;
+```
+
+## Specify a base class
+
+The [`@inherits`](xref:mvc/views/razor#inherits) directive can be used to specify a base class for a component. The following example shows how a component can inherit a base class, `BlazorRocksBase`, to provide the component's properties and methods. The base class should derive from `ComponentBase`.
+
+*Pages/BlazorRocks.razor*:
+
+```razor
+@page "/BlazorRocks"
+@inherits BlazorRocksBase
+
+<h1>@BlazorRocksText</h1>
+```
+
+*BlazorRocksBase.cs*:
+
+```csharp
+using Microsoft.AspNetCore.Components;
+
+namespace BlazorSample
+{
+    public class BlazorRocksBase : ComponentBase
+    {
+        public string BlazorRocksText { get; set; } = 
+            "Blazor rocks the browser!";
+    }
+}
+```
+
+## Specify an attribute
+
+Attributes can be specified in Razor components with the [`@attribute`](xref:mvc/views/razor#attribute) directive. The following example applies the `[Authorize]` attribute to the component class:
+
+```razor
+@page "/"
+@attribute [Authorize]
 ```
 
 ## Import components

--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -104,6 +104,15 @@ Rendering server components from a static HTML page isn't supported.
 
 For more information on how components are rendered, component state, and the `Component` Tag Helper, see <xref:blazor/hosting-models>.
 
+## Tag Helpers aren't used in components
+
+[Tag Helpers](xref:mvc/views/tag-helpers/intro) generate HTML strings for webpages, which isn't a valid approach for rendering content in an SPA framework, such as Blazor. In Blazor apps:
+
+* There's a live Document Object Model (DOM) that's updated via DOM APIs.
+* The abstraction for UI reuse is *components*. Components provide a richer editor experience than Tag Helpers and are designed for performance in an SPA app.
+
+To provide Tag Helper-like functionality in Blazor, create a component with the same functionality as the Tag Helper and use the component instead.
+
 ## Use components
 
 Components can include other components by declaring them using HTML element syntax. The markup for using a component looks like an HTML tag where the name of the tag is the component type.

--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -82,7 +82,10 @@ To render a component from a page or view, use the `Component` Tag Helper:
     param-IncrementAmount="10" />
 ```
 
-Passing parameters (for example, `IncrementAmount` in the preceding example) is supported.
+Passing parameters (for example, `IncrementAmount` in the preceding example) is supported:
+
+* The component must have a parameterless constructor.
+* The parameter must be a settable property with the `[Parameter]` attribute applied.
 
 `RenderMode` configures whether the component:
 


### PR DESCRIPTION
Fixes #16111
Fixes #16327
Fixes #16636

* Revert removal of `@inherits` base class content.
* Add `@attribute`.
* Cross-link both to Razor syntax topic.
* Enhance passing parameters with Component Tag Helper remarks.
* Surface a bit of guidance on not using THs in components. Thanks @Locomotion77! :guitar: