### PR TITLE
Add what's new page for January 2020

### DIFF
--- a/aspnetcore/whats-new/2020-01.md
+++ b/aspnetcore/whats-new/2020-01.md
@@ -1,0 +1,72 @@
+---
+title: "ASP.NET Core docs: What's new for January 2020"
+description: "What's new in ASP.NET Core docs for January 2020."
+ms.date: 02/03/2020
+---
+
+# ASP.NET Core docs: What's new for January 2020
+
+Welcome to what's new in ASP.NET Core docs for January 2020. This article lists some of the major changes to docs during this period.
+
+## Blazor
+
+### Updated articles
+
+- [ASP.NET Core Blazor forms and validation](../blazor/forms-validation.md) - Blazor forms updates
+- [ASP.NET Core Blazor hosting models](../blazor/hosting-models.md) - Explain integration of Razor Components into Razor Pages and MVC projects
+
+## gRPC
+
+### New articles
+
+- [gRPC in browser apps](../grpc/browser.md) - Add gRPC-Web article
+- [Versioning gRPC services](../grpc/versioning.md) - Add gRPC versioning article
+
+## Hosting and deployment
+
+### Updated articles
+
+- [Host ASP.NET Core in a Windows Service](../host-and-deploy/windows-service.md) - Add a Windows Service troubleshooting section
+
+## MVC
+
+### Updated articles
+
+- [Custom Model Binding in ASP.NET Core](../mvc/advanced/custom-model-binding.md) - Prepare for Custom Model Binding 3.x.
+- [Filters in ASP.NET Core](../mvc/controllers/filters.md) - Update Filters to 3.1
+
+## Razor Pages
+
+### New articles
+
+- [ASP.NET Core Web SDK](../razor-pages/web-sdk.md) - Fill in SDK gaps
+
+## Community contributors
+
+The following people have contributed to ASP.NET Core docs in January 2020. Thank you! You can learn how to contribute by following the links under "Get involved" in the [what's new landing page](index.yml).
+
+- [serpent5](https://github.com/serpent5) - Kirk Larkin (7)
+- [mohsinnasir](https://github.com/mohsinnasir) - Mohsin Nasir (3)
+- [alexvy86](https://github.com/alexvy86) - Alex Villarreal (2)
+- [damienbod](https://github.com/damienbod) - damienbod (2)
+- [donhuvy](https://github.com/donhuvy) - donhuvy (2)
+- [antmdvs](https://github.com/antmdvs) - Tony (1)
+- [arialdomartini](https://github.com/arialdomartini) - Arialdo Martini (1)
+- [camkinney](https://github.com/camkinney) - itsMeCamK (1)
+- [chanmmn](https://github.com/chanmmn) (1)
+- [Daniel15](https://github.com/Daniel15) - Daniel Lo Nigro (1)
+- [ernonewman](https://github.com/ernonewman) - Erno (1)
+- [GeorgeAlexandria](https://github.com/GeorgeAlexandria) (1)
+- [gurry](https://github.com/gurry) - Gurinder Singh (1)
+- [jnpwly](https://github.com/jnpwly) - Jon Pawley (1)
+- [khancyr](https://github.com/khancyr) - Pierre Kancir (1)
+- [Log234](https://github.com/Log234) (1)
+- [MaherJendoubi](https://github.com/MaherJendoubi) - Maher Jendoubi (1)
+- [mrmowji](https://github.com/mrmowji) - Mojtaba Javan (1)
+- [Reisclef](https://github.com/Reisclef) - Richard (1)
+- [ryanauj](https://github.com/ryanauj) - Ryan Jackson (1)
+- [samsmithnz](https://github.com/samsmithnz) - Sam Smith (Microsoft) (1)
+- [shahabganji](https://github.com/shahabganji) - Saeed Ganji (1)
+- [StevenLiekens](https://github.com/StevenLiekens) - Steven Liekens (1)
+- [SychevIgor](https://github.com/SychevIgor) - SychevIgor (1)
+- [voroninp](https://github.com/voroninp) - Pavel Voronin (1)

--- a/aspnetcore/whats-new/2020-01.md
+++ b/aspnetcore/whats-new/2020-01.md
@@ -6,7 +6,7 @@ ms.date: 02/03/2020
 
 # ASP.NET Core docs: What's new for January 2020
 
-Welcome to what's new in ASP.NET Core docs for January 2020. This article lists some of the major changes to docs during this period.
+This article lists some of the significant changes to docs during this period.
 
 ## Blazor
 

--- a/aspnetcore/whats-new/2020-01.md
+++ b/aspnetcore/whats-new/2020-01.md
@@ -3,7 +3,6 @@ title: "ASP.NET Core docs: What's new for January 2020"
 description: "What's new in ASP.NET Core docs for January 2020."
 ms.date: 02/03/2020
 ---
-
 # ASP.NET Core docs: What's new for January 2020
 
 This article lists some of the significant changes to docs during this period.

--- a/aspnetcore/whats-new/index.yml
+++ b/aspnetcore/whats-new/index.yml
@@ -14,6 +14,8 @@ landingContent:
     linkLists:
       - linkListType: whats-new
         links:
+          - text: January 2020
+            url: 2020-01.md
           - text: December 2019
             url: 2019-12.md
           - text: November 2019

--- a/aspnetcore/whats-new/toc.yml
+++ b/aspnetcore/whats-new/toc.yml
@@ -2,6 +2,11 @@
   href: index.yml
   expanded: true
   items:
+    - name: 2020
+      expanded: true
+      items:
+      - name: January
+        href: 2020-01.md
     - name: 2019
       expanded: true
       items:


### PR DESCRIPTION
Publish the generated page for January. Following the same format used over at https://github.com/dotnet/docs/pull/16931. New this month is a contribution count in the community contributors list.