### PR TITLE
Drop 'command-line interface' before 'CLI'

### DIFF
--- a/aspnetcore/client-side/libman/libman-cli.md
+++ b/aspnetcore/client-side/libman/libman-cli.md
@@ -1,14 +1,14 @@
 ---
-title: Use the LibMan command-line interface (CLI) with ASP.NET Core
+title: Use the LibMan CLI with ASP.NET Core
 author: scottaddie
-description: Learn how to use the LibMan command-line interface (CLI) in an ASP.NET Core project.
+description: Learn how to use the LibMan CLI in an ASP.NET Core project.
 ms.author: scaddie
 ms.custom: mvc
 ms.date: 11/12/2019
 no-loc: [SignalR]
 uid: client-side/libman/libman-cli
 ---
-# Use the LibMan command-line interface (CLI) with ASP.NET Core
+# Use the LibMan CLI with ASP.NET Core
 
 By [Scott Addie](https://twitter.com/Scott_Addie)
 

--- a/aspnetcore/data/ef-mvc/migrations.md
+++ b/aspnetcore/data/ef-mvc/migrations.md
@@ -33,7 +33,7 @@ When you develop a new application, your data model changes frequently, and each
 
 This method of keeping the database in sync with the data model works well until you deploy the application to production. When the application is running in production it's usually storing data that you want to keep, and you don't want to lose everything each time you make a change such as adding a new column. The EF Core Migrations feature solves this problem by enabling EF to update the database schema instead of creating  a new database.
 
-To work with migrations, you can use the **Package Manager Console** (PMC) or the command-line interface (CLI).  These tutorials show how to use CLI commands. Information about the PMC is at [the end of this tutorial](#pmc).
+To work with migrations, you can use the **Package Manager Console** (PMC) or the CLI.  These tutorials show how to use CLI commands. Information about the PMC is at [the end of this tutorial](#pmc).
 
 ## Change the connection string
 

--- a/aspnetcore/data/ef-rp/migrations.md
+++ b/aspnetcore/data/ef-rp/migrations.md
@@ -37,7 +37,7 @@ Drop-Database
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
-* Run the following command at a command prompt to install the EF CLI tools:
+* Run the following command at a command prompt to install the EF CLI:
 
   ```dotnetcli
   dotnet tool install --global dotnet-ef

--- a/aspnetcore/getting-started/index.md
+++ b/aspnetcore/getting-started/index.md
@@ -9,7 +9,7 @@ uid: getting-started
 ---
 # Tutorial: Get started with ASP.NET Core
 
-This tutorial shows how to use the .NET Core command-line interface to create and run an ASP.NET Core web app.
+This tutorial shows how to use the .NET Core CLI to create and run an ASP.NET Core web app.
 
 You'll learn how to:
 

--- a/aspnetcore/host-and-deploy/azure-apps/index.md
+++ b/aspnetcore/host-and-deploy/azure-apps/index.md
@@ -274,7 +274,7 @@ For a 64-bit deployment:
 
 ### Deploy the app self-contained
 
-Use Visual Studio or the command-line interface (CLI) tools for a [self-contained deployment (SCD)](/dotnet/core/deploying/#self-contained-deployments-scd).
+Use Visual Studio or the .NET Core CLI for a [self-contained deployment (SCD)](/dotnet/core/deploying/#self-contained-deployments-scd).
 
 # [Visual Studio](#tab/visual-studio)
 

--- a/aspnetcore/host-and-deploy/linux-nginx.md
+++ b/aspnetcore/host-and-deploy/linux-nginx.md
@@ -304,7 +304,7 @@ Linux Security Modules (LSM) is a framework that's part of the Linux kernel sinc
 
 ### Configure the firewall
 
-Close off all external ports that are not in use. Uncomplicated firewall (ufw) provides a front end for `iptables` by providing a command line interface for configuring the firewall.
+Close off all external ports that are not in use. Uncomplicated firewall (ufw) provides a front end for `iptables` by providing a CLI for configuring the firewall.
 
 > [!WARNING]
 > A firewall will prevent access to the whole system if not configured correctly. Failure to specify the correct SSH port will effectively lock you out of the system if you are using SSH to connect to it. The default port is 22. For more information, see the [introduction to ufw](https://help.ubuntu.com/community/UFW) and the [manual](https://manpages.ubuntu.com/manpages/bionic/man8/ufw.8.html).

--- a/aspnetcore/includes/ef-cli.md
+++ b/aspnetcore/includes/ef-cli.md
@@ -1,1 +1,1 @@
-For more information on the CLI tools for EF Core, see [EF Core tools reference for .Net CLI](/ef/core/miscellaneous/cli/dotnet).
+For more information on the CLI for EF Core, see [EF Core tools reference for .Net CLI](/ef/core/miscellaneous/cli/dotnet).

--- a/aspnetcore/security/key-vault-configuration.md
+++ b/aspnetcore/security/key-vault-configuration.md
@@ -71,7 +71,7 @@ The instructions provided by the [Quickstart: Set and retrieve a secret from Azu
    * Open Cloud Shell in your browser with the **Launch Cloud Shell** button.
    * Select the **Cloud Shell** button on the menu in the upper-right corner of the Azure portal.
 
-   For more information, see [Azure Command-Line Interface (CLI)](/cli/azure/) and [Overview of Azure Cloud Shell](/azure/cloud-shell/overview).
+   For more information, see [Azure CLI](/cli/azure/) and [Overview of Azure Cloud Shell](/azure/cloud-shell/overview).
 
 1. If you aren't already authenticated, sign in with the `az login` command.
 

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -702,7 +702,7 @@
         - name: Publish with Visual Studio for Mac
           displayName: azure, deploy, publish
           href: /visualstudio/mac/publish-app-svc?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
-        - name: Publish with CLI tools
+        - name: Publish with the CLI
           displayName: azure, deploy, publish
           href: /azure/app-service/app-service-web-tutorial-dotnetcore-sqldb?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
         - name: Publish with Visual Studio and Git

--- a/aspnetcore/tutorials/first-mvc-app/adding-model.md
+++ b/aspnetcore/tutorials/first-mvc-app/adding-model.md
@@ -259,7 +259,7 @@ dotnet ef database update
 
 * `ef database update`: Updates the database to the latest migration, which the previous command created. This command runs the `Up` method in the *Migrations/{time-stamp}_InitialCreate.cs* file, which creates the database.
 
-[!INCLUDE [more information on the CLI tools for EF Core](~/includes/ef-cli.md)]
+[!INCLUDE [more information on the CLI for EF Core](~/includes/ef-cli.md)]
 
 ---
 


### PR DESCRIPTION
Also drop "tools" after CLI.  See https://github.com/dotnet/docs/pull/16880
