### PR TITLE
Added missing instructions for sign in with Twitter.

### DIFF
--- a/aspnetcore/security/authentication/social/social-code/3.x/StartupTwitter3x.cs
+++ b/aspnetcore/security/authentication/social/social-code/3.x/StartupTwitter3x.cs
@@ -14,8 +14,8 @@ public void ConfigureServices(IServiceCollection services)
         twitterOptions.ConsumerKey = Configuration["Authentication:Twitter:ConsumerAPIKey"];
         twitterOptions.ConsumerSecret = Configuration["Authentication:Twitter:ConsumerSecret"];
 		
-		// Request the email address from users
-		twitterOptions.RetrieveUserDetails = true;
+        // Request the email address from users
+        twitterOptions.RetrieveUserDetails = true;
     });
 
 }

--- a/aspnetcore/security/authentication/social/social-code/3.x/StartupTwitter3x.cs
+++ b/aspnetcore/security/authentication/social/social-code/3.x/StartupTwitter3x.cs
@@ -13,6 +13,9 @@ public void ConfigureServices(IServiceCollection services)
     {
         twitterOptions.ConsumerKey = Configuration["Authentication:Twitter:ConsumerAPIKey"];
         twitterOptions.ConsumerSecret = Configuration["Authentication:Twitter:ConsumerSecret"];
+		
+		// Request the email address from users
+		twitterOptions.RetrieveUserDetails = true;
     });
 
 }

--- a/aspnetcore/security/authentication/social/social-code/3.x/StartupTwitter3x.cs
+++ b/aspnetcore/security/authentication/social/social-code/3.x/StartupTwitter3x.cs
@@ -13,8 +13,6 @@ public void ConfigureServices(IServiceCollection services)
     {
         twitterOptions.ConsumerKey = Configuration["Authentication:Twitter:ConsumerAPIKey"];
         twitterOptions.ConsumerSecret = Configuration["Authentication:Twitter:ConsumerSecret"];
-		
-        // Request the email address from users
         twitterOptions.RetrieveUserDetails = true;
     });
 

--- a/aspnetcore/security/authentication/social/twitter-logins.md
+++ b/aspnetcore/security/authentication/social/twitter-logins.md
@@ -22,6 +22,10 @@ This sample shows how to enable users to [sign in with their Twitter account](ht
 
 * Select **Create an app**. Fill out the **App name**, **Application description** and public **Website** URI (this can be temporary until you register the domain name):
 
+* Check the box next to **Enable Sign in with Twitter**
+
+* Microsoft.AspNetCore.Identity requires users to have an email address by default. Go to the **Permissions** tab, click the **Edit** button and check the box next to **Request email address from users**.
+
 * Enter your development URI with `/signin-twitter` appended into the **Callback URLs** field (for example: `https://webapp128.azurewebsites.net/signin-twitter`). The Twitter authentication scheme configured later in this sample will automatically handle requests at `/signin-twitter` route to implement the OAuth flow.
 
   > [!NOTE]

--- a/aspnetcore/security/authentication/social/twitter-logins.md
+++ b/aspnetcore/security/authentication/social/twitter-logins.md
@@ -50,7 +50,7 @@ These tokens can be found on the **Keys and Access Tokens** tab after creating a
 
 Add the Twitter service in the `ConfigureServices` method in *Startup.cs* file:
 
-[!code-csharp[](~/security/authentication/social/social-code/3.x/StartupTwitter3x.cs?name=snippet&highlight=10-14)]
+[!code-csharp[](~/security/authentication/social/social-code/3.x/StartupTwitter3x.cs?name=snippet&highlight=10-15)]
 
 [!INCLUDE [default settings configuration](includes/default-settings.md)]
 


### PR DESCRIPTION
[Internal Review](https://review.docs.microsoft.com/en-us/aspnet/core/security/authentication/social/twitter-logins?view=aspnetcore-3.1&branch=pr-en-us-16809)

Fixes issue #16969

There are some additional permissions to be set to the Twitter app. The PR mentions them.

- App details: **Enable Sign in with Twitter** must be checked
- After creating the app: go to Permissions tab -> edit ->  **Request email address from users** must be checked
- `twitterOptions.RetrieveUserDetails = true;` is already mentioned

[topic link: Twitter external sign-in setup with ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/social/twitter-logins?view=aspnetcore-3.1#configure-twitter-authentication)