### PR TITLE
Clarification on setting Kestrel options from config providers

### DIFF
--- a/aspnetcore/fundamentals/servers/kestrel.md
+++ b/aspnetcore/fundamentals/servers/kestrel.md
@@ -5,7 +5,7 @@ description: Learn about Kestrel, the cross-platform web server for ASP.NET Core
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 12/26/2019
+ms.date: 02/06/2020
 uid: fundamentals/servers/kestrel
 ---
 # Kestrel web server implementation in ASP.NET Core
@@ -111,7 +111,7 @@ The following examples use the <xref:Microsoft.AspNetCore.Server.Kestrel.Core> n
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 ```
 
-Kestrel options, which are configured in C# code in the following examples, can also be set using a [configuration provider](xref:fundamentals/configuration/index). For example, the File Configuration Provider can load Kestrel configuration from an *appsettings.json* or *appsettings.{Environment}.json* file:
+In examples shown later in this article, Kestrel options are configured in C# code. Kestrel options can also be set using a [configuration provider](xref:fundamentals/configuration/index). For example, the [File Configuration Provider](xref:fundamentals/configuration/index#file-configuration-provider) can load Kestrel configuration from an *appsettings.json* or *appsettings.{Environment}.json* file:
 
 ```json
 {
@@ -124,6 +124,9 @@ Kestrel options, which are configured in C# code in the following examples, can 
   }
 }
 ```
+
+> [!NOTE]
+> <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions> and [endpoint configuration](#endpoint-configuration) are configurable from configuration providers. Remaining Kestrel configuration must be configured in C# code.
 
 Use **one** of the following approaches:
 
@@ -484,7 +487,6 @@ In the following *appsettings.json* example:
       "Http": {
         "Url": "http://localhost:5000"
       },
-
       "HttpsInlineCertFile": {
         "Url": "https://localhost:5001",
         "Certificate": {
@@ -492,7 +494,6 @@ In the following *appsettings.json* example:
           "Password": "<certificate password>"
         }
       },
-
       "HttpsInlineCertStore": {
         "Url": "https://localhost:5002",
         "Certificate": {
@@ -502,11 +503,9 @@ In the following *appsettings.json* example:
           "AllowInvalid": "<true or false; defaults to false>"
         }
       },
-
       "HttpsDefaultCert": {
         "Url": "https://localhost:5003"
       },
-
       "Https": {
         "Url": "https://*:5004",
         "Certificate": {


### PR DESCRIPTION
Fixes #16759

To harden the text a bit, I'm deliberately vague in the NOTE due to in-progress/in-design work:

* [Read additional KestrelServerOptions from config #4765](https://github.com/dotnet/aspnetcore/issues/4765)
* [Setting the ClientCertificateMode Kestrel server option from an appsettings.json file. #18660](https://github.com/dotnet/aspnetcore/issues/18660)
* [ClientCertificateMode now read from config #18759](https://github.com/dotnet/aspnetcore/pull/18759)

The rest of the guidance seems correct.