### PR TITLE
SignalR Docs update in response to CVE-2020-5234 in MessagePack library

### DIFF
--- a/aspnetcore/signalr/messagepackhubprotocol.md
+++ b/aspnetcore/signalr/messagepackhubprotocol.md
@@ -45,7 +45,7 @@ services.AddSignalR()
 ```
 
 > [!WARNING]
-> In response to [CVE-2020-5234](https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf), we strongly recommend setting the `MessagePackSecurity.Active` static property to `MessagePackSecurity.UntrustedData`. To do this, manually install a [1.9.x version of MessagePack](https://www.nuget.org/packages/MessagePack/1.9.3). Installing `MessagePack` 1.9.x upgrades the version SignalR uses. When `MessagePackSecurity.Active` is not set to  `MessagePackSecurity.UntrustedData`, a malicious client could cause a denial of service. Set `MessagePackSecurity.Active` in `Program.Main`, as shown in the following code:
+> We strongly recommend reviewing [CVE-2020-5234](https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf) and applying the recommended patches. For example, setting the `MessagePackSecurity.Active` static property to `MessagePackSecurity.UntrustedData`. Setting the `MessagePackSecurity.Active` requires manually installing a [1.9.x version of MessagePack](https://www.nuget.org/packages/MessagePack/1.9.3). Installing `MessagePack` 1.9.x upgrades the version SignalR uses. When `MessagePackSecurity.Active` is not set to `MessagePackSecurity.UntrustedData`, a malicious client could cause a denial of service. Set `MessagePackSecurity.Active` in `Program.Main`, as shown in the following code:
 
 ```csharp
 public static void Main(string[] args)

--- a/aspnetcore/signalr/messagepackhubprotocol.md
+++ b/aspnetcore/signalr/messagepackhubprotocol.md
@@ -44,6 +44,21 @@ services.AddSignalR()
     });
 ```
 
+> [!NOTE]
+> In response to [CVE-2020-5234](https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf), we strongly recommend setting the `MessagePackSecurity.Active` static property to `MessagePackSecurity.UntrustedData`. You can do this in your `Program.Main` function, as shown below. If you do not set this value, it may be possible for a malicious client to caused a denial of service in your application.
+
+```csharp
+public static void Main(string[] args)
+{
+  // Add the following lines:
+  // Enable additional security in MessagePack to handle untrusted data.
+  MessagePackSecurity.Active = MessagePackSecurity.UntrustedData;
+
+  // Continue with program initialization...
+  CreateHostBuilder(args).Build().Run();
+}
+```
+
 ## Configure MessagePack on the client
 
 > [!NOTE]

--- a/aspnetcore/signalr/messagepackhubprotocol.md
+++ b/aspnetcore/signalr/messagepackhubprotocol.md
@@ -45,7 +45,7 @@ services.AddSignalR()
 ```
 
 > [!NOTE]
-> In response to [CVE-2020-5234](https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf), we strongly recommend setting the `MessagePackSecurity.Active` static property to `MessagePackSecurity.UntrustedData`. You can do this in your `Program.Main` function, as shown below. If you do not set this value, it may be possible for a malicious client to caused a denial of service in your application.
+> In response to [CVE-2020-5234](https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf), we strongly recommend setting the `MessagePackSecurity.Active` static property to `MessagePackSecurity.UntrustedData`. To do this, you must manually install [a 1.9.x version of `MessagePack`](https://www.nuget.org/packages/MessagePack/1.9.3) in your application, which will upgrade the version SignalR uses. You can set this property in your `Program.Main` function, as shown below. If you do not set this value, it may be possible for a malicious client to caused a denial of service in your application.
 
 ```csharp
 public static void Main(string[] args)

--- a/aspnetcore/signalr/messagepackhubprotocol.md
+++ b/aspnetcore/signalr/messagepackhubprotocol.md
@@ -44,17 +44,14 @@ services.AddSignalR()
     });
 ```
 
-> [!NOTE]
-> In response to [CVE-2020-5234](https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf), we strongly recommend setting the `MessagePackSecurity.Active` static property to `MessagePackSecurity.UntrustedData`. To do this, you must manually install [a 1.9.x version of `MessagePack`](https://www.nuget.org/packages/MessagePack/1.9.3) in your application, which will upgrade the version SignalR uses. You can set this property in your `Program.Main` function, as shown below. If you do not set this value, it may be possible for a malicious client to caused a denial of service in your application.
+> [!WARNING]
+> In response to [CVE-2020-5234](https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf), we strongly recommend setting the `MessagePackSecurity.Active` static property to `MessagePackSecurity.UntrustedData`. To do this, manually install a [1.9.x version of MessagePack](https://www.nuget.org/packages/MessagePack/1.9.3). Installing `MessagePack` 1.9.x upgrades the version SignalR uses. When `MessagePackSecurity.Active` is not set to  `MessagePackSecurity.UntrustedData`, a malicious client could cause a denial of service. Set `MessagePackSecurity.Active` in `Program.Main`, as shown in the following code:
 
 ```csharp
 public static void Main(string[] args)
 {
-  // Add the following lines:
-  // Enable additional security in MessagePack to handle untrusted data.
   MessagePackSecurity.Active = MessagePackSecurity.UntrustedData;
 
-  // Continue with program initialization...
   CreateHostBuilder(args).Build().Run();
 }
 ```


### PR DESCRIPTION
In response to [CVE-2020-5234](https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf), we are updating our docs to recommend setting a new static property in their applications when using MessagePack.

cc @AArnott 

`@Rick-Anderson  edit:` [Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/signalr/messagepackhubprotocol?view=aspnetcore-2.1&branch=pr-en-us-16799#configure-messagepack-on-the-server)