### PR TITLE
Re-order description of JSON snippet

### DIFF
--- a/aspnetcore/security/authentication/identity-api-authorization.md
+++ b/aspnetcore/security/authentication/identity-api-authorization.md
@@ -279,9 +279,9 @@ This section describes deploying the app to Azure websites using a certificate s
 }
 ```
 
-* The name property on certificate corresponds with the distinguished subject for the certificate.
-* The store location represents where to load the certificate from (`CurrentUser` or `LocalMachine`).
 * The store name represents the name of the certificate store where the certificate is stored. In this case, it points to the personal user store.
+* The store location represents where to load the certificate from (`CurrentUser` or `LocalMachine`).
+* The name property on certificate corresponds with the distinguished subject for the certificate.
 
 To deploy to Azure Websites, deploy the app following the steps in [Deploy the app to Azure](xref:tutorials/publish-to-azure-webapp-using-vs#deploy-the-app-to-azure) to create the necessary Azure resources and deploy the app to production.
 


### PR DESCRIPTION
The description of the JSON snippet is in reversed order of the JSON items.
I propose reversing the description of items so that it matches the JSON snippet.

Fixes #16768 