### PR TITLE
Add k6 to the list of third party alternatives

### DIFF
--- a/aspnetcore/test/load-tests.md
+++ b/aspnetcore/test/load-tests.md
@@ -34,7 +34,9 @@ The following list contains third-party web performance tools with various featu
 * [Apache JMeter](https://jmeter.apache.org/)
 * [ApacheBench (ab)](https://httpd.apache.org/docs/2.4/programs/ab.html)
 * [Gatling](https://gatling.io/)
+* [k6](https://k6.io)
 * [Locust](https://locust.io/)
 * [West Wind WebSurge](https://websurge.west-wind.com/)
 * [Netling](https://github.com/hallatore/Netling)
 * [Vegeta](https://github.com/tsenart/vegeta)
+


### PR DESCRIPTION
Hi! 👋🏼

This commit adds k6 to the list of third-party performance testing tools.
Let me know if you need anything else for this PR to be merged.

Thanks,
Simon

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->