### PR TITLE
Fix link to dotnet-docker repo.

### DIFF
--- a/aspnetcore/security/docker-https.md
+++ b/aspnetcore/security/docker-https.md
@@ -17,7 +17,7 @@ ASP.NET Core uses [HTTPS by default](/aspnet/core/security/enforcing-ssl). [HTTP
 
 This document explains how to run pre-built container images with HTTPS.
 
-See [Developing ASP.NET Core Applications with Docker over HTTPS](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/aspnetcore-docker-https-development.md) for development scenarios.
+See [Developing ASP.NET Core Applications with Docker over HTTPS](https://github.com/dotnet/dotnet-docker/blob/master/samples/run-aspnetcore-https-development.md) for development scenarios.
 
 This sample requires [Docker 17.06](https://docs.docker.com/release-notes/docker-ce) or later of the [Docker client](https://www.docker.com/products/docker).
 


### PR DESCRIPTION
Fixes #16900.

I checked the entire repo for references to the `dotnet-docker` repo, but this was the only one I found that was broken.