### PR TITLE
Configure valid docset dev langs for docs-markdown extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,4 +3,27 @@
     "[markdown]": {
         "files.trimTrailingWhitespace": false
     },
+    "markdown.docsetLanguages": [
+        ".NET Core CLI",
+        "Azure CLI",
+        "Bash",
+        "C#",
+        "CSS",
+        "Dockerfile",
+        "Gradle",
+        "HTML",
+        "Ini",
+        "JSON",
+        "Java",
+        "JavaScript",
+        "Markdown",
+        "Nginx",
+        "PowerShell",
+        "Protocol Buffers",
+        "Razor CSHTML",
+        "SQL",
+        "TypeScript",
+        "XML",
+        "YAML"
+    ]
 }


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore.Docs/issues/16985

MVF1 of the extension has landed in the Docs Authoring Pack. Here it is in action with the config proposed in this PR. Type 3 backticks, and the auto-complete list appears. I've included all valid values used in our repo.

![devlangs](https://user-images.githubusercontent.com/10702007/74375768-8b961480-4da6-11ea-9d5a-477564e7751a.gif)

Adding @guardrex, @CamSoper, & @wadepickett for awareness.