### PR TITLE
Replace ToUpper/ToLower with ToUpperInvariant/ToLowerInvariant.

### DIFF
--- a/aspnetcore/fundamentals/middleware/request-response/samples/3.x/RequestResponseSample/Startup.cs
+++ b/aspnetcore/fundamentals/middleware/request-response/samples/3.x/RequestResponseSample/Startup.cs
@@ -34,7 +34,7 @@ namespace RequestResponseSample
 
                     foreach (var item in list)
                     {
-                        await context.Response.WriteAsync(item.ToUpper());
+                        await context.Response.WriteAsync(item.ToUpperInvariant());
                         await context.Response.WriteAsync(Environment.NewLine);
                     }
                 });
@@ -45,7 +45,7 @@ namespace RequestResponseSample
 
                     foreach (var item in list)
                     {
-                        await context.Response.WriteAsync(item.ToUpper());
+                        await context.Response.WriteAsync(item.ToUpperInvariant());
                         await context.Response.WriteAsync(Environment.NewLine);
                     }
                 });
@@ -55,7 +55,7 @@ namespace RequestResponseSample
                     var list = await GetListOfStringFromPipe(context.Request.BodyPipe);
                     foreach (var item in list)
                     {
-                        await context.Response.WriteAsync(item.ToUpper());
+                        await context.Response.WriteAsync(item.ToUpperInvariant());
                         await context.Response.WriteAsync(Environment.NewLine);
                     }
                 });

--- a/aspnetcore/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml.cs
+++ b/aspnetcore/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml.cs
@@ -35,7 +35,7 @@ namespace RazorPagesContacts.Pages.Customers
             {
                 return Page();
             }
-            Customer.Name = Customer.Name?.ToUpper();
+            Customer.Name = Customer.Name?.ToUpperInvariant();
             return await OnPostJoinListAsync();
         }
     }

--- a/aspnetcore/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateRoute.cshtml.cs
+++ b/aspnetcore/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateRoute.cshtml.cs
@@ -35,7 +35,7 @@ namespace RazorPagesContacts.Pages.Customers
             {
                 return Page();
             }
-            Customer.Name = Customer.Name?.ToUpper();
+            Customer.Name = Customer.Name?.ToUpperInvariant();
             return await OnPostJoinListAsync();
         }
     }


### PR DESCRIPTION
Fixes #16855.

This first commit shows the extent of the changes to code files. The only remaining calls/references to `ToLower` or `ToUpper` are in the following .md files:

* data/ef-mvc/sort-filter-page.md
* data/ef-rp/sort-filter-page.md
* mvc/controllers/routing.md
* razor-pages/razor-pages-conventions.md

I'll address those in another commit, excluding the `SlugifyParameterTransformer` stuff.

Note: The `SlugifyParameterTransformer` code is all inline in .md files, with no corresponding sample files.

cc @Rick-Anderson, @guardrex 