### PR TITLE
Add WebJobs crosslink to Background Tasks topic

### DIFF
--- a/aspnetcore/fundamentals/host/hosted-services.md
+++ b/aspnetcore/fundamentals/host/hosted-services.md
@@ -5,7 +5,7 @@ description: Learn how to implement background tasks with hosted services in ASP
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 01/08/2020
+ms.date: 02/05/2020
 uid: fundamentals/host/hosted-services
 ---
 # Background tasks with hosted services in ASP.NET Core
@@ -259,4 +259,5 @@ When the **Add Task** button is selected on the Index page, the `OnPostAddTask` 
 ## Additional resources
 
 * [Implement background tasks in microservices with IHostedService and the BackgroundService class](/dotnet/standard/microservices-architecture/multi-container-microservice-net-applications/background-tasks-with-ihostedservice)
+* [Run background tasks with WebJobs in Azure App Service](/azure/app-service/webjobs-create)
 * <xref:System.Threading.Timer>


### PR DESCRIPTION
Fixes #16579

I can't say if using the `StartupCommand` with `dotnet {ASSEMBLY}.dll` would work in an Azure Pipeline for an Azure App Service (regular) app, but I can add the Azure App Service WebJobs topic (first of a node in the Azure docs) to the additional resources section here.