### PR TITLE
Add missing services for authorization

### DIFF
--- a/aspnetcore/security/blazor/index.md
+++ b/aspnetcore/security/blazor/index.md
@@ -196,6 +196,8 @@ public class Program
     public static async Task Main(string[] args)
     {
         var builder = WebAssemblyHostBuilder.CreateDefault(args);
+        builder.Services.AddOptions();
+        builder.Services.AddAuthorizationCore();
         builder.Services.AddScoped<AuthenticationStateProvider, 
             CustomAuthStateProvider>();
         builder.RootComponents.Add<App>("app");


### PR DESCRIPTION
Without these two lines program throws:

> System.InvalidOperationException: Unable to resolve service for type 'Microsoft.Extensions.Options.IOptions`1[Microsoft.AspNetCore.Authorization.AuthorizationOptions]' while attempting to activate 'Microsoft.AspNetCore.Authorization.DefaultAuthorizationPolicyProvider'



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->