### PR TITLE
Added convention based registration bullet

### DIFF
--- a/aspnetcore/fundamentals/dependency-injection.md
+++ b/aspnetcore/fundamentals/dependency-injection.md
@@ -5,7 +5,7 @@ description: Learn how ASP.NET Core implements dependency injection and how to u
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/05/2019
+ms.date: 01/30/2020
 uid: fundamentals/dependency-injection
 ---
 # Dependency injection in ASP.NET Core
@@ -607,7 +607,7 @@ The built-in service container is designed to serve the needs of the framework a
 * Child containers
 * Custom lifetime management
 * `Func<T>` support for lazy initialization
-* Convention based registration
+* Convention-based registration
 
 The following 3rd party containers can be used with ASP.NET Core apps:
 

--- a/aspnetcore/fundamentals/dependency-injection.md
+++ b/aspnetcore/fundamentals/dependency-injection.md
@@ -607,6 +607,7 @@ The built-in service container is designed to serve the needs of the framework a
 * Child containers
 * Custom lifetime management
 * `Func<T>` support for lazy initialization
+* Convention based registration
 
 The following 3rd party containers can be used with ASP.NET Core apps:
 


### PR DESCRIPTION
Added convention based registration (e.g.: auto-registration of `ISomething` ->`Something`) to the list of reasons for "Default service container replacement", though this appears to be addressed by the [Scrutor project](https://andrewlock.net/using-scrutor-to-automatically-register-your-services-with-the-asp-net-core-di-container/)



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->