### PR TITLE
Clarify log level and default for Windows Services

### DIFF
--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -47,7 +47,7 @@ The app requires a package reference for [Microsoft.Extensions.Hosting.WindowsSe
 * Enables logging to the event log:
   * The application name is used as the default source name.
   * The default log level is *Warning* or higher for an app based on an ASP.NET Core template that calls `CreateDefaultBuilder` to build the host.
-  * Override the default log level with the `Logging:LogLevel:Default` key in *appsettings.json*/*appsettings.{Environment}.json*.
+  * Override the default log level with the `Logging:LogLevel:Default` key in *appsettings.json*/*appsettings.{Environment}.json* or other configuration provider.
   * Only administrators can create new event sources. When an event source can't be created using the application name, a warning is logged to the *Application* source and event logs are disabled.
 
 In `CreateHostBuilder` of *Program.cs*:

--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -5,7 +5,7 @@ description: Learn how to host an ASP.NET Core app in a Windows Service.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 01/13/2020
+ms.date: 02/04/2020
 uid: host-and-deploy/windows-service
 ---
 # Host ASP.NET Core in a Windows Service
@@ -44,8 +44,9 @@ The app requires a package reference for [Microsoft.Extensions.Hosting.WindowsSe
 
 * Sets the host lifetime to `WindowsServiceLifetime`.
 * Sets the [content root](xref:fundamentals/index#content-root) to [AppContext.BaseDirectory](xref:System.AppContext.BaseDirectory). For more information, see the [Current directory and content root](#current-directory-and-content-root) section.
-* Enables logging to the event log with the application name as the default source name.
-  * The log level can be configured using the `Logging:LogLevel:Default` key in the *appsettings.Production.json* file.
+* Enables logging to the event log:
+  * The application name is used as the default source name.
+  * The log level is set by the `Logging:LogLevel:Default` key in *appsettings.json*/*appsettings.{Environment}.json*. The default log level is *Information* or higher for an app based on an ASP.NET Core template.
   * Only administrators can create new event sources. When an event source can't be created using the application name, a warning is logged to the *Application* source and event logs are disabled.
 
 In `CreateHostBuilder` of *Program.cs*:

--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -5,7 +5,7 @@ description: Learn how to host an ASP.NET Core app in a Windows Service.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 02/04/2020
+ms.date: 02/06/2020
 uid: host-and-deploy/windows-service
 ---
 # Host ASP.NET Core in a Windows Service
@@ -47,7 +47,7 @@ The app requires a package reference for [Microsoft.Extensions.Hosting.WindowsSe
 * Enables logging to the event log:
   * The application name is used as the default source name.
   * The default log level is *Warning* or higher for an app based on an ASP.NET Core template that calls `CreateDefaultBuilder` to build the host.
-  * Override the default log level with the `Logging:LogLevel:Default` key in *appsettings.json*/*appsettings.{Environment}.json* or other configuration provider.
+  * Override the default log level with the `Logging:EventLog:LogLevel:Default` key in *appsettings.json*/*appsettings.{Environment}.json* or other configuration provider.
   * Only administrators can create new event sources. When an event source can't be created using the application name, a warning is logged to the *Application* source and event logs are disabled.
 
 In `CreateHostBuilder` of *Program.cs*:

--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -46,7 +46,8 @@ The app requires a package reference for [Microsoft.Extensions.Hosting.WindowsSe
 * Sets the [content root](xref:fundamentals/index#content-root) to [AppContext.BaseDirectory](xref:System.AppContext.BaseDirectory). For more information, see the [Current directory and content root](#current-directory-and-content-root) section.
 * Enables logging to the event log:
   * The application name is used as the default source name.
-  * The log level is set by the `Logging:LogLevel:Default` key in *appsettings.json*/*appsettings.{Environment}.json*. The default log level is *Information* or higher for an app based on an ASP.NET Core template.
+  * The default log level is *Warning* or higher for an app based on an ASP.NET Core template that calls `CreateDefaultBuilder` to build the host.
+  * Override the default log level with the `Logging:LogLevel:Default` key in *appsettings.json*/*appsettings.{Environment}.json*.
   * Only administrators can create new event sources. When an event source can't be created using the application name, a warning is logged to the *Application* source and event logs are disabled.
 
 In `CreateHostBuilder` of *Program.cs*:


### PR DESCRIPTION
Fixes #16843

CR, would have handled this one with only docs review, but need to check something with you:

From the issue comment (pertaining to the Event Logging added automatically for a Windows Service app) ...

> the default event log source config is to log only messages with warning or higher

... but we've documented the log level as being set by `Logging:LogLevel:Default`, which should be *Information* or higher via a template-based app.

Is the guidance on this PR correct, or is the level actually defaulting to *Warning* or higher? If *Warning* or higher, where's that coming from?