### PR TITLE
Blazor binding content and layout updates

### DIFF
--- a/aspnetcore/blazor/common/samples/3.x/BlazorServerSample/Components/ChildComponent.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorServerSample/Components/ChildComponent.razor
@@ -2,7 +2,7 @@
     <div class="panel-heading">@Title</div>
     <div class="panel-body">@ChildContent</div>
 
-    <button class="btn btn-primary" @onclick="OnClick">
+    <button class="btn btn-primary" @onclick="OnClickCallback">
         Trigger a Parent component method
     </button>
 </div>
@@ -15,6 +15,6 @@
     public RenderFragment ChildContent { get; set; }
 
     [Parameter]
-    public EventCallback<MouseEventArgs> OnClick { get; set; }
+    public EventCallback<MouseEventArgs> OnClickCallback { get; set; }
 }
 

--- a/aspnetcore/blazor/common/samples/3.x/BlazorServerSample/Pages/ParentComponent.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorServerSample/Pages/ParentComponent.razor
@@ -3,7 +3,7 @@
 <h1>Parent-child example</h1>
 
 <ChildComponent Title="Panel Title from Parent"
-                OnClick="@ShowMessage">
+                OnClickCallback="@ShowMessage">
     Content of the child component is supplied
     by the parent component.
 </ChildComponent>
@@ -33,7 +33,7 @@
 
 <h2>Parent component</h2>
 
-<pre><code>&lt;ChildComponent Title="Panel Title from Parent" OnClick="@@ShowMessage"&gt;
+<pre><code>&lt;ChildComponent Title="Panel Title from Parent" OnClickCallback="@@ShowMessage"&gt;
     Content of the child component is supplied by the parent component.
 &lt;/ChildComponent&gt;
 
@@ -54,7 +54,7 @@
     &lt;div class="panel-heading"&gt;@@Title&lt;/div&gt;
     &lt;div class="panel-body"&gt;@@ChildContent&lt;/div&gt;
 
-    &lt;button class="btn btn-primary" @@onclick="OnClick"&gt;Trigger a Parent component method&lt;/button&gt;
+    &lt;button class="btn btn-primary" @@onclick="OnClickCallback"&gt;Trigger a Parent component method&lt;/button&gt;
 &lt;/div&gt;
 
 @@code {
@@ -65,5 +65,5 @@
     public RenderFragment ChildContent { get; set; }
 
     [Parameter]
-    public EventCallback&lt;MouseEventArgs&gt; OnClick { get; set; }
+    public EventCallback&lt;MouseEventArgs&gt; OnClickCallback { get; set; }
 }</code></pre>

--- a/aspnetcore/blazor/common/samples/3.x/BlazorWebAssemblySample/Components/ChildComponent.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorWebAssemblySample/Components/ChildComponent.razor
@@ -2,7 +2,7 @@
     <div class="panel-heading">@Title</div>
     <div class="panel-body">@ChildContent</div>
 
-    <button class="btn btn-primary" @onclick="OnClick">
+    <button class="btn btn-primary" @onclick="OnClickCallback">
         Trigger a Parent component method
     </button>
 </div>
@@ -15,6 +15,6 @@
     public RenderFragment ChildContent { get; set; }
 
     [Parameter]
-    public EventCallback<MouseEventArgs> OnClick { get; set; }
+    public EventCallback<MouseEventArgs> OnClickCallback { get; set; }
 }
 

--- a/aspnetcore/blazor/common/samples/3.x/BlazorWebAssemblySample/Pages/ParentComponent.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorWebAssemblySample/Pages/ParentComponent.razor
@@ -3,7 +3,7 @@
 <h1>Parent-child example</h1>
 
 <ChildComponent Title="Panel Title from Parent"
-                OnClick="@ShowMessage">
+                OnClickCallback="@ShowMessage">
     Content of the child component is supplied
     by the parent component.
 </ChildComponent>
@@ -33,7 +33,7 @@
 
 <h2>Parent component</h2>
 
-<pre><code>&lt;ChildComponent Title="Panel Title from Parent" OnClick="@@ShowMessage"&gt;
+<pre><code>&lt;ChildComponent Title="Panel Title from Parent" OnClickCallback="@@ShowMessage"&gt;
     Content of the child component is supplied by the parent component.
 &lt;/ChildComponent&gt;
 
@@ -54,7 +54,7 @@
     &lt;div class="panel-heading"&gt;@@Title&lt;/div&gt;
     &lt;div class="panel-body"&gt;@@ChildContent&lt;/div&gt;
 
-    &lt;button class="btn btn-primary" @@onclick="OnClick"&gt;Trigger a Parent component method&lt;/button&gt;
+    &lt;button class="btn btn-primary" @@onclick="OnClickCallback"&gt;Trigger a Parent component method&lt;/button&gt;
 &lt;/div&gt;
 
 @@code {
@@ -65,5 +65,5 @@
     public RenderFragment ChildContent { get; set; }
 
     [Parameter]
-    public EventCallback&lt;MouseEventArgs&gt; OnClick { get; set; }
+    public EventCallback&lt;MouseEventArgs&gt; OnClickCallback { get; set; }
 }</code></pre>

--- a/aspnetcore/blazor/javascript-interop/samples_snapshot/component3.razor
+++ b/aspnetcore/blazor/javascript-interop/samples_snapshot/component3.razor
@@ -2,7 +2,7 @@
 @using JsInteropClasses
 
 <input @ref="_username" />
-<button @onclick="OnClick">Do something generic</button>
+<button @onclick="OnClickMethod">Do something generic</button>
 
 <p>
     _returnValue: @_returnValue
@@ -12,7 +12,7 @@
     private ElementReference _username;
     private string _returnValue;
 
-    private async Task OnClick()
+    private async Task OnClickMethod()
     {
         _returnValue = await _username.GenericMethod<string>(JSRuntime);
     }


### PR DESCRIPTION
Fixes #16693

* The ask is to make the chained bind example match the component param example (i.e., use the `Year`-`YearChanged` example instead of the password example). I don't think that's necessary ... I see a set of changes that *may* reduce confusion without sacrificing the password example, which is a nice real-world example:
  * The chained bind section was outside of the bind section merely because it used an event handler (`onclick`). I move the chained bind section directly into the bind content area of the topic and add a line saying what `onclick` does with a cross-link to the *Event handling* section.
  * Both of these sections (parent-to-child with component param and child-to-parent with chained bind) didn't make the scenario clear: I make them say "parent-to-child" and "child-to-parent."
  * The chained bind example (password example) didn't clearly show the "parent" and "child," so I've added a route for the parent and a heading to each to make it clear what you're looking at.
* While we're at it here, let's make those bind section headings actual **headings** and not just bold text.

I'm trying to make a simple conceptual model for the reader. ❓ *QUESTION* ❓ Is this ok? Are "parent-to-child" and "child-to-parent" reasonable terms in these scenarios?

...... and a :tada: **_bLaZoR BoNuS!_**:tm: 💃🕺 ....

Let's **_NOT_** call the `onclick` callback in our examples `OnClick`. It immediately overloads the term. I go with `OnClickCallback`. One example is just a method, so I call that one `OnClickMethod`. Much better imo.

Thanks @MisinformedDNA! ⛷