### PR TITLE
Update global application example of AutoValidateAntiForgeryTokenAttribute

### DIFF
--- a/aspnetcore/security/anti-request-forgery.md
+++ b/aspnetcore/security/anti-request-forgery.md
@@ -329,7 +329,7 @@ public class ManageController : Controller
 Global example:
 
 ```csharp
-services.AddMvc(options => 
+services.AddControllersWithViews(options => 
     options.Filters.Add(new AutoValidateAntiforgeryTokenAttribute()));
 ```
 

--- a/aspnetcore/security/anti-request-forgery.md
+++ b/aspnetcore/security/anti-request-forgery.md
@@ -328,10 +328,21 @@ public class ManageController : Controller
 
 Global example:
 
+::: moniker range="< aspnetcore-3.0"
+
+services.AddMvc(options =>
+    options.Filters.Add(new AutoValidateAntiforgeryTokenAttribute()));
+
+::: moniker-end
+
+::: moniker range=">= aspnetcore-3.0"
+
 ```csharp
-services.AddControllersWithViews(options => 
+services.AddControllersWithViews(options =>
     options.Filters.Add(new AutoValidateAntiforgeryTokenAttribute()));
 ```
+
+::: moniker-end
 
 ### Override global or controller antiforgery attributes
 


### PR DESCRIPTION
I replaced `services.AddMvc` with `services.AddControllersWithViews` as the way to apply filters globally was changed with the release of ASP.NET Core 3
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->